### PR TITLE
Remove update method in favor of dataclasses.replace. This follows eq…

### DIFF
--- a/src/cryojax/core.py
+++ b/src/cryojax/core.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 __all__ = ["field", "Module"]
 
-import dataclasses
 from types import FunctionType
 from typing import Any, Union
 from jaxtyping import Array, ArrayLike, Float, Complex, Int
@@ -96,7 +95,7 @@ class _Serializable(DataClassJsonMixin):
             s = f.read()
         return cls.from_json(s, **kwargs)
 
-    def dump(self, filename: str, **kwargs: Any) -> _Serializable:
+    def dump(self, filename: str, **kwargs: Any):
         """
         Dump a ``cryojax`` object to a file.
         """
@@ -122,17 +121,6 @@ class Module(eqx.Module, _Serializable):
     Base class for ``cryojax`` objects.
     """
 
-    def update(self, **kwargs: Any) -> Module:
-        """
-        Update a set of ``Module`` attributes.
-
-        Similar to ``dataclasses.replace``.
-        """
-        values = [kwargs[k] for k in kwargs]
-        return eqx.tree_at(
-            lambda x: [getattr(x, k) for k in kwargs], self, values
-        )
-
 
 # 0-d array type hints
 Real_ = Float[Array, ""]
@@ -149,10 +137,10 @@ RealVector = Float[Array, "N"]
 """Type hint for a real-valued vector."""
 
 ComplexVector = Complex[Array, "N"]
-"""Type hint for an complex-valued image."""
+"""Type hint for an complex-valued vector."""
 
 Vector = Union[RealVector, ComplexVector]
-"""Type hint for an image."""
+"""Type hint for a vector."""
 
 # 2-d array type hints
 RealImage = Float[Array, "N1 N2"]

--- a/src/cryojax/simulator/density.py
+++ b/src/cryojax/simulator/density.py
@@ -14,7 +14,7 @@ __all__ = [
 from abc import ABCMeta, abstractmethod
 from typing import Optional, Any, Type
 from jaxtyping import Array
-from dataclasses import fields
+from dataclasses import fields, replace
 
 from .scattering import ScatteringConfig
 from .pose import Pose
@@ -204,7 +204,7 @@ class ElectronCloud(Voxels):
         """
         coordinates = pose.rotate(self.coordinates, real=True)
 
-        return self.update(coordinates=coordinates)
+        return replace(self, coordinates=coordinates)
 
     @classmethod
     def from_mrc(
@@ -246,7 +246,7 @@ class ElectronGrid(Voxels):
         """
         coordinates = pose.rotate(self.coordinates, real=False)
 
-        return self.update(coordinates=coordinates)
+        return replace(self, coordinates=coordinates)
 
     @classmethod
     def from_mrc(

--- a/tests/test_rescale.py
+++ b/tests/test_rescale.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dataclasses import replace
 from jax import config
 
 from cryojax.utils import irfftn
@@ -16,8 +17,8 @@ def test_rescale(rescaled_model, request):
     exposure = rescaled_model.state.exposure
     mu, N = exposure.mu, exposure.N
     # Create null model
-    state = rescaled_model.state.update(exposure=NullExposure())
-    null_model = rescaled_model.update(state=state)
+    state = replace(rescaled_model.state, exposure=NullExposure())
+    null_model = replace(rescaled_model, state=state)
     # Compute images
     null_image = irfftn(null_model.render(view=False))
     rescaled_image = irfftn(rescaled_model.render(view=False))

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -2,6 +2,7 @@ import pytest
 
 import numpy as np
 from jax import config
+from dataclasses import replace
 
 import cryojax.simulator as cs
 from cryojax.utils import fftn
@@ -21,14 +22,16 @@ def test_deserialize_state_components(noisy_model):
     exposure = cs.UniformExposure.from_json(
         noisy_model.state.exposure.to_json()
     )
-    model = noisy_model.update(
-        state=state.update(
+    model = replace(
+        noisy_model,
+        state=replace(
+            state,
             pose=pose,
             detector=detector,
             ice=ice,
             optics=optics,
             exposure=exposure,
-        )
+        ),
     )
     np.testing.assert_allclose(fftn(noisy_model()), fftn(model()))
 

--- a/tutorials/test-pipeline.ipynb
+++ b/tutorials/test-pipeline.ipynb
@@ -28,6 +28,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Dataclasses imports\n",
+    "from dataclasses import replace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Plotting imports and function definitions\n",
     "from matplotlib import pyplot as plt\n",
     "from mpl_toolkits.axes_grid1 import make_axes_locatable"
@@ -280,7 +290,7 @@
     "def build_pipeline(pixel_size: jax.Array) -> cs.GaussianImage:\n",
     "    # Build the PipelineState\n",
     "    state = cs.PipelineState(\n",
-    "        pose=pose, optics=optics, detector=detector.update(pixel_size=pixel_size), ice=ice, exposure=exposure\n",
+    "        pose=pose, optics=optics, detector=replace(detector, pixel_size=pixel_size), ice=ice, exposure=exposure\n",
     "    )\n",
     "    # Build the model\n",
     "    model = cs.GaussianImage(\n",
@@ -351,7 +361,7 @@
     "def build_loss(pixel_size: jax.Array) -> cs.GaussianImage:\n",
     "    # Build the PipelineState\n",
     "    state = cs.PipelineState(\n",
-    "        pose=pose, optics=optics, detector=detector.update(pixel_size=pixel_size)\n",
+    "        pose=pose, optics=optics, detector=replace(detector, pixel_size=pixel_size)\n",
     "    )\n",
     "    # Build the model\n",
     "    model = cs.GaussianImage(\n",
@@ -390,6 +400,13 @@
     "# Benchmark gradient pipeline\n",
     "%timeit grad = grad_loss(detector.pixel_size)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
…uinox conventions that model updates should be functional (i.e. using tree_at)