### PR TITLE
Update test_serialize.py

### DIFF
--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -63,7 +63,7 @@ def test_deserialize_filters_and_masks(filters_or_masks, request):
     for idx, f in enumerate(filters_or_masks):
         test = types[idx].from_json(f.to_json())
         assert test.to_json() == f.to_json()
-        np.testing.assert_allclose(test.compute(), f.compute(), rtol=1e-6)
+        np.testing.assert_allclose(test.evaluate(), f.evaluate(), rtol=1e-6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updated the API in test_serialize from "compute" to "evaluate": I think this is just a holdover from an old API?