### PR TITLE
Pixel size refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,19 @@ The [jax-finufft](https://github.com/dfm/jax-finufft) package is an optional dep
 
 Please note that this library is currently experimental and the API is subject to change! The following is a basic workflow to generate an image with a gaussian white noise model.
 
-First, instantiate the scattering model ("scattering") and its respective representation
-of an electron density ("density").
+First, instantiate the `ScatteringModel` and its respective representation
+of an `ElectronDensity`.
 
 ```python
 import jax
 import jax.numpy as jnp
 import cryojax.simulator as cs
 
-template = "example.mrc"
-density = cs.VoxelGrid.from_file(template)
+filename = "example.mrc"
+density = cs.VoxelGrid.from_file(filename)
+pixel_size = density.voxel_size
 manager = cs.ImageManager(shape=(320, 320))
-scattering = cs.FourierSliceExtract(manager, pixel_size=density.voxel_size)
+scattering = cs.FourierSliceExtract(manager, pixel_size=pixel_size)
 ```
 
 Here, `template` is a 3D electron density map in MRC format. This could be taken from the [EMDB](https://www.ebi.ac.uk/emdb/), or rasterized from a [PDB](https://www.rcsb.org/). [cisTEM](https://github.com/timothygrant80/cisTEM) provides an excellent rasterization tool in its image simulation program. In the above example, a voxel electron density in fourier space is loaded and the fourier-slice projection theorem is initialized. Note that we must explicitly set the pixel size of the projection image. Here, it is the same as the voxel size of the electron density. We can now instantiate the `Ensemble` of biological specimen.
@@ -72,13 +73,12 @@ The stack of electron densities is stored in a single `ElectronDensity`, whose p
 Next, the model for the electron microscope. `Optics` and `Detector` models and their respective parameters are initialized. These are stored in the `Instrument` container.
 
 ```python
-new_pixel_size = scattering.pixel_size+0.02
 optics = cs.CTFOptics(defocus_u=10000.0, defocus_v=9800.0, defocus_angle=10.0)
-detector = cs.GaussianDetector(pixel_size=new_pixel_size, variance=cs.Constant(1.0))
+detector = cs.GaussianDetector(variance=cs.Constant(1.0))
 instrument = cs.Instrument(optics=optics, detector=detector)
 ```
 
-Here, the `Detector` has an optional pixel size that interpolates the rasterized pixel size to a new one. This is meant to correct for small mismeasurements in experimentally reported pixel size due to microscope alignment imperfections. The `CTFOptics` has all parameters used in CTFFIND4, which take their default values if not
+Here, the `Detector` is simply modeled by gaussian white noise. The `CTFOptics` has all parameters used in CTFFIND4, which take their default values if not
 explicitly configured here. Finally, we can instantiate the `ImagePipeline`.
 
 ```python
@@ -122,7 +122,7 @@ For these more advanced examples, see the tutorials section of the repository. I
 
 ## Creating a loss function
 
-In `jax`, we ultimately want to build a loss function and apply functional transformations to it. Assuming we have already globally configured our model components at our desired initial state, the below creates a loss function at an updated set of parameters. First, we must update the model.
+In `jax`, we may want to build a loss function and apply functional transformations to it. Assuming we have already globally configured our model components at our desired initial state, the below creates a loss function at an updated set of parameters. First, we must update the model.
 
 ```python
 
@@ -131,7 +131,7 @@ def update_model(model, params):
     """
     Update the model with equinox.tree_at (https://docs.kidger.site/equinox/api/manipulation/#equinox.tree_at).
     """
-    where = lambda model: (model.ensemble.pose.view_phi, model.instrument.optics.defocus_u, model.instrument.detector.pixel_size)
+    where = lambda model: (model.ensemble.pose.view_phi, model.instrument.optics.defocus_u, model.scattering.pixel_size)
     updated_model = eqx.tree_at(where, model, (params["view_phi"], params["defocus_u"], params["pixel_size"]))
     return updated_model
 ```
@@ -149,11 +149,11 @@ def loss(params, model, observed):
 Finally, we can evaluate an updated set of parameters.
 
 ```python
-params = dict(view_phi=jnp.asarray(jnp.pi), defocus_u=jnp.asarray(9000.0), pixel_size=jnp.asarray(1.30))
+params = dict(view_phi=jnp.asarray(jnp.pi), defocus_u=jnp.asarray(9000.0), pixel_size=jnp.asarray(density.voxel_size+0.02))
 log_likelihood, grad = loss(params, model, observed)
 ```
 
-To summarize, this example creates a loss function at an updated set of `Pose`, `Optics`, and `Detector` parameters. In general, any `cryojax` `Module` may contain model parameters. The exception to this is in the `ImageManager`, `Filter`, and `Mask`. These classes do computation upon initialization, so they should not be explicitly instantiated in the loss function evaluation. Another gotcha is that if the `model` is not passed as an argument to the loss, there may be long compilation times because the electron density will be treated as static. However, this may result in slight speedups.
+To summarize, this example creates a loss function at an updated set of `Pose`, `Optics`, and `ScatteringModel` parameters. In general, any `cryojax` `Module` may contain model parameters. The exception to this is in the `ImageManager`, `Filter`, and `Mask`. These classes do computation upon initialization, so they should not be explicitly instantiated in the loss function evaluation. Another gotcha is that if the `model` is not passed as an argument to the loss, there may be long compilation times because the electron density will be treated as static. However, this may result in slight speedups.
 
 In general, there are many ways to write loss functions. See the [equinox](https://github.com/patrick-kidger/equinox/) documentation for more use cases.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ manager = cs.ImageManager(shape=(320, 320))
 scattering = cs.FourierSliceExtract(manager, pixel_size=pixel_size)
 ```
 
-Here, `template` is a 3D electron density map in MRC format. This could be taken from the [EMDB](https://www.ebi.ac.uk/emdb/), or rasterized from a [PDB](https://www.rcsb.org/). [cisTEM](https://github.com/timothygrant80/cisTEM) provides an excellent rasterization tool in its image simulation program. In the above example, a voxel electron density in fourier space is loaded and the fourier-slice projection theorem is initialized. Note that we must explicitly set the pixel size of the projection image. Here, it is the same as the voxel size of the electron density. We can now instantiate the `Ensemble` of biological specimen.
+Here, `filename` is a 3D electron density map in MRC format. This could be taken from the [EMDB](https://www.ebi.ac.uk/emdb/), or rasterized from a [PDB](https://www.rcsb.org/). [cisTEM](https://github.com/timothygrant80/cisTEM) provides an excellent rasterization tool in its image simulation program. In the above example, a voxel electron density in fourier space is loaded and the fourier-slice projection theorem is initialized. Note that we must explicitly set the pixel size of the projection image. Here, it is the same as the voxel size of the electron density. We can now instantiate the `Ensemble` of biological specimen.
 
 ```python
 # Translations in Angstroms, angles in degrees

--- a/src/cryojax/simulator/density/_atom_density.py
+++ b/src/cryojax/simulator/density/_atom_density.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 __all__ = ["AtomCloud"]
 
-from typing import Type, Any
+from typing import Type, Any, ClassVar
 
 import equinox as eqx
 from jaxtyping import Array
@@ -26,13 +26,7 @@ class AtomCloud(ElectronDensity):
     variances: Array = field()
     identity: Array = field()
 
-    is_real: bool = field(default=True, static=True)
-
-    def __check_init__(self):
-        if self.is_real is False:
-            raise NotImplementedError(
-                "Fourier atomic densities are not supported."
-            )
+    is_real: ClassVar[bool] = True
 
     def rotate_to(self, pose: Pose) -> AtomCloud:
         coordinates = pose.rotate(self.coordinates, is_real=self.is_real)
@@ -52,19 +46,3 @@ class AtomCloud(ElectronDensity):
         """
         raise NotImplementedError
         # return cls.from_mrc(filename, config=config, **kwargs)
-
-    @classmethod
-    def from_stack(
-        cls: Type["AtomCloud"], stack: list["AtomCloud"]
-    ) -> "AtomCloud":
-        """
-        Stack a list of electron densities along the leading
-        axis of a single electron density.
-        """
-        raise NotImplementedError
-
-    def __getitem__(self, key: int) -> "AtomCloud":
-        raise NotImplementedError
-
-    def __len__(self) -> int:
-        raise NotImplementedError

--- a/src/cryojax/simulator/density/_electron_density.py
+++ b/src/cryojax/simulator/density/_electron_density.py
@@ -65,10 +65,6 @@ class ElectronDensity(Module):
             raise TypeError(
                 "Electron density stack should all be of the same type."
             )
-        if not all([stack[0].is_real == density.is_real for density in stack]):
-            raise TypeError(
-                "Electron density stack should all be in real or fourier space."
-            )
         # Gather static and traced fields separately
         static, traced = {}, {}
         for field in dataclasses.fields(stack[0]):

--- a/src/cryojax/simulator/detector.py
+++ b/src/cryojax/simulator/detector.py
@@ -5,64 +5,27 @@ Abstraction of electron detectors in a cryo-EM image.
 __all__ = [
     "Detector",
     "NullDetector",
-    "NoiselessDetector",
     "GaussianDetector",
-    "rescale_pixel_size",
 ]
 
 from abc import abstractmethod
 from typing import Optional, Any
 from typing_extensions import override
-from functools import partial
 
-import jax
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
 
 from .noise import GaussianNoise
 from .kernel import Kernel, Constant
-from ..utils import scale, ifftn
+from ..utils import ifftn
 from ..core import field, Module
-from ..typing import Real_, RealImage, ImageCoords
+from ..typing import RealImage, ImageCoords
 
 
 class Detector(Module):
     """
     Base class for an electron detector.
-
-    Attributes
-    ----------
-    pixel_size :
-        The pixel size measured by the detector.
-        This is in dimensions of physical length.
-        If this is given, the pixel size of the
-        image will be interpolated to this new pixel
-        size.
-    interpolation_method :
-        The interpolation method used for measuring
-        the image at the new ``pixel_size``.
     """
-
-    pixel_size: Optional[Real_] = field(default=None)
-    interpolation_method: str = field(static=True, default="bicubic")
-
-    def measure_at_pixel_size(
-        self, image: RealImage, current_pixel_size: Real_
-    ) -> RealImage:
-        """
-        Measure an image at a given pixel size to
-        the detector pixel size.
-        """
-        if self.pixel_size is None:
-            return image
-        else:
-            return rescale_pixel_size(
-                image,
-                current_pixel_size,
-                new_pixel_size=self.pixel_size,
-                method=self.interpolation_method,
-                antialias=False,
-            )
 
     @abstractmethod
     def sample(
@@ -78,21 +41,6 @@ class Detector(Module):
 class NullDetector(Detector):
     """
     A 'null' detector.
-    """
-
-    @override
-    def sample(
-        self,
-        key: PRNGKeyArray,
-        freqs: ImageCoords,
-        image: Optional[RealImage] = None,
-    ) -> RealImage:
-        return jnp.zeros(jnp.asarray(freqs).shape[0:-1])
-
-
-class NoiselessDetector(Detector):
-    """
-    A detector with no noise model.
     """
 
     @override
@@ -128,29 +76,3 @@ class GaussianDetector(GaussianNoise, Detector):
         image: Optional[RealImage] = None,
     ) -> RealImage:
         return ifftn(super().sample(key, freqs)).real
-
-
-@partial(jax.jit, static_argnames=["method", "antialias"])
-def rescale_pixel_size(
-    image: RealImage,
-    current_pixel_size: Real_,
-    new_pixel_size: Real_,
-    **kwargs: Any,
-) -> RealImage:
-    """
-    Measure an image at a given pixel size using interpolation.
-
-    For more detail, see ``cryojax.utils.interpolation.scale``.
-
-    Parameters
-    ----------
-    image :
-        The image to be magnified.
-    current_pixel_size :
-        The pixel size of the input image.
-    new_pixel_size :
-        The new pixel size after interpolation.
-    """
-    scale_factor = current_pixel_size / new_pixel_size
-    s = jnp.array([scale_factor, scale_factor])
-    return scale(image, image.shape, s, **kwargs)

--- a/src/cryojax/simulator/distribution.py
+++ b/src/cryojax/simulator/distribution.py
@@ -100,7 +100,7 @@ class GaussianImage(Distribution):
     @cached_property
     def variance(self) -> Union[Real_, RealImage]:
         # Gather image configuration
-        freqs = self.manager.freqs / self.pixel_size
+        freqs = self.manager.freqs / self.scattering.pixel_size
         # Variance from detector
         if not isinstance(self.instrument.detector, NullDetector):
             variance = self.instrument.detector.variance(freqs)

--- a/src/cryojax/simulator/distribution.py
+++ b/src/cryojax/simulator/distribution.py
@@ -87,7 +87,7 @@ class GaussianImage(Distribution):
         # Get residuals
         residuals = fftn(self.render() - observed)
         # Crop redundant frequencies
-        _, N2 = self.manager.shape
+        _, N2 = self.scattering.manager.shape
         z = N2 // 2 + 1
         residuals = residuals[:, :z]
         if not isinstance(variance, Real_):
@@ -99,8 +99,8 @@ class GaussianImage(Distribution):
 
     @cached_property
     def variance(self) -> Union[Real_, RealImage]:
-        # Gather image configuration
-        freqs = self.manager.freqs / self.scattering.pixel_size
+        # Gather frequency coordinates
+        freqs = self.scattering.physical_freqs
         # Variance from detector
         if not isinstance(self.instrument.detector, NullDetector):
             variance = self.instrument.detector.variance(freqs)

--- a/src/cryojax/simulator/image.py
+++ b/src/cryojax/simulator/image.py
@@ -82,7 +82,7 @@ class ImagePipeline(Module):
             )
 
         if view:
-            image = self._view(image)
+            image = self._filter_crop_mask(image)
 
         return image
 
@@ -128,7 +128,7 @@ class ImagePipeline(Module):
             image = image + noise
             idx += 1
         if view:
-            image = self._view(image)
+            image = self._filter_crop_mask(image)
 
         return image
 
@@ -145,7 +145,9 @@ class ImagePipeline(Module):
         else:
             return self.sample(key, view=view)
 
-    def _view(self, image: Image, is_real: bool = True) -> RealImage:
+    def _filter_crop_mask(
+        self, image: Image, is_real: bool = True
+    ) -> RealImage:
         """
         View the image. This function applies
         filters, crops the image, then applies masks.

--- a/src/cryojax/simulator/image.py
+++ b/src/cryojax/simulator/image.py
@@ -21,13 +21,11 @@ from .assembly import Assembly
 from .scattering import ScatteringModel
 from .manager import ImageManager
 from .instrument import Instrument
-from .exposure import NullExposure
 from .detector import NullDetector
-from .optics import NullOptics
 from .ice import Ice, NullIce
 from ..utils import fftn, ifftn
 from ..core import field, Module
-from ..typing import RealImage, ComplexImage, Image, Real_
+from ..typing import RealImage, ComplexImage, Image
 
 
 _PRNGKeyArrayLike = Shaped[PRNGKeyArray, "M"]
@@ -74,16 +72,8 @@ class ImagePipeline(Module):
 
     @property
     def manager(self) -> ImageManager:
-        """The ImageManager"""
+        """Expose the ImageManager API"""
         return self.scattering.manager
-
-    @property
-    def pixel_size(self) -> Real_:
-        """The image pixel size."""
-        if self.instrument.detector.pixel_size is not None:
-            return self.instrument.detector.pixel_size
-        else:
-            return self.scattering.pixel_size
 
     def render(self, view: bool = True) -> RealImage:
         """
@@ -132,7 +122,7 @@ class ImagePipeline(Module):
         if isinstance(key, get_args(PRNGKeyArray)):
             key = jnp.expand_dims(key, axis=0)
         # Frequencies
-        freqs = self.manager.padded_freqs / self.pixel_size
+        freqs = self.manager.padded_freqs / self.scattering.pixel_size
         # The image of the specimen drawn from the ensemble
         image = self.render(view=False)
         if not isinstance(self.solvent, NullIce):
@@ -192,9 +182,7 @@ class ImagePipeline(Module):
         # Draw the electron density at a particular conformation and pose
         density = self.ensemble.realization
         # Compute the scattering image in fourier space
-        image = self.scattering.scatter(density)
-        # Normalize to cisTEM conventions
-        image = self.manager.normalize_to_cistem(image, is_real=False)
+        image = self.scattering(density, pose=self.ensemble.pose)
         # Apply translation
         image *= self.ensemble.pose.shifts(freqs)
         # Measure the image with the instrument
@@ -206,20 +194,11 @@ class ImagePipeline(Module):
         """Render an image of an Assembly from its subunits."""
         # Get the subunits
         subunits = self.ensemble.subunits
-        # Split up computation with two different instruments
-        optics_instrument = eqx.tree_at(
-            lambda ins: (ins.exposure, ins.detector),
-            self.instrument,
-            (NullExposure(), NullDetector()),
-        )
-        no_optics_instrument = eqx.tree_at(
-            lambda ins: ins.optics, self.instrument, NullOptics()
-        )
         # Create an ImagePipeline for the subunits
         subunit_pipeline = eqx.tree_at(
-            lambda m: (m.ensemble, m.instrument),
+            lambda m: m.ensemble,
             self,
-            (subunits, optics_instrument),
+            subunits,
         )
         # Setup vmap over poses and conformations
         if self.ensemble.conformation is None:
@@ -248,13 +227,6 @@ class ImagePipeline(Module):
             )
         )
         image = compute_stack_and_sum(vmap, novmap)
-        # Finally, measure the image without applying the CTF
-        no_optics_pipeline = eqx.tree_at(
-            lambda m: m.instrument, self, no_optics_instrument
-        )
-        image = no_optics_pipeline._measure_with_instrument(
-            image, get_real=get_real
-        )
 
         return image
 
@@ -263,8 +235,7 @@ class ImagePipeline(Module):
     ) -> Image:
         """Measure an image with the instrument"""
         instrument = self.instrument
-        current_pixel_size = self.scattering.pixel_size
-        freqs = self.manager.padded_freqs / current_pixel_size
+        freqs = self.manager.padded_freqs / self.scattering.pixel_size
         # Compute and apply CTF
         ctf = instrument.optics(freqs, pose=self.ensemble.pose)
         image = ctf * image
@@ -273,16 +244,8 @@ class ImagePipeline(Module):
             freqs
         ), instrument.exposure.offset(freqs)
         image = scaling * image + offset
-        # Add some detector logic to avoid unecessary FFTs
-        if instrument.detector.pixel_size is not None:
-            # Measure at the detector pixel size
-            image = instrument.detector.measure_at_pixel_size(
-                ifftn(image).real, current_pixel_size
-            )
-            if not get_real:
-                image = fftn(image)
-        else:
-            if get_real:
-                image = ifftn(image).real
+
+        if get_real:
+            image = ifftn(image).real
 
         return image

--- a/src/cryojax/simulator/image.py
+++ b/src/cryojax/simulator/image.py
@@ -156,7 +156,7 @@ class ImagePipeline(Module):
                 image = fftn(image)
             image = ifftn(self.filter(image)).real
         # Crop the image
-        image = self.scattering.manager.crop(image)
+        image = self.scattering.manager.crop_to_shape(image)
         # Mask the image
         if self.mask is not None:
             image = self.mask(image)

--- a/src/cryojax/simulator/manager.py
+++ b/src/cryojax/simulator/manager.py
@@ -76,21 +76,21 @@ class ImageManager(Buffer):
         self.coords = make_coordinates(self.shape)
         self.padded_coords = make_coordinates(self.padded_shape)
 
-    def crop(self, image: Image) -> Image:
+    def crop_to_shape(self, image: Image) -> Image:
         """Crop an image."""
         return crop(image, self.shape)
 
-    def pad(self, image: Image, **kwargs: Any) -> Image:
+    def pad_to_padded_shape(self, image: Image, **kwargs: Any) -> Image:
         """Pad an image."""
         return pad(image, self.padded_shape, mode=self.pad_mode, **kwargs)
 
-    def crop_or_pad(self, image: Image, **kwargs: Any) -> Image:
+    def crop_or_pad_to_padded_shape(self, image: Image, **kwargs: Any) -> Image:
         """Reshape an image using cropping or padding."""
         return crop_or_pad(
             image, self.padded_shape, mode=self.pad_mode, **kwargs
         )
 
-    def downsample(
+    def downsample_to_shape(
         self, image: Image, method="lanczos5", **kwargs: Any
     ) -> Image:
         """Downsample an image using interpolation."""
@@ -98,7 +98,7 @@ class ImageManager(Buffer):
             image, self.shape, antialias=False, method=method, **kwargs
         )
 
-    def upsample(self, image: Image, method="bicubic", **kwargs: Any) -> Image:
+    def upsample_to_padded_shape(self, image: Image, method="bicubic", **kwargs: Any) -> Image:
         """Upsample an image using interpolation."""
         return resize(image, self.padded_shape, method=method, **kwargs)
 

--- a/src/cryojax/simulator/manager.py
+++ b/src/cryojax/simulator/manager.py
@@ -21,7 +21,6 @@ from ..utils import (
     crop,
     pad,
     crop_or_pad,
-    resize,
 )
 
 
@@ -91,20 +90,6 @@ class ImageManager(Buffer):
         return crop_or_pad(
             image, self.padded_shape, mode=self.pad_mode, **kwargs
         )
-
-    def downsample_to_shape(
-        self, image: Image, method="lanczos5", **kwargs: Any
-    ) -> Image:
-        """Downsample an image using interpolation."""
-        return resize(
-            image, self.shape, antialias=False, method=method, **kwargs
-        )
-
-    def upsample_to_padded_shape(
-        self, image: Image, method="bicubic", **kwargs: Any
-    ) -> Image:
-        """Upsample an image using interpolation."""
-        return resize(image, self.padded_shape, method=method, **kwargs)
 
     def normalize_to_cistem(
         self, image: Image, is_real: bool = False

--- a/src/cryojax/simulator/manager.py
+++ b/src/cryojax/simulator/manager.py
@@ -80,11 +80,15 @@ class ImageManager(Buffer):
         """Crop an image."""
         return crop(image, self.shape)
 
-    def pad_to_padded_shape(self, image: Image, **kwargs: Any) -> Image:
+    def pad_to_padded_shape(
+        self, image: Image, **kwargs: Any
+    ) -> Image:
         """Pad an image."""
         return pad(image, self.padded_shape, mode=self.pad_mode, **kwargs)
 
-    def crop_or_pad_to_padded_shape(self, image: Image, **kwargs: Any) -> Image:
+    def crop_or_pad_to_padded_shape(
+        self, image: Image, **kwargs: Any
+    ) -> Image:
         """Reshape an image using cropping or padding."""
         return crop_or_pad(
             image, self.padded_shape, mode=self.pad_mode, **kwargs
@@ -98,7 +102,9 @@ class ImageManager(Buffer):
             image, self.shape, antialias=False, method=method, **kwargs
         )
 
-    def upsample_to_padded_shape(self, image: Image, method="bicubic", **kwargs: Any) -> Image:
+    def upsample_to_padded_shape(
+        self, image: Image, method="bicubic", **kwargs: Any
+    ) -> Image:
         """Upsample an image using interpolation."""
         return resize(image, self.padded_shape, method=method, **kwargs)
 

--- a/src/cryojax/simulator/manager.py
+++ b/src/cryojax/simulator/manager.py
@@ -80,9 +80,7 @@ class ImageManager(Buffer):
         """Crop an image."""
         return crop(image, self.shape)
 
-    def pad_to_padded_shape(
-        self, image: Image, **kwargs: Any
-    ) -> Image:
+    def pad_to_padded_shape(self, image: Image, **kwargs: Any) -> Image:
         """Pad an image."""
         return pad(image, self.padded_shape, mode=self.pad_mode, **kwargs)
 

--- a/src/cryojax/simulator/scattering/_fourier_slice_extract.py
+++ b/src/cryojax/simulator/scattering/_fourier_slice_extract.py
@@ -44,7 +44,7 @@ class FourierSliceExtract(ScatteringModel):
         return extract_slice(
             density.weights,
             density.coordinates,
-            self.pixel_size,
+            density.voxel_size,
             order=self.order,
             mode=self.mode,
             cval=self.cval,
@@ -54,7 +54,7 @@ class FourierSliceExtract(ScatteringModel):
 def extract_slice(
     weights: ComplexVolume,
     coordinates: VolumeCoords,
-    pixel_size: Real_,
+    voxel_size: Real_,
     **kwargs: Any,
 ) -> ComplexImage:
     """
@@ -67,8 +67,8 @@ def extract_slice(
         Density grid in fourier space.
     coordinates : shape `(N1, N2, 1, 3)`
         Frequency central slice coordinate system.
-    pixel_size :
-        The pixel_size of ``coordinates``.
+    voxel_size :
+        The voxel_size of ``coordinates``.
     kwargs:
         Passed to ``cryojax.utils.interpolate.map_coordinates``.
 
@@ -81,7 +81,7 @@ def extract_slice(
     N1, N2, N3 = weights.shape
     if not all([Ni == N1 for Ni in [N1, N2, N3]]):
         raise ValueError("Only cubic boxes are supported for fourier slice.")
-    dx = pixel_size
+    dx = voxel_size
     box_size = jnp.array([N1 * dx, N2 * dx, N3 * dx])
     # Need to convert to "array index coordinates".
     # Make coordinates dimensionless

--- a/src/cryojax/simulator/scattering/_nufft_project.py
+++ b/src/cryojax/simulator/scattering/_nufft_project.py
@@ -53,7 +53,7 @@ class NufftProject(ScatteringModel):
             fourier_projection = project_with_nufft(
                 density.weights,
                 density.coordinates,
-                self.pixel_size,
+                density.voxel_size,
                 self.manager.padded_shape,
                 eps=self.eps,
             )
@@ -103,7 +103,7 @@ def project_atoms_with_nufft(
 def project_with_nufft(
     weights: RealCloud,
     coordinates: Union[CloudCoords2D, CloudCoords3D],
-    pixel_size: Real_,
+    voxel_size: Real_,
     shape: tuple[int, int],
     **kwargs: Any,
 ) -> ComplexImage:
@@ -119,8 +119,8 @@ def project_with_nufft(
         Density point cloud.
     coordinates : shape `(N, 3)`
         Coordinate system of point cloud.
-    pixel_size :
-        The rasterization pixel_size.
+    voxel_size :
+        The rasterization voxel size.
     shape :
         Shape of the imaging plane in pixels.
         ``width, height = shape[0], shape[1]``
@@ -135,7 +135,7 @@ def project_with_nufft(
     """
     weights, coordinates = jnp.asarray(weights), jnp.asarray(coordinates)
     M1, M2 = shape
-    image_size = jnp.array(np.array([M1, M2]) * pixel_size)
+    image_size = jnp.array(np.array([M1, M2]) * voxel_size)
     coordinates = jnp.flip(coordinates[:, :2], axis=-1)
     fourier_projection = nufft(
         weights, coordinates, image_size, shape, **kwargs

--- a/src/cryojax/simulator/scattering/_nufft_project.py
+++ b/src/cryojax/simulator/scattering/_nufft_project.py
@@ -10,11 +10,12 @@ __all__ = [
     "NufftProject",
 ]
 
-from typing import Any, Union
+from typing import Any, Union, Optional
 
 import jax.numpy as jnp
 import numpy as np
 
+from ..pose import Pose
 from ..density import VoxelCloud, AtomCloud
 from ._scattering_model import ScatteringModel
 from ...core import field
@@ -42,7 +43,11 @@ class NufftProject(ScatteringModel):
 
     eps: float = field(static=True, default=1e-6)
 
-    def scatter(self, density: Union[VoxelCloud, AtomCloud]) -> ComplexImage:
+    def scatter(
+        self,
+        density: Union[VoxelCloud, AtomCloud],
+        pose: Optional[Pose] = None,
+    ) -> ComplexImage:
         """Rasterize image with non-uniform FFTs."""
         if isinstance(density, VoxelCloud):
             fourier_projection = project_with_nufft(

--- a/src/cryojax/simulator/scattering/_scattering_model.py
+++ b/src/cryojax/simulator/scattering/_scattering_model.py
@@ -5,15 +5,22 @@ fields.
 
 from __future__ import annotations
 
-__all__ = ["ScatteringModel"]
+__all__ = ["ScatteringModel", "rescale_pixel_size"]
 
 from abc import abstractmethod
+from functools import partial
+from typing import Any, Optional
 
-from ..density import ElectronDensity
+import jax
+import jax.numpy as jnp
+
+from ..density import ElectronDensity, Voxels
+from ..pose import Pose
 from ..manager import ImageManager
 
+from ...utils import fftn, ifftn, scale
 from ...core import field, Module
-from ...typing import Real_, ComplexImage
+from ...typing import Real_, RealImage, ComplexImage
 
 
 class ScatteringModel(Module):
@@ -31,6 +38,9 @@ class ScatteringModel(Module):
     pixel_size :
         Rasterization pixel size. This is in
         dimensions of length.
+    interpolation_method :
+        The interpolation method used for measuring
+        the image at the new ``pixel_size``.
 
     Methods
     -------
@@ -41,8 +51,12 @@ class ScatteringModel(Module):
     manager: ImageManager = field()
     pixel_size: Real_ = field()
 
+    interpolation_method: str = field(static=True, default="bicubic")
+
     @abstractmethod
-    def scatter(self, density: ElectronDensity) -> ComplexImage:
+    def scatter(
+        self, density: ElectronDensity, pose: Optional[Pose] = None
+    ) -> ComplexImage:
         """
         Compute the scattered wave of the electron
         density in the exit plane.
@@ -53,3 +67,51 @@ class ScatteringModel(Module):
             The electron density representation.
         """
         raise NotImplementedError
+
+    def __call__(
+        self, density: ElectronDensity, **kwargs: Any
+    ) -> ComplexImage:
+        """
+        Compute an image at the exit plane, measured at the
+        pixel size and post-processed with the ImageManager utilities.
+        """
+        image = self.scatter(density, **kwargs)
+        image = ifftn(image).real
+        if self.manager.padded_shape != image.shape:
+            image = self.manager.crop_or_pad(image)
+        if isinstance(density, Voxels):
+            image = rescale_pixel_size(
+                image,
+                current_pixel_size=density.voxel_size,
+                new_pixel_size=self.pixel_size,
+                method=self.interpolation_method,
+                antialias=False,
+            )
+        image = self.manager.normalize_to_cistem(fftn(image), is_real=False)
+        return image
+
+
+@partial(jax.jit, static_argnames=["method", "antialias"])
+def rescale_pixel_size(
+    image: RealImage,
+    current_pixel_size: Real_,
+    new_pixel_size: Real_,
+    **kwargs: Any,
+) -> RealImage:
+    """
+    Measure an image at a given pixel size using interpolation.
+
+    For more detail, see ``cryojax.utils.interpolation.scale``.
+
+    Parameters
+    ----------
+    image :
+        The image to be magnified.
+    current_pixel_size :
+        The pixel size of the input image.
+    new_pixel_size :
+        The new pixel size after interpolation.
+    """
+    scale_factor = current_pixel_size / new_pixel_size
+    s = jnp.array([scale_factor, scale_factor])
+    return scale(image, image.shape, s, **kwargs)

--- a/src/cryojax/simulator/scattering/_scattering_model.py
+++ b/src/cryojax/simulator/scattering/_scattering_model.py
@@ -81,7 +81,7 @@ class ScatteringModel(Module):
         image = ifftn(image).real
         # Resize the image to match the ImageManager config
         if self.manager.padded_shape != image.shape:
-            image = self.manager.crop_or_pad(image)
+            image = self.manager.crop_or_pad_to_padded_shape(image)
         # Rescale the pixel size if different from the voxel size
         if isinstance(density, Voxels):
             current_pixel_size = density.voxel_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def instrument(pixel_size):
     return cs.Instrument(
         optics=cs.CTFOptics(),
         exposure=cs.UniformExposure(N=1e5, mu=1.0),
-        detector=cs.GaussianDetector(pixel_size=pixel_size),
+        detector=cs.GaussianDetector(),
     )
 
 

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -7,5 +7,5 @@ def test_shape(model, request):
     model = request.getfixturevalue(model)
     image = model()
     padded_image = model(view=False)
-    assert image.shape == model.manager.shape
-    assert padded_image.shape == model.manager.padded_shape
+    assert image.shape == model.scattering.manager.shape
+    assert padded_image.shape == model.scattering.manager.padded_shape

--- a/tutorials/test-pipeline.ipynb
+++ b/tutorials/test-pipeline.ipynb
@@ -128,7 +128,7 @@
     "# Initialize the instrument\n",
     "optics = cs.CTFOptics(defocus_u=10000, defocus_v=10000, amplitude_contrast=.07)\n",
     "exposure = cs.UniformExposure(N=1e5, mu=0.0)\n",
-    "detector = cs.GaussianDetector(pixel_size=pixel_size, variance=cs.Constant(1.0))\n",
+    "detector = cs.GaussianDetector(variance=cs.Constant(1.0))\n",
     "instrument_s = cs.Instrument(exposure=exposure)\n",
     "instrument_o = cs.Instrument(exposure=exposure, optics=optics)\n",
     "instrument_d = cs.Instrument(exposure=exposure, optics=optics, detector=detector)"
@@ -248,7 +248,7 @@
    "outputs": [],
    "source": [
     "def update_model(pixel_size: jax.Array, model: cs.GaussianImage) -> cs.GaussianImage:\n",
-    "    return eqx.tree_at(lambda m: m.instrument.detector.pixel_size, model, pixel_size)\n",
+    "    return eqx.tree_at(lambda m: m.scattering.pixel_size, model, pixel_size)\n",
     "\n",
     "@jax.jit\n",
     "def compute_image(pixel_size: jax.Array, model: cs.GaussianImage) -> jax.Array:\n",
@@ -265,8 +265,8 @@
     "# Plot jitted model with updated parameters.\n",
     "fig, axes = plt.subplots(ncols=2, figsize=(8, 6))\n",
     "ax1, ax2 = axes\n",
-    "plot_image(compute_image(detector.pixel_size, detector_model), fig, ax1)\n",
-    "plot_image(compute_image(1.1*detector.pixel_size, detector_model), fig, ax2)"
+    "plot_image(compute_image(scattering.pixel_size, detector_model), fig, ax1)\n",
+    "plot_image(compute_image(1.1*scattering.pixel_size, detector_model), fig, ax2)"
    ]
   },
   {
@@ -310,7 +310,7 @@
    "outputs": [],
    "source": [
     "def update_model(pixel_size: jax.Array, model: cs.GaussianImage) -> cs.GaussianImage:\n",
-    "    return eqx.tree_at(lambda m: m.instrument.detector.pixel_size, model, pixel_size)\n",
+    "    return eqx.tree_at(lambda m: m.scattering.pixel_size, model, pixel_size)\n",
     "\n",
     "@jax.jit\n",
     "def compute_loss(pixel_size: jax.Array, model: cs.GaussianImage, observed: jax.Array) -> jax.Array:\n",
@@ -330,7 +330,7 @@
    "outputs": [],
    "source": [
     "# Benchmark loss pipeline\n",
-    "%timeit likelihood = compute_loss(detector.pixel_size+.01, model, observed)"
+    "%timeit likelihood = compute_loss(scattering.pixel_size+.01, model, observed)"
    ]
   },
   {
@@ -340,7 +340,7 @@
    "outputs": [],
    "source": [
     "# Benchmark gradient pipeline\n",
-    "%timeit grad = compute_grad(detector.pixel_size+.01, model, observed)"
+    "%timeit grad = compute_grad(scattering.pixel_size+.01, model, observed)"
    ]
   },
   {


### PR DESCRIPTION
Addressing #88 and #51. Now, `pixel_size` is a parameter in the `ScatteringModel`. For voxel-based densities, this is an independent parameter from the voxel size that interpolates the voxel size to a new pixel size only if the two values are different. This functionality used to be in the `Detector`, but it was way too confusing and hacky to have it here. For future atom-based densities, this `pixel_size` parameter can be used directly.