### PR TITLE
Add metadata to dataclass fields to specify if we want to stack a particular field

### DIFF
--- a/src/cryojax/simulator/density/_electron_density.py
+++ b/src/cryojax/simulator/density/_electron_density.py
@@ -104,7 +104,7 @@ class ElectronDensity(Module):
                     indexed[name] = getattr(self, name)[idx]
             return cls(**indexed, **other, _is_stacked=False)
         else:
-            raise SyntaxError("Cannot index an unstacked ElectronDensity.")
+            raise IndexError("Cannot index an non-stacked ElectronDensity.")
 
     def __len__(self) -> int:
         if self._is_stacked:
@@ -121,6 +121,6 @@ class ElectronDensity(Module):
                 "Could not get the length of the ElectronDensity stack."
             )
         else:
-            raise SyntaxError(
-                "Cannot get the length of an unstacked ElectronDensity."
+            raise TypeError(
+                "Cannot get length of non-stacked ElectronDensity."
             )

--- a/src/cryojax/simulator/density/_electron_density.py
+++ b/src/cryojax/simulator/density/_electron_density.py
@@ -66,51 +66,61 @@ class ElectronDensity(Module):
                 "Electron density stack should all be of the same type."
             )
         # Gather static and traced fields separately
-        static, traced = {}, {}
+        other, stacked = {}, {}
         for field in dataclasses.fields(stack[0]):
             name = field.name
             if name == "_is_stacked":
                 pass
-            elif "static" in field.metadata and field.metadata["static"]:
-                # Static fields should all match, so take the first.
-                static[name] = getattr(stack[0], name)
+            elif ("static" in field.metadata and field.metadata["static"]) or (
+                "stack" in field.metadata and not field.metadata["stack"]
+            ):
+                # Static or unstacked fields should all match, so take the first.
+                other[name] = getattr(stack[0], name)
             else:
-                # Traced fields get stacked.
-                traced[name] = jnp.stack(
+                # Traced fields, unless specified in metadata, get stacked.
+                stacked[name] = jnp.stack(
                     [getattr(density, name) for density in stack], axis=0
                 )
-        return cls(**traced, **static, _is_stacked=True)
+        return cls(**stacked, **other, _is_stacked=True)
 
     def __getitem__(self, idx: int) -> "ElectronDensity":
         if self._is_stacked:
             cls = type(self)
             # Gather static and traced fields separately
-            static, traced = {}, {}
+            indexed, other = {}, {}
             for field in dataclasses.fields(self):
                 name = field.name
                 if name == "_is_stacked":
                     pass
-                elif "static" in field.metadata and field.metadata["static"]:
-                    # Get static fields
-                    static[name] = getattr(self, name)
+                elif (
+                    "static" in field.metadata and field.metadata["static"]
+                ) or (
+                    "stack" in field.metadata and not field.metadata["stack"]
+                ):
+                    # Get static or unstacked fields
+                    other[name] = getattr(self, name)
                 else:
-                    # Get traced fields at particular index
-                    traced[name] = getattr(self, name)[idx]
-            return cls(**traced, **static, _is_stacked=False)
+                    # Get stacked fields at particular index
+                    indexed[name] = getattr(self, name)[idx]
+            return cls(**indexed, **other, _is_stacked=False)
         else:
-            return self
+            raise SyntaxError("Cannot index an unstacked ElectronDensity.")
 
     def __len__(self) -> int:
         if self._is_stacked:
             for field in dataclasses.fields(self):
-                value = getattr(self, field.name)
-                if (
-                    "static" not in field.metadata
-                    or not field.metadata["static"]
+                if not (
+                    ("static" in field.metadata and field.metadata["static"])
+                    or (
+                        "stack" in field.metadata
+                        and not field.metadata["stack"]
+                    )
                 ):
-                    return value.shape[0]
+                    return getattr(self, field.name).shape[0]
             raise AttributeError(
                 "Could not get the length of the ElectronDensity stack."
             )
         else:
-            return 1
+            raise SyntaxError(
+                "Cannot get the length of an unstacked ElectronDensity."
+            )

--- a/src/cryojax/simulator/density/_voxel_density.py
+++ b/src/cryojax/simulator/density/_voxel_density.py
@@ -56,7 +56,7 @@ class Voxels(ElectronDensity):
     """
 
     weights: AbstractVar[Array]
-    voxel_size: Real_ = field()
+    voxel_size: Real_ = field(metadata={"stack": False})
 
     @classmethod
     def from_file(
@@ -94,7 +94,7 @@ class VoxelGrid(Voxels):
     """
 
     weights: _ComplexCubicVolume = field()
-    frequency_slice: _VolumeSliceCoords = field()
+    frequency_slice: _VolumeSliceCoords = field(metadata={"stack": False})
 
     is_real: ClassVar[bool] = False
 
@@ -228,7 +228,7 @@ class VoxelCloud(Voxels):
     """
 
     weights: RealCloud = field()
-    coordinate_list: CloudCoords3D = field()
+    coordinate_list: CloudCoords3D = field(metadata={"stack": False})
 
     is_real: ClassVar[bool] = True
 


### PR DESCRIPTION
Adding this metadata lets us create an ElectronDensity with only particular fields stacked. The base ElectronDensity class can read this metadata, so the ``from_stack``, ``__getitem__`` and ``__len__`` methods can stay in the base class.

This PR fixes the fact that we store copies of the same coordinate system when using the stacked ElectronDensity utilities (e.g. ``frequency_slice`` will no longer get a batch dimension).

This is compatible with the potential ``from_mdtraj`` loader.

I'm cringing a little adding custom metadata outside the ``cryojax.core.field`` wrapper, but it's a pretty good solution I think.