### PR TITLE
Get rid of file loaders in the electron density

### DIFF
--- a/docs/api/simulator/electron_density.md
+++ b/docs/api/simulator/electron_density.md
@@ -17,6 +17,7 @@
             members:
                 - is_real
                 - shape
+                - rotate_to_pose
                 - from_density_grid
                 - from_atoms
 
@@ -44,6 +45,8 @@
                 - voxel_size
                 - frequency_slice
                 - frequency_slice_in_angstroms
+                - from_density_grid
+                - from_atoms
 
 ---
 
@@ -55,6 +58,8 @@
                 - voxel_size
                 - frequency_slice
                 - frequency_slice_in_angstroms
+                - from_density_grid
+                - from_atoms
 
 ### Real-space voxel representations
 
@@ -66,6 +71,8 @@
                 - voxel_size
                 - coordinate_grid
                 - coordinate_grid_in_angstroms
+                - from_density_grid
+                - from_atoms
 
 ---
 
@@ -77,3 +84,23 @@
                 - voxel_size
                 - coordinate_list
                 - coordinate_list_in_angstroms
+                - from_density_grid
+                - from_atoms
+
+### Pure function API
+
+::: cryojax.simulator.build_real_space_voxels_from_atoms
+        options:
+            heading_level: 5
+
+---
+
+::: cryojax.simulator.evaluate_3d_atom_potential
+        options:
+            heading_level: 5
+
+---
+
+::: cryojax.simulator.evaluate_3d_real_space_gaussian
+        options:
+            heading_level: 5

--- a/src/cryojax/simulator/_density/__init__.py
+++ b/src/cryojax/simulator/_density/__init__.py
@@ -10,4 +10,6 @@ from ._voxel_density import (
     RealVoxelGrid as RealVoxelGrid,
     RealVoxelCloud as RealVoxelCloud,
     build_real_space_voxels_from_atoms as build_real_space_voxels_from_atoms,
+    evaluate_3d_atom_potential as evaluate_3d_atom_potential,
+    evaluate_3d_real_space_gaussian as evaluate_3d_real_space_gaussian,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import jax.random as jr
 from jax import config
 
 import cryojax.simulator as cs
+from cryojax.io import read_image_or_volume_with_spacing_from_mrc
 from cryojax.image import operators as op
 from cryojax.image import rfftn
 
@@ -76,7 +77,12 @@ def scattering(manager):
 
 @pytest.fixture
 def density(sample_mrc_path):
-    return cs.FourierVoxelGrid.from_file(sample_mrc_path, pad_scale=1.3)
+    density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(
+        sample_mrc_path
+    )
+    return cs.FourierVoxelGrid.from_density_grid(
+        density_grid, voxel_size, pad_scale=1.3
+    )
 
 
 @pytest.fixture

--- a/tests/test_agree_with_cistem.py
+++ b/tests/test_agree_with_cistem.py
@@ -5,6 +5,7 @@ from jax import config
 from pycistem.core import CTF as cisCTF, Image, AnglesAndShifts
 
 import cryojax.simulator as cs
+from cryojax.io import read_image_or_volume_with_spacing_from_mrc
 from cryojax.simulator import CTF, make_euler_rotation
 from cryojax.image import powerspectrum, irfftn
 from cryojax.coordinates import make_frequencies, cartesian_to_polar
@@ -106,7 +107,10 @@ def test_euler_matrix_with_cistem(phi, theta, psi):
 )
 def test_compute_projection_with_cistem(phi, theta, psi, sample_mrc_path, pixel_size):
     # cryojax
-    density = cs.FourierVoxelGrid.from_file(sample_mrc_path)
+    density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(
+        sample_mrc_path
+    )
+    density = cs.FourierVoxelGrid.from_density_grid(density_grid, voxel_size)
     pose = cs.EulerPose(view_phi=phi, view_theta=theta, view_psi=psi)
     specimen = cs.Specimen(density, pose)
     box_size = density.shape[0]

--- a/tests/test_helix.py
+++ b/tests/test_helix.py
@@ -5,14 +5,18 @@ import jax.numpy as jnp
 import numpy as np
 import equinox as eqx
 import cryojax.simulator as cs
+from cryojax.io import read_image_or_volume_with_spacing_from_mrc
 from jax import config
 
 config.update("jax_enable_x64", True)
 
 
 def build_helix(sample_subunit_mrc_path, n_subunits_per_start) -> cs.Helix:
-    subunit_density = cs.FourierVoxelGrid.from_file(
-        sample_subunit_mrc_path, pad_scale=2
+    density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(
+        sample_subunit_mrc_path
+    )
+    subunit_density = cs.FourierVoxelGrid.from_density_grid(
+        density_grid, voxel_size, pad_scale=2
     )
     r_0 = jnp.asarray([-88.70895129, 9.75357114, 0.0], dtype=float)
     subunit_pose = cs.EulerPose(*r_0)
@@ -30,7 +34,12 @@ def build_helix_with_conformation(
     sample_subunit_mrc_path, n_subunits_per_start
 ) -> cs.Helix:
     subunit_density = tuple(
-        [cs.FourierVoxelGrid.from_file(sample_subunit_mrc_path) for _ in range(2)]
+        [
+            cs.FourierVoxelGrid.from_density_grid(
+                *read_image_or_volume_with_spacing_from_mrc(sample_subunit_mrc_path)
+            )
+            for _ in range(2)
+        ]
     )
     n_start = 6
     r_0 = jnp.asarray([-88.70895129, 9.75357114, 0.0], dtype=float)

--- a/tests/test_projection_agreement.py
+++ b/tests/test_projection_agreement.py
@@ -3,12 +3,16 @@ import pytest
 import numpy as np
 import cryojax.simulator as cs
 from cryojax.image import crop_to_shape
+from cryojax.io import read_image_or_volume_with_spacing_from_mrc
 
 
 @pytest.mark.parametrize("shape", [(65, 65), (65, 64), (64, 65)])
 def test_even_vs_odd_image_shape(shape, sample_mrc_path, pixel_size):
     control_shape = (64, 64)
-    density = cs.FourierVoxelGrid.from_file(sample_mrc_path)
+    density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(
+        sample_mrc_path
+    )
+    density = cs.FourierVoxelGrid.from_density_grid(density_grid, voxel_size)
     assert control_shape == density.fourier_density_grid.shape[0:2]
     pose = cs.EulerPose()
     specimen = cs.Specimen(density, pose)

--- a/tests/test_voxels_from_atoms.py
+++ b/tests/test_voxels_from_atoms.py
@@ -5,6 +5,7 @@ import pytest
 from cryojax.simulator import FourierVoxelGrid, RealVoxelGrid
 from cryojax.simulator import build_real_space_voxels_from_atoms
 
+from cryojax.io import read_atoms_from_pdb
 from cryojax.image import ifftn
 from cryojax.coordinates import CoordinateGrid
 from jax import config
@@ -21,10 +22,13 @@ def test_VoxelGrid_agreement(sample_pdb_path):
     voxel_size = 0.5
 
     # Load the PDB file into a VoxelGrid
-    vg = FourierVoxelGrid.from_pdb(
-        sample_pdb_path,
-        n_voxels_per_side=n_voxels_per_side,
-        voxel_size=voxel_size,
+    atom_positions, atom_elements = read_atoms_from_pdb(sample_pdb_path)
+    coordinate_grid_in_angstroms = CoordinateGrid(n_voxels_per_side, voxel_size)
+    vg = FourierVoxelGrid.from_atoms(
+        atom_positions,
+        atom_elements,
+        voxel_size,
+        coordinate_grid_in_angstroms,
     )
     # Since Voxelgrid is in Frequency space by default, we have to first
     # transform back into real space.
@@ -32,10 +36,11 @@ def test_VoxelGrid_agreement(sample_pdb_path):
     # Ravel the grid
     vg_density = vg_density.ravel()
 
-    vc = RealVoxelGrid.from_pdb(
-        sample_pdb_path,
-        n_voxels_per_side=n_voxels_per_side,
-        voxel_size=voxel_size,
+    vc = RealVoxelGrid.from_atoms(
+        atom_positions,
+        atom_elements,
+        voxel_size,
+        coordinate_grid_in_angstroms,
     )
 
     np.testing.assert_allclose(

--- a/tests/test_voxels_from_atoms.py
+++ b/tests/test_voxels_from_atoms.py
@@ -1,3 +1,4 @@
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -111,7 +112,10 @@ class TestBuildVoxelsFromTrajectories:
         # Build the trajectory $density
         elements = np.array([1, 1, 2, 6])
 
-        traj_voxels = RealVoxelGrid.from_trajectory(
+        make_voxel_grid_ensemble = jax.vmap(
+            RealVoxelGrid.from_atoms, in_axes=[0, None, None, None]
+        )
+        traj_voxels = make_voxel_grid_ensemble(
             traj, elements, voxel_size, coordinate_grid
         )
 

--- a/tutorials/simulate-helix.ipynb
+++ b/tutorials/simulate-helix.ipynb
@@ -42,7 +42,8 @@
    "source": [
     "# Image simulator imports\n",
     "import cryojax.simulator as cs\n",
-    "from cryojax.image import fftn, irfftn"
+    "from cryojax.image import fftn, irfftn\n",
+    "from cryojax.io import read_image_or_volume_with_spacing_from_mrc"
    ]
   },
   {
@@ -113,17 +114,21 @@
    "outputs": [],
    "source": [
     "# Initialize density distributions and center of mass pose\n",
-    "subunit_density = cs.FourierVoxelGrid.from_file(subunit_filename, pad_scale=1.2)\n",
-    "assembly_density = cs.FourierVoxelGrid.from_file(assembly_filename, pad_scale=1.2)\n",
+    "# ... the voxel grid of the subunit\n",
+    "subunit_density_grid, subunit_voxel_size = read_image_or_volume_with_spacing_from_mrc(subunit_filename)\n",
+    "subunit_density = cs.FourierVoxelGrid.from_density_grid(subunit_density_grid, subunit_voxel_size, pad_scale=1.2)\n",
+    "# ... and of the whole assembly\n",
+    "assembly_density_grid, assembly_voxel_size = read_image_or_volume_with_spacing_from_mrc(assembly_filename)\n",
+    "assembly_density = cs.FourierVoxelGrid.from_density_grid(assembly_density_grid, assembly_voxel_size, pad_scale=1.2)\n",
     "pose = cs.EulerPose(\n",
     "    offset_x=0.0, offset_y=0.0, view_phi=0.0, view_theta=0.0, view_psi=0.0\n",
     ")\n",
     "\n",
-    "# ... initialize the Specimen\n",
+    "# Initialize the Specimen\n",
     "initial_subunit = cs.Specimen(density=subunit_density, pose=cs.EulerPose(*r_0))\n",
     "true_assembly = cs.Specimen(density=assembly_density, pose=pose)\n",
     "\n",
-    "# ... initialize the Helix\n",
+    "# Initialize the Helix\n",
     "helix = cs.Helix(\n",
     "    subunit=initial_subunit,\n",
     "    pose=pose,\n",

--- a/tutorials/simulate-image.ipynb
+++ b/tutorials/simulate-image.ipynb
@@ -54,7 +54,8 @@
     "import cryojax.simulator as cs\n",
     "from cryojax.image import operators as op\n",
     "from cryojax.image import fftn, rfftn, irfftn\n",
-    "from cryojax.coordinates import make_frequencies"
+    "from cryojax.coordinates import make_frequencies\n",
+    "from cryojax.io import read_image_or_volume_with_spacing_from_mrc"
    ]
   },
   {
@@ -81,9 +82,8 @@
    "outputs": [],
    "source": [
     "# Read template into either an ElectronCloud or ElectronGrid\n",
-    "# density = cs.RealVoxelGrid.from_file(filename, crop_scale=0.9)\n",
-    "# density = cs.VoxelCloud.from_file(filename)\n",
-    "density = cs.FourierVoxelGrid.from_file(filename, pad_scale=2)\n",
+    "density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(filename)\n",
+    "density = cs.FourierVoxelGrid.from_density_grid(density_grid, voxel_size, pad_scale=2)\n",
     "pose = cs.EulerPose(\n",
     "    offset_x=0.0, offset_y=15.0, view_phi=0.0, view_theta=90.0, view_psi=0.0\n",
     ")\n",
@@ -107,7 +107,6 @@
     "shape = (64, 64)\n",
     "pixel_size = 4.4  # Angstroms\n",
     "manager = cs.ImageManager(shape, pixel_size, pad_scale=2)\n",
-    "# scattering = cs.NufftProject(manager, eps=1e-5)\n",
     "scattering = cs.FourierSliceExtract(\n",
     "    manager, interpolation_order=1, interpolation_mode=\"fill\"\n",
     ")"

--- a/tutorials/simulate-micrograph.ipynb
+++ b/tutorials/simulate-micrograph.ipynb
@@ -23,6 +23,7 @@
     "from functools import partial\n",
     "\n",
     "import cryojax.simulator as cs\n",
+    "from cryojax.io import read_image_or_volume_with_spacing_from_mrc\n",
     "\n",
     "config.update(\"jax_enable_x64\", False)"
    ]
@@ -93,8 +94,9 @@
     "\n",
     "# ... load the ElectronDensity and ScatteringModel\n",
     "filename = \"../tests/data/3j9g_bfm1_ps4_4.mrc\"\n",
+    "density_grid, voxel_size = read_image_or_volume_with_spacing_from_mrc(filename)\n",
     "manager = cs.ImageManager(shape, pixel_size, pad_scale=1.2)\n",
-    "density = cs.FourierVoxelGrid.from_file(filename, pad_scale=1.3)\n",
+    "density = cs.FourierVoxelGrid.from_density_grid(density_grid, voxel_size, pad_scale=1.3)\n",
     "scattering = cs.FourierSliceExtract(manager)\n",
     "\n",
     "# ... build the specimen\n",


### PR DESCRIPTION
I think it's best all file loaders are removed from the electron density. This is for three main reasons

1. I think it is bad practice to hide user interaction with `cryojax.io`.
2. Relatedly, the file loaders hide what exactly should be passed to the constructors.
3. Finally, I am going to start maintaining that all functions in `cryojax` objects must work with `jax.jit`. Otherwise, users could get confused and it would require additional documentation on our part.

With this PR, the only custom constructors are `AbstractVoxels.from_density_grid` and  `AbstractVoxels.from_atoms`. I also propose getting rid of `AbstractVoxels.from_trajectory` in favor of vmapping over `AbstractVoxels.from_atoms`. `AbstractVoxels.from_trajectory` presents some issues with typing, and it requires documenting what exact fields are vmapped over. I've updated the test in `test_voxels_from_atoms.py` to show how the `from_trajectory` behavior can easily be replicated.

@ehthiede, what do you think? You have suggested this in the past, but at the time I wasn't on board...