### PR TITLE
Rotation logic is more clear. Now, AbstractPose rotation parameters by default define a rotation of the real space volume. Before, they were with respect to a fourier space volume.

### DIFF
--- a/src/cryojax/coordinates/__init__.py
+++ b/src/cryojax/coordinates/__init__.py
@@ -1,5 +1,5 @@
 from ._coordinates import (
-    is_not_coordinate_array as is_not_coordinate_array,
+    is_not_coordinates as is_not_coordinates,
     get_not_coordinate_filter_spec as get_not_coordinate_filter_spec,
 )
 from ._coordinates import (

--- a/src/cryojax/coordinates/_coordinates.py
+++ b/src/cryojax/coordinates/_coordinates.py
@@ -98,8 +98,9 @@ class CoordinateGrid(AbstractCoordinates, strict=True):
         self,
         shape: tuple[int, int] | tuple[int, int, int],
         grid_spacing: float | ArrayLike = 1.0,
+        indexing: str = "xy",
     ):
-        self.array = make_coordinates(shape, grid_spacing)
+        self.array = make_coordinates(shape, grid_spacing, indexing=indexing)
 
 
 class FrequencyGrid(AbstractCoordinates, strict=True):
@@ -114,9 +115,10 @@ class FrequencyGrid(AbstractCoordinates, strict=True):
         shape: tuple[int, int] | tuple[int, int, int],
         grid_spacing: float | ArrayLike = 1.0,
         half_space: bool = True,
+        indexing: str = "xy",
     ):
         self.array = make_frequencies(
-            shape, grid_spacing, half_space=half_space
+            shape, grid_spacing, half_space=half_space, indexing=indexing
         )
 
 
@@ -135,9 +137,10 @@ class FrequencySlice(AbstractCoordinates, strict=True):
         shape: tuple[int, int],
         grid_spacing: float | ArrayLike = 1.0,
         half_space: bool = True,
+        indexing: str = "xy",
     ):
         frequency_slice = make_frequencies(
-            shape, grid_spacing, half_space=half_space
+            shape, grid_spacing, half_space=half_space, indexing=indexing
         )
         if half_space:
             frequency_slice = jnp.fft.fftshift(frequency_slice, axes=(0,))
@@ -158,6 +161,7 @@ class FrequencySlice(AbstractCoordinates, strict=True):
 def make_coordinates(
     shape: tuple[int, ...],
     grid_spacing: float | ArrayLike = 1.0,
+    indexing: str = "xy",
 ) -> Float[Array, "*shape len(shape)"]:
     """
     Create a real-space cartesian coordinate system on a grid.
@@ -179,7 +183,7 @@ def make_coordinates(
         Cartesian coordinate system in real space.
     """
     coordinate_grid = _make_coordinates_or_frequencies(
-        shape, grid_spacing=grid_spacing, real_space=True, indexing="ij"
+        shape, grid_spacing=grid_spacing, real_space=True, indexing=indexing
     )
     return coordinate_grid
 
@@ -188,6 +192,7 @@ def make_frequencies(
     shape: tuple[int, ...],
     grid_spacing: float | ArrayLike = 1.0,
     half_space: bool = True,
+    indexing: str = "xy",
 ) -> Float[Array, "*shape len(shape)"]:
     """
     Create a fourier-space cartesian coordinate system on a grid.
@@ -218,7 +223,7 @@ def make_frequencies(
         grid_spacing=grid_spacing,
         real_space=False,
         half_space=half_space,
-        indexing="ij",
+        indexing=indexing,
     )
     return frequency_grid
 

--- a/src/cryojax/coordinates/_coordinates.py
+++ b/src/cryojax/coordinates/_coordinates.py
@@ -24,8 +24,8 @@ from ..typing import (
 #
 # Filter functions
 #
-def is_not_coordinate_array(element: Any) -> bool:
-    """Returns ``False`` if ``element`` is ``Coordinates``."""
+def is_not_coordinates(element: Any) -> bool:
+    """Returns ``False`` if ``element`` is ``AbstractCoordinates``."""
     if isinstance(element, AbstractCoordinates):
         return False
     else:
@@ -38,7 +38,7 @@ def is_not_coordinate_array(element: Any) -> bool:
 def get_not_coordinate_filter_spec(pytree: PyTree) -> PyTree[bool]:
     """Filter spec that is ``True`` for all arrays that are not ``Coordinates``."""
     return jtu.tree_map(
-        is_not_coordinate_array,
+        is_not_coordinates,
         pytree,
         is_leaf=lambda x: isinstance(x, AbstractCoordinates),
     )
@@ -49,30 +49,30 @@ class AbstractCoordinates(eqx.Module, strict=True):
     A base class that wraps a coordinate array.
     """
 
-    buffer: AbstractVar[Any]
+    array: AbstractVar[Any]
 
     def get(self):
         """Get the coordinates."""
-        return self.buffer
+        return self.array
 
     def __mul__(self, arr: ArrayLike) -> Self:
         return eqx.tree_at(
-            lambda x: x.buffer, self, self.buffer * jnp.asarray(arr)
+            lambda x: x.array, self, self.array * jnp.asarray(arr)
         )
 
     def __rmul__(self, arr: ArrayLike) -> Self:
         return eqx.tree_at(
-            lambda x: x.buffer, self, jnp.asarray(arr) * self.buffer
+            lambda x: x.array, self, jnp.asarray(arr) * self.array
         )
 
     def __truediv__(self, arr: ArrayLike) -> Self:
         return eqx.tree_at(
-            lambda x: x.buffer, self, self.buffer / jnp.asarray(arr)
+            lambda x: x.array, self, self.array / jnp.asarray(arr)
         )
 
     def __rtruediv__(self, arr: ArrayLike) -> Self:
         return eqx.tree_at(
-            lambda x: x.buffer, self, jnp.asarray(arr) / self.buffer
+            lambda x: x.array, self, jnp.asarray(arr) / self.array
         )
 
 
@@ -81,10 +81,10 @@ class CoordinateList(AbstractCoordinates, strict=True):
     A Pytree that wraps a coordinate list.
     """
 
-    buffer: CloudCoords3D | CloudCoords2D = eqx.field(converter=jnp.asarray)
+    array: CloudCoords3D | CloudCoords2D = eqx.field(converter=jnp.asarray)
 
     def __init__(self, coordinate_list: CloudCoords2D | CloudCoords3D):
-        self.buffer = coordinate_list
+        self.array = coordinate_list
 
 
 class CoordinateGrid(AbstractCoordinates, strict=True):
@@ -92,14 +92,14 @@ class CoordinateGrid(AbstractCoordinates, strict=True):
     A Pytree that wraps a coordinate grid.
     """
 
-    buffer: ImageCoords | VolumeCoords = eqx.field(converter=jnp.asarray)
+    array: ImageCoords | VolumeCoords = eqx.field(converter=jnp.asarray)
 
     def __init__(
         self,
         shape: tuple[int, int] | tuple[int, int, int],
         grid_spacing: float | ArrayLike = 1.0,
     ):
-        self.buffer = make_coordinates(shape, grid_spacing)
+        self.array = make_coordinates(shape, grid_spacing)
 
 
 class FrequencyGrid(AbstractCoordinates, strict=True):
@@ -107,7 +107,7 @@ class FrequencyGrid(AbstractCoordinates, strict=True):
     A Pytree that wraps a frequency grid.
     """
 
-    buffer: ImageCoords | VolumeCoords = eqx.field(converter=jnp.asarray)
+    array: ImageCoords | VolumeCoords = eqx.field(converter=jnp.asarray)
 
     def __init__(
         self,
@@ -115,7 +115,7 @@ class FrequencyGrid(AbstractCoordinates, strict=True):
         grid_spacing: float | ArrayLike = 1.0,
         half_space: bool = True,
     ):
-        self.buffer = make_frequencies(
+        self.array = make_frequencies(
             shape, grid_spacing, half_space=half_space
         )
 
@@ -128,7 +128,7 @@ class FrequencySlice(AbstractCoordinates, strict=True):
     component in the center.
     """
 
-    buffer: VolumeSliceCoords = eqx.field(converter=jnp.asarray)
+    array: VolumeSliceCoords = eqx.field(converter=jnp.asarray)
 
     def __init__(
         self,
@@ -136,8 +136,6 @@ class FrequencySlice(AbstractCoordinates, strict=True):
         grid_spacing: float | ArrayLike = 1.0,
         half_space: bool = True,
     ):
-        """Create a frequency slice. If not given, by default store
-        with the zero frequency component in the center."""
         frequency_slice = make_frequencies(
             shape, grid_spacing, half_space=half_space
         )
@@ -154,7 +152,7 @@ class FrequencySlice(AbstractCoordinates, strict=True):
             ),
             axis=2,
         )
-        self.buffer = frequency_slice
+        self.array = frequency_slice
 
 
 def make_coordinates(

--- a/src/cryojax/coordinates/_coordinates.py
+++ b/src/cryojax/coordinates/_coordinates.py
@@ -158,7 +158,6 @@ class FrequencySlice(AbstractCoordinates, strict=True):
 def make_coordinates(
     shape: tuple[int, ...],
     grid_spacing: float | ArrayLike = 1.0,
-    indexing: str = "xy",
 ) -> Float[Array, "*shape len(shape)"]:
     """
     Create a real-space cartesian coordinate system on a grid.
@@ -180,7 +179,7 @@ def make_coordinates(
         Cartesian coordinate system in real space.
     """
     coordinate_grid = _make_coordinates_or_frequencies(
-        shape, grid_spacing=grid_spacing, real_space=True, indexing=indexing
+        shape, grid_spacing=grid_spacing, real_space=True, indexing="ij"
     )
     return coordinate_grid
 
@@ -189,7 +188,6 @@ def make_frequencies(
     shape: tuple[int, ...],
     grid_spacing: float | ArrayLike = 1.0,
     half_space: bool = True,
-    indexing: str = "xy",
 ) -> Float[Array, "*shape len(shape)"]:
     """
     Create a fourier-space cartesian coordinate system on a grid.
@@ -220,7 +218,7 @@ def make_frequencies(
         grid_spacing=grid_spacing,
         real_space=False,
         half_space=half_space,
-        indexing=indexing,
+        indexing="ij",
     )
     return frequency_grid
 

--- a/src/cryojax/inference/distributions/_distributions.py
+++ b/src/cryojax/inference/distributions/_distributions.py
@@ -10,7 +10,7 @@ import equinox as eqx
 import jax.random as jr
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
-from equinox import Module
+from equinox import Module, AbstractVar
 
 from ...image.operators import FourierOperatorLike, Constant
 from ...simulator import GaussianIce
@@ -19,12 +19,12 @@ from ...simulator import AbstractPipeline
 from ...typing import Real_, RealImage, ComplexImage, Image
 
 
-class AbstractDistribution(Module):
+class AbstractDistribution(Module, strict=True):
     """
     An imaging pipeline equipped with a probabilistic model.
     """
 
-    pipeline: AbstractPipeline
+    pipeline: AbstractVar[AbstractPipeline]
 
     @abstractmethod
     def log_probability(self, observed: Image) -> Real_:
@@ -52,7 +52,7 @@ class AbstractDistribution(Module):
         raise NotImplementedError
 
 
-class IndependentFourierGaussian(AbstractDistribution):
+class IndependentFourierGaussian(AbstractDistribution, strict=True):
     r"""
     A gaussian noise model, where each fourier mode is independent.
 
@@ -74,6 +74,7 @@ class IndependentFourierGaussian(AbstractDistribution):
         models as described above.
     """
 
+    pipeline: AbstractPipeline
     variance: FourierOperatorLike
 
     def __init__(

--- a/src/cryojax/io/_mrc.py
+++ b/src/cryojax/io/_mrc.py
@@ -27,13 +27,11 @@ def load_mrc(filename: str) -> tuple[np.ndarray, float]:
     with mrcfile.open(filename) as mrc:
         data = np.asarray(mrc.data, dtype=float)
         if data.ndim == 2:
-            # Change how template sits in box to match cisTEM
-            data = np.transpose(data, axes=[1, 0])
             voxel_size = np.asarray(
                 [mrc.voxel_size.y, mrc.voxel_size.x], dtype=float
             )
         elif data.ndim == 3:
-            # Change how template sits in box to match cisTEM
+            # Change how grid sits in box to match cisTEM
             data = np.transpose(data, axes=[2, 1, 0])
             voxel_size = np.asarray(
                 [mrc.voxel_size.z, mrc.voxel_size.y, mrc.voxel_size.x],

--- a/src/cryojax/io/_mrc.py
+++ b/src/cryojax/io/_mrc.py
@@ -34,9 +34,9 @@ def load_mrc(filename: str) -> tuple[np.ndarray, float]:
             )
         elif data.ndim == 3:
             # Change how template sits in box to match cisTEM
-            data = np.transpose(data, axes=[1, 2, 0])
+            data = np.transpose(data, axes=[2, 1, 0])
             voxel_size = np.asarray(
-                [mrc.voxel_size.y, mrc.voxel_size.z, mrc.voxel_size.x],
+                [mrc.voxel_size.z, mrc.voxel_size.y, mrc.voxel_size.x],
                 dtype=float,
             )
         else:

--- a/src/cryojax/simulator/_assembly/_assembly.py
+++ b/src/cryojax/simulator/_assembly/_assembly.py
@@ -88,12 +88,15 @@ class AbstractAssembly(eqx.Module, strict=True):
         """
         # Transform the subunit positions by pose of the helix
         transformed_positions = (
-            self.pose.rotate_coordinates(self.positions, is_real=True)
+            self.pose.rotate_coordinates(self.positions, inverse=False)
             + self.pose.offset
         )
         # Transform the subunit rotations by the pose of the helix
         transformed_rotations = jnp.einsum(
             "nij,jk->nik", self.rotations, self.pose.rotation.as_matrix()
+        )
+        transformed_rotations = jnp.transpose(
+            transformed_rotations, axes=[0, 2, 1]
         )
         return MatrixPose(
             offset_x=transformed_positions[:, 0],

--- a/src/cryojax/simulator/_assembly/_assembly.py
+++ b/src/cryojax/simulator/_assembly/_assembly.py
@@ -91,13 +91,13 @@ class AbstractAssembly(eqx.Module, strict=True):
             self.pose.rotate_coordinates(self.positions, inverse=False)
             + self.pose.offset
         )
-        # Transform the subunit rotations by the pose of the helix
+        # Transform the subunit rotations by the pose of the helix. This operation
+        # left multiplies by the pose of the helix, taking care that first subunits
+        # are rotated to the center of mass frame, then the lab frame.
         transformed_rotations = jnp.einsum(
-            "nij,jk->nik", self.rotations, self.pose.rotation.as_matrix()
+            "ij,njk->nik", self.pose.rotation.as_matrix(), self.rotations
         )
-        transformed_rotations = jnp.transpose(
-            transformed_rotations, axes=[0, 2, 1]
-        )
+
         return MatrixPose(
             offset_x=transformed_positions[:, 0],
             offset_y=transformed_positions[:, 1],

--- a/src/cryojax/simulator/_assembly/_helix.py
+++ b/src/cryojax/simulator/_assembly/_helix.py
@@ -202,7 +202,7 @@ def compute_helical_lattice_positions(
         # ... rotate the sub-helix around the screw axis to a different sub-helix
         c_n, s_n = jnp.cos(symmetry_angle), jnp.sin(symmetry_angle)
         R_n = jnp.array(
-            ((c_n, s_n, 0), (-s_n, c_n, 0), (0, 0, 1)), dtype=float
+            ((c_n, -s_n, 0), (s_n, c_n, 0), (0, 0, 1)), dtype=float
         )
         return (R_n @ r.T).T
 
@@ -291,7 +291,7 @@ def compute_helical_lattice_rotations(
         # ... rotate the sub-helix around the screw axis to a different sub-helix
         c_n, s_n = jnp.cos(symmetry_angle), jnp.sin(symmetry_angle)
         R_n = jnp.array(
-            ((c_n, s_n, 0), (-s_n, c_n, 0), (0, 0, 1)), dtype=float
+            ((c_n, -s_n, 0), (s_n, c_n, 0), (0, 0, 1)), dtype=float
         )
         return jnp.einsum("ij,njk->nik", R_n, R)
 

--- a/src/cryojax/simulator/_density/_electron_density.py
+++ b/src/cryojax/simulator/_density/_electron_density.py
@@ -44,6 +44,9 @@ class AbstractElectronDensity(Module, strict=True):
         """
         View the electron density at a given pose.
 
+        In subclasses, fourier-space electron density representations
+        should rotate coordinates by a backrotation (the inverse rotation).
+
         Arguments
         ---------
         pose :

--- a/src/cryojax/simulator/_density/_voxel_density.py
+++ b/src/cryojax/simulator/_density/_voxel_density.py
@@ -536,8 +536,7 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         coordinate_grid: Optional[CoordinateGrid] = None,
         *,
         crop_scale: None,
-    ) -> "RealVoxelGrid":
-        ...
+    ) -> "RealVoxelGrid": ...
 
     @overload
     @classmethod
@@ -548,8 +547,7 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         coordinate_grid: None,
         *,
         crop_scale: Optional[float],
-    ) -> "RealVoxelGrid":
-        ...
+    ) -> "RealVoxelGrid": ...
 
     @classmethod
     def from_density_grid(

--- a/src/cryojax/simulator/_density/_voxel_density.py
+++ b/src/cryojax/simulator/_density/_voxel_density.py
@@ -568,7 +568,10 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
                     [int(s * crop_scale) for s in density_grid.shape[-3:]]
                 )
                 density_grid = crop_to_shape(density_grid, cropped_shape)
-            coordinate_grid = CoordinateGrid(density_grid.shape[-3:])
+            # ij indexing is for jax-finufft compatibility
+            coordinate_grid = CoordinateGrid(
+                density_grid.shape[-3:], indexing="ij"
+            )
 
         return cls(density_grid, coordinate_grid, jnp.asarray(voxel_size))
 
@@ -634,7 +637,8 @@ class VoxelCloud(AbstractVoxels, strict=True):
     ) -> "VoxelCloud":
         # Make coordinates if not given
         if coordinate_grid is None:
-            coordinate_grid = CoordinateGrid(density_grid.shape)
+            # ... ij indexing is for jax-finufft
+            coordinate_grid = CoordinateGrid(density_grid.shape, indexing="ij")
         # ... mask zeros to store smaller arrays. This
         # option is not jittable.
         nonzero = jnp.where(~jnp.isclose(density_grid, 0.0))

--- a/src/cryojax/simulator/_density/_voxel_density.py
+++ b/src/cryojax/simulator/_density/_voxel_density.py
@@ -338,9 +338,7 @@ class AbstractFourierVoxelGrid(AbstractVoxels, strict=True):
         return eqx.tree_at(
             lambda d: d.frequency_slice.buffer,
             self,
-            pose.rotate_coordinates(
-                self.frequency_slice.get(), is_real=self.is_real
-            ),
+            pose.rotate_coordinates(self.frequency_slice.get(), inverse=True),
         )
 
     @classmethod
@@ -528,9 +526,7 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         return eqx.tree_at(
             lambda d: d.coordinate_grid.buffer,
             self,
-            pose.rotate_coordinates(
-                self.coordinate_grid.get(), is_real=self.is_real
-            ),
+            pose.rotate_coordinates(self.coordinate_grid.get(), inverse=False),
         )
 
     @overload
@@ -628,9 +624,7 @@ class VoxelCloud(AbstractVoxels, strict=True):
         return eqx.tree_at(
             lambda d: d.coordinate_list.buffer,
             self,
-            pose.rotate_coordinates(
-                self.coordinate_list.get(), is_real=self.is_real
-            ),
+            pose.rotate_coordinates(self.coordinate_list.get(), inverse=False),
         )
 
     @classmethod

--- a/src/cryojax/simulator/_density/_voxel_density.py
+++ b/src/cryojax/simulator/_density/_voxel_density.py
@@ -65,9 +65,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
 
     Attributes
     ----------
-    weights :
-        The electron density.
-    voxel_size
+    voxel_size :
         The voxel size of the electron density.
     """
 
@@ -83,7 +81,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         **kwargs: Any,
     ) -> VoxelT:
         """
-        Load a Voxels object from real-valued 3D electron
+        Load a AbstractVoxels object from real-valued 3D electron
         density map.
         """
         raise NotImplementedError
@@ -99,7 +97,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         **kwargs: Any,
     ) -> VoxelT:
         """
-        Load a Voxels object from atom positions and identities.
+        Load a AbstractVoxels object from atom positions and identities.
         """
         a_vals, b_vals = load_atoms.get_form_factor_params(
             atom_identities, form_factors
@@ -161,7 +159,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         **kwargs: Any,
     ) -> VoxelT:
         """
-        Loads a PDB file as a Voxels subclass.  Uses the Gemmi library.
+        Loads a PDB file as a AbstractVoxels subclass.  Uses the Gemmi library.
         Heavily based on a code from Frederic Poitevin, located at
 
         https://github.com/compSPI/ioSPI/blob/master/ioSPI/atomic_models.py
@@ -206,7 +204,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         filename: str,
         **kwargs: Any,
     ) -> VoxelT:
-        """Load Voxels from MRC file format."""
+        """Load AbstractVoxels from MRC file format."""
         density_grid, voxel_size = load_mrc(filename)
         return cls.from_density_grid(
             jnp.asarray(density_grid), voxel_size, **kwargs
@@ -220,7 +218,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         voxel_size: Real_ | float = 1.0,
         **kwargs: Any,
     ) -> VoxelT:
-        """Load Voxels from PDB file format."""
+        """Load AbstractVoxels from PDB file format."""
         atom_positions, atom_elements = read_atoms_from_pdb(filename)
         coordinate_grid_in_angstroms = CoordinateGrid(
             n_voxels_per_side, voxel_size
@@ -242,7 +240,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         voxel_size: Real_ | float = 1.0,
         **kwargs: Any,
     ) -> VoxelT:
-        """Load Voxels from CIF file format."""
+        """Load AbstractVoxels from CIF file format."""
         atom_positions, atom_elements = read_atoms_from_cif(filename)
         coordinate_grid_in_angstroms = CoordinateGrid(
             n_voxels_per_side, voxel_size
@@ -266,7 +264,7 @@ class AbstractVoxels(AbstractElectronDensity, strict=True):
         **kwargs: Any,
     ) -> VoxelT:
         """
-        Load Voxels from MDTraj trajectory.
+        Load AbstractVoxels from MDTraj trajectory.
 
         Parameters
         ----------
@@ -336,7 +334,7 @@ class AbstractFourierVoxelGrid(AbstractVoxels, strict=True):
         This rotation is the inverse rotation as in real space.
         """
         return eqx.tree_at(
-            lambda d: d.frequency_slice.buffer,
+            lambda d: d.frequency_slice.array,
             self,
             pose.rotate_coordinates(self.frequency_slice.get(), inverse=True),
         )
@@ -524,7 +522,7 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         with rotated coordinates.
         """
         return eqx.tree_at(
-            lambda d: d.coordinate_grid.buffer,
+            lambda d: d.coordinate_grid.array,
             self,
             pose.rotate_coordinates(self.coordinate_grid.get(), inverse=False),
         )
@@ -538,7 +536,8 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         coordinate_grid: Optional[CoordinateGrid] = None,
         *,
         crop_scale: None,
-    ) -> "RealVoxelGrid": ...
+    ) -> "RealVoxelGrid":
+        ...
 
     @overload
     @classmethod
@@ -549,7 +548,8 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
         coordinate_grid: None,
         *,
         crop_scale: Optional[float],
-    ) -> "RealVoxelGrid": ...
+    ) -> "RealVoxelGrid":
+        ...
 
     @classmethod
     def from_density_grid(
@@ -572,7 +572,7 @@ class RealVoxelGrid(AbstractVoxels, strict=True):
                 density_grid = crop_to_shape(density_grid, cropped_shape)
             coordinate_grid = CoordinateGrid(density_grid.shape[-3:])
 
-        return cls(density_grid, coordinate_grid, voxel_size)
+        return cls(density_grid, coordinate_grid, jnp.asarray(voxel_size))
 
 
 class VoxelCloud(AbstractVoxels, strict=True):
@@ -598,7 +598,7 @@ class VoxelCloud(AbstractVoxels, strict=True):
 
     def __init__(
         self,
-        density_weights: ComplexCubicVolume,
+        density_weights: RealCloud,
         coordinate_list: CoordinateList,
         voxel_size: Real_,
     ):
@@ -622,7 +622,7 @@ class VoxelCloud(AbstractVoxels, strict=True):
         with rotated coordinates.
         """
         return eqx.tree_at(
-            lambda d: d.coordinate_list.buffer,
+            lambda d: d.coordinate_list.array,
             self,
             pose.rotate_coordinates(self.coordinate_list.get(), inverse=False),
         )
@@ -636,14 +636,14 @@ class VoxelCloud(AbstractVoxels, strict=True):
     ) -> "VoxelCloud":
         # Make coordinates if not given
         if coordinate_grid is None:
-            coordinate_grid = make_coordinates(density_grid.shape)
+            coordinate_grid = CoordinateGrid(density_grid.shape)
         # ... mask zeros to store smaller arrays. This
         # option is not jittable.
         nonzero = jnp.where(~jnp.isclose(density_grid, 0.0))
         flat_density = density_grid[nonzero]
-        coordinate_list = coordinate_grid[nonzero]
+        coordinate_list = CoordinateList(coordinate_grid.get()[nonzero])
 
-        return cls(flat_density, CoordinateList(coordinate_list), voxel_size)
+        return cls(flat_density, coordinate_list, jnp.asarray(voxel_size))
 
 
 def _eval_3d_real_space_gaussian(

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -55,14 +55,12 @@ class AbstractPose(Module, strict=True):
     @overload
     def rotate_coordinates(
         self, volume_coordinates: VolumeCoords, inverse: bool = False
-    ) -> VolumeCoords:
-        ...
+    ) -> VolumeCoords: ...
 
     @overload
     def rotate_coordinates(
         self, volume_coordinates: CloudCoords3D, inverse: bool = False
-    ) -> CloudCoords3D:
-        ...
+    ) -> CloudCoords3D: ...
 
     def rotate_coordinates(
         self,

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -169,7 +169,6 @@ class EulerPose(AbstractPose, strict=True):
 
     inverse: bool = field(static=True, default=False)
     convention: str = field(static=True, default="zyz")
-    intrinsic: bool = field(static=True, default=True)
     degrees: bool = field(static=True, default=True)
 
     @cached_property
@@ -182,7 +181,6 @@ class EulerPose(AbstractPose, strict=True):
             self.view_psi,
             degrees=self.degrees,
             convention=self.convention,
-            intrinsic=self.intrinsic,
         )
         return R.inverse() if self.inverse else R
 
@@ -265,7 +263,6 @@ def make_euler_rotation(
     theta: Union[float, Real_],
     psi: Union[float, Real_],
     convention: str = "zyz",
-    intrinsic: bool = True,
     degrees: bool = False,
 ) -> SO3:
     """
@@ -281,6 +278,4 @@ def make_euler_rotation(
     R1 = rotations[0](phi)
     R2 = rotations[1](theta)
     R3 = rotations[2](psi)
-    R = R1 @ R2 @ R3 if intrinsic else R3 @ R2 @ R1
-
-    return R
+    return R3 @ R2 @ R1

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -265,17 +265,18 @@ def make_euler_rotation(
     convention: str = "zyz",
     degrees: bool = False,
 ) -> SO3:
-    """
-    Helper routine to generate a rotation in a particular
+    """Helper routine to generate a rotation in a particular
     convention.
     """
-    # Generate sequence of rotations
-    rotations = [getattr(SO3, f"from_{axis}_radians") for axis in convention]
+    # Convert to radians.
     if degrees:
         phi = jnp.deg2rad(phi)
         theta = jnp.deg2rad(theta)
         psi = jnp.deg2rad(psi)
-    R1 = rotations[0](phi)
-    R2 = rotations[1](theta)
-    R3 = rotations[2](psi)
+    # Get sequence of rotations, converting to cryojax conventions
+    # from jaxlie
+    R1, R2, R3 = [
+        getattr(SO3, f"from_{axis}_radians")(angle).inverse()
+        for axis, angle in zip(convention, [phi, theta, psi])
+    ]
     return R3 @ R2 @ R1

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -3,7 +3,7 @@ Routines that compute coordinate rotations and translations.
 """
 
 from abc import abstractmethod
-from typing import Union, TypeVar, overload
+from typing import Union, overload
 from typing_extensions import override
 from jaxtyping import Float, Array
 from functools import cached_property
@@ -55,12 +55,14 @@ class AbstractPose(Module, strict=True):
     @overload
     def rotate_coordinates(
         self, volume_coordinates: VolumeCoords, inverse: bool = False
-    ) -> VolumeCoords: ...
+    ) -> VolumeCoords:
+        ...
 
     @overload
     def rotate_coordinates(
         self, volume_coordinates: CloudCoords3D, inverse: bool = False
-    ) -> CloudCoords3D: ...
+    ) -> CloudCoords3D:
+        ...
 
     def rotate_coordinates(
         self,

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -259,9 +259,9 @@ class MatrixPose(AbstractPose, strict=True):
 
 
 def make_euler_rotation(
-    phi: Union[float, Real_],
-    theta: Union[float, Real_],
-    psi: Union[float, Real_],
+    phi: Real_,
+    theta: Real_,
+    psi: Real_,
     convention: str = "zyz",
     degrees: bool = False,
 ) -> SO3:

--- a/src/cryojax/simulator/_scattering/_fourier_slice_extract.py
+++ b/src/cryojax/simulator/_scattering/_fourier_slice_extract.py
@@ -123,7 +123,7 @@ def extract_slice(
     N = frequency_slice.shape[0]
     logical_frequency_slice = (frequency_slice * N) + N // 2
     # Convert arguments to map_coordinates convention and compute
-    k_y, k_x, k_z = jnp.transpose(logical_frequency_slice, axes=[3, 0, 1, 2])
+    k_x, k_y, k_z = jnp.transpose(logical_frequency_slice, axes=[3, 0, 1, 2])
     projection = map_coordinates(
         fourier_density_grid, (k_x, k_y, k_z), interpolation_order, **kwargs
     )[:, :, 0]
@@ -162,7 +162,7 @@ def extract_slice_with_cubic_spline(
     N = frequency_slice.shape[0]
     logical_frequency_slice = (frequency_slice * N) + N // 2
     # Convert arguments to map_coordinates convention and compute
-    k_y, k_x, k_z = jnp.transpose(logical_frequency_slice, axes=[3, 0, 1, 2])
+    k_x, k_y, k_z = jnp.transpose(logical_frequency_slice, axes=[3, 0, 1, 2])
     projection = map_coordinates_with_cubic_spline(
         spline_coefficients, (k_x, k_y, k_z), **kwargs
     )[:, :, 0]

--- a/src/cryojax/simulator/_scattering/_fourier_slice_extract.py
+++ b/src/cryojax/simulator/_scattering/_fourier_slice_extract.py
@@ -130,7 +130,11 @@ def extract_slice(
     # Shift zero frequency component to corner and take upper half plane
     projection = jnp.fft.ifftshift(projection)[:, : N // 2 + 1]
     # Set last line of frequencies to zero if image dimension is even
-    return projection if N % 2 == 1 else projection.at[:, -1].set(0.0 + 0.0j)
+    if N % 2 == 0:
+        projection = (
+            projection.at[:, -1].set(0.0 + 0.0j).at[N // 2, :].set(0.0 + 0.0j)
+        )
+    return projection
 
 
 def extract_slice_with_cubic_spline(

--- a/src/cryojax/simulator/_scattering/_nufft_project.py
+++ b/src/cryojax/simulator/_scattering/_nufft_project.py
@@ -98,7 +98,7 @@ def project_with_nufft(
     image_size = jnp.asarray((M1, M2), dtype=float)
     coordinates_periodic = 2 * jnp.pi * coordinates_yx / image_size
     # Unpack and compute
-    y, x = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
+    x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     projection = nufft1(shape, weights, x, y, **kwargs)
     # Shift zero frequency component to corner and take upper half plane
     projection = jnp.fft.ifftshift(projection)[:, : M2 // 2 + 1]

--- a/src/cryojax/simulator/_scattering/_nufft_project.py
+++ b/src/cryojax/simulator/_scattering/_nufft_project.py
@@ -62,15 +62,13 @@ class NufftProject(AbstractProjectionMethod, strict=True):
 
 def project_with_nufft(
     weights: RealCloud,
-    coordinates: Union[CloudCoords2D, CloudCoords3D],
+    coordinate_list: Union[CloudCoords2D, CloudCoords3D],
     shape: tuple[int, int],
     **kwargs: Any,
 ) -> ComplexImage:
     """
     Project and interpolate 3D volume point cloud
     onto imaging plane using a non-uniform FFT.
-
-    See ``cryojax.utils.integration.nufft`` for more detail.
 
     Arguments
     ---------
@@ -90,17 +88,17 @@ def project_with_nufft(
     """
     from jax_finufft import nufft1
 
-    weights, coordinates = jnp.asarray(weights).astype(complex), jnp.asarray(
-        coordinates
-    )
-    # Flip and negate x and y to convert to cryojax conventions
-    coordinates = -jnp.flip(coordinates[:, :2], axis=-1)
+    weights, coordinate_list = jnp.asarray(weights).astype(
+        complex
+    ), jnp.asarray(coordinate_list)
+    # Negate x and y to convert to cryojax conventions
+    coordinates_yx = -coordinate_list[:, :2]
     # Normalize coordinates betweeen -pi and pi
     M1, M2 = shape
     image_size = jnp.asarray((M1, M2), dtype=float)
-    periodic_coords = 2 * jnp.pi * coordinates / image_size
-    # Compute and shift origin to cryojax conventions
-    x, y = periodic_coords.T
+    coordinates_periodic = 2 * jnp.pi * coordinates_yx / image_size
+    # Unpack and compute
+    y, x = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     projection = nufft1(shape, weights, x, y, **kwargs)
     # Shift zero frequency component to corner and take upper half plane
     projection = jnp.fft.ifftshift(projection)[:, : M2 // 2 + 1]

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -32,13 +32,8 @@ def test_euler_matrix(phi, theta, psi):
     matrix[0, 2] = sin_theta * cos_phi
     matrix[1, 2] = sin_theta * sin_phi
     matrix[2, 2] = cos_theta
-    # Generate rotation
+    # Generate rotation that matches this rotation matrix
     rotation = make_euler_rotation(
-        phi,
-        theta,
-        psi,
-        convention="zyz",
-        intrinsic=True,
-        degrees=False,
+        phi, theta, psi, convention="zyz", degrees=False
     )
-    np.testing.assert_allclose(rotation.as_matrix(), matrix, atol=1e-16)
+    np.testing.assert_allclose(rotation.as_matrix(), matrix.T, atol=1e-12)

--- a/tutorials/simulate-image.ipynb
+++ b/tutorials/simulate-image.ipynb
@@ -83,7 +83,7 @@
     "#density = cs.RealVoxelGrid.from_file(filename, crop_scale=0.9)\n",
     "#density = cs.VoxelCloud.from_file(filename)\n",
     "density = cs.FourierVoxelGrid.from_file(filename, pad_scale=2)\n",
-    "pose = cs.EulerPose(offset_x=-10.0, offset_y=5.0, view_phi=-20., view_theta=70., view_psi=45.)\n",
+    "pose = cs.EulerPose(offset_x=0.0, offset_y=15.0, view_phi=0., view_theta=90., view_psi=0.)\n",
     "specimen = cs.Specimen(density=density, pose=pose)"
    ]
   },

--- a/tutorials/simulate-image.ipynb
+++ b/tutorials/simulate-image.ipynb
@@ -79,20 +79,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "op.Lowpass(make_frequencies((64, 64, 64), half_space=False))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Read template into either an ElectronCloud or ElectronGrid\n",
     "#density = cs.RealVoxelGrid.from_file(filename, crop_scale=0.9)\n",
     "#density = cs.VoxelCloud.from_file(filename)\n",
-    "density = cs.FourierVoxelGrid.from_file(filename, pad_scale=1.0)\n",
-    "pose = cs.EulerPose(offset_x=5.0, offset_y=-3.0, view_phi=-20., view_theta=70., view_psi=45.)\n",
+    "density = cs.FourierVoxelGrid.from_file(filename, pad_scale=2)\n",
+    "pose = cs.EulerPose(offset_x=-10.0, offset_y=5.0, view_phi=-20., view_theta=70., view_psi=45.)\n",
     "specimen = cs.Specimen(density=density, pose=pose)"
    ]
   },
@@ -112,7 +103,7 @@
     "# Configure the image formation process\n",
     "shape = (64, 64)\n",
     "pixel_size = 4.4  # Angstroms\n",
-    "manager = cs.ImageManager(shape, pixel_size, pad_scale=1)\n",
+    "manager = cs.ImageManager(shape, pixel_size, pad_scale=2)\n",
     "#scattering = cs.NufftProject(manager, eps=1e-5)\n",
     "scattering = cs.FourierSliceExtract(manager, interpolation_order=1, interpolation_mode=\"fill\")"
    ]
@@ -171,9 +162,9 @@
    "outputs": [],
    "source": [
     "# Image formation models\n",
-    "scattering_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_s, solvent=solvent)\n",
-    "optics_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_o, solvent=solvent)\n",
-    "detector_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_d, solvent=solvent)"
+    "scattering_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_s)#, solvent=solvent)\n",
+    "optics_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_o)#, solvent=solvent)\n",
+    "detector_model = cs.ImagePipeline(scattering=scattering, specimen=specimen, instrument=instrument_d)#, solvent=solvent)"
    ]
   },
   {


### PR DESCRIPTION
Found a bug in the AbstractAssembly that was computing the inverse rotation on accident of the subunit positions. There were accidental transposes lying everywhere in the Helix class. The reason for the bug was unclear naming in the AbstractPose.rotate_coordinates function.

This lead to the larger change that now, the AbstractPose rotation defines a rotation of the **real space** volume. Before, the rotation was sneakily with respect to the fourier space volume.