### PR TITLE
kw_only can lead to weird behavior. in general, explicitly write __in…

### DIFF
--- a/src/cryojax/simulator/noise.py
+++ b/src/cryojax/simulator/noise.py
@@ -25,7 +25,7 @@ class Noise(Module):
         1) Overwrite ``Noise.sample``.
     """
 
-    key: Union[Array, PRNGKeyArray] = field(static=True, kw_only=True)
+    key: Union[Array, PRNGKeyArray] = field(static=True, default_factory=random.PRNGKey)
 
     @abstractmethod
     def sample(self, freqs: ImageCoords) -> ComplexImage:


### PR DESCRIPTION
…it__ instead. here, just add a default key.