### PR TITLE
First pass at a cryojax.core submodule

### DIFF
--- a/src/cryojax/__init__.py
+++ b/src/cryojax/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     typing as typing,
     io as io,
+    core as core,
     image as image,
     coordinates as coordinates,
     rotations as rotations,

--- a/src/cryojax/core/__init__.py
+++ b/src/cryojax/core/__init__.py
@@ -1,0 +1,10 @@
+from ._filter_specs import get_filter_spec as get_filter_spec
+from ._filtered_transformations import (
+    filter_grad as filter_grad,
+    filter_value_and_grad as filter_value_and_grad,
+    filter_vmap as filter_vmap,
+)
+from ._errors import (
+    error_if_negative as error_if_negative,
+    error_if_not_fractional as error_if_not_fractional,
+)

--- a/src/cryojax/core/_errors.py
+++ b/src/cryojax/core/_errors.py
@@ -1,0 +1,21 @@
+"""
+Utilities for runtime errors, wrapping `equinox.error_if`. 
+"""
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+
+def error_if_negative(x: ArrayLike) -> Array:
+    x = jnp.asarray(x)
+    return eqx.error_if(x, x < 0, "A positive quantity was found to be negative!")
+
+
+def error_if_not_fractional(x: ArrayLike) -> Array:
+    x = jnp.asarray(x)
+    return eqx.error_if(
+        x,
+        ~jnp.logical_and(x > 0.0, x <= 1.0),
+        "A fractional quantity was found to not be between 0 and 1!",
+    )

--- a/src/cryojax/core/_filter_specs.py
+++ b/src/cryojax/core/_filter_specs.py
@@ -1,0 +1,27 @@
+"""
+Utilities for creating equinox filter_specs.
+"""
+
+import equinox as eqx
+import jax.tree_util as jtu
+from jaxtyping import PyTree
+from typing import Callable, Optional, Union, Sequence, Any
+
+
+def get_filter_spec(
+    pytree: PyTree,
+    where: Callable[[PyTree], Union[Any, Sequence[Any]]],
+    *,
+    inverse: bool = False,
+    is_leaf: Optional[Callable[[Any], bool]] = None,
+) -> PyTree[bool]:
+    if not inverse:
+        false_pytree = jtu.tree_map(lambda _: False, pytree)
+        return eqx.tree_at(
+            where, false_pytree, replace_fn=lambda x: True, is_leaf=is_leaf
+        )
+    else:
+        true_pytree = jtu.tree_map(lambda _: True, pytree)
+        return eqx.tree_at(
+            where, true_pytree, replace_fn=lambda x: False, is_leaf=is_leaf
+        )

--- a/src/cryojax/core/_filtered_transformations.py
+++ b/src/cryojax/core/_filtered_transformations.py
@@ -1,0 +1,108 @@
+"""
+Utilities for creating equinox filtered transformations. These routines
+are modified from `zodiax`, which was created for the project dLux: https://louisdesdoigts.github.io/dLux/.
+"""
+
+import equinox as eqx
+from jaxtyping import PyTree
+from functools import wraps, partial
+from typing import Callable, Union, Sequence, Any, Optional, Hashable
+
+from ._filter_specs import get_filter_spec
+
+
+def filter_grad(
+    func: Callable,
+    where_or_filter_spec: Callable[[PyTree], Union[Any, Sequence[Any]]] | PyTree[bool],
+    *,
+    inverse: bool = False,
+    has_aux: bool = False,
+) -> Callable:
+
+    @wraps(func)
+    def wrapper(pytree: PyTree, *args: Any, **kwargs: Any):
+
+        if isinstance(where_or_filter_spec, Callable):
+            where = where_or_filter_spec
+            filter_spec = get_filter_spec(pytree, where, inverse=inverse)
+        else:
+            filter_spec = where_or_filter_spec
+
+        @partial(eqx.filter_grad, has_aux=has_aux)
+        def recombine_fn(pytree_if_true: PyTree, pytree_if_false: PyTree):
+            pytree = eqx.combine(pytree_if_true, pytree_if_false)
+            return func(pytree, *args, **kwargs)
+
+        pytree_if_true, pytree_if_false = eqx.partition(pytree, filter_spec)
+        return recombine_fn(pytree_if_true, pytree_if_false)
+
+    return wrapper
+
+
+def filter_value_and_grad(
+    func: Callable,
+    where_or_filter_spec: Callable[[PyTree], Union[Any, Sequence[Any]]] | PyTree[bool],
+    *,
+    inverse: bool = False,
+    has_aux: bool = False,
+) -> Callable:
+
+    @wraps(func)
+    def wrapper(pytree: PyTree, *args: Any, **kwargs: Any):
+
+        if isinstance(where_or_filter_spec, Callable):
+            where = where_or_filter_spec
+            filter_spec = get_filter_spec(pytree, where, inverse=inverse)
+        else:
+            filter_spec = where_or_filter_spec
+
+        @partial(eqx.filter_value_and_grad, has_aux=has_aux)
+        def recombine_fn(pytree_if_true: PyTree, pytree_if_false: PyTree):
+            pytree = eqx.combine(pytree_if_true, pytree_if_false)
+            return func(pytree, *args, **kwargs)
+
+        pytree_if_true, pytree_if_false = eqx.partition(pytree, filter_spec)
+        return recombine_fn(pytree_if_true, pytree_if_false)
+
+    return wrapper
+
+
+def filter_vmap(
+    func: Callable,
+    where_or_filter_spec: Callable[[PyTree], Union[Any, Sequence[Any]]],
+    *,
+    inverse: bool = False,
+    in_axes: PyTree[Union[int, None, Callable[[Any], Optional[int]]]] = eqx.if_array(
+        axis=0
+    ),
+    out_axes: PyTree[Union[int, None, Callable[[Any], Optional[int]]]] = eqx.if_array(
+        axis=0
+    ),
+    axis_name: Hashable = None,
+    axis_size: Optional[int] = None,
+) -> Callable:
+
+    @wraps(func)
+    def wrapper(pytree: PyTree, *args: Any, **kwargs: Any):
+
+        if isinstance(where_or_filter_spec, Callable):
+            where = where_or_filter_spec
+            filter_spec = get_filter_spec(pytree, where, inverse=inverse)
+        else:
+            filter_spec = where_or_filter_spec
+
+        @partial(
+            eqx.filter_vmap,
+            in_axes=(in_axes, None),
+            out_axes=out_axes,
+            axis_name=axis_name,
+            axis_size=axis_size,
+        )
+        def recombine_fn(pytree_if_true: PyTree, pytree_if_false: PyTree):
+            pytree = eqx.combine(pytree_if_true, pytree_if_false)
+            return func(pytree, *args, **kwargs)
+
+        pytree_if_true, pytree_if_false = eqx.partition(pytree, filter_spec)
+        return recombine_fn(pytree_if_true, pytree_if_false)
+
+    return wrapper

--- a/src/cryojax/image/_map_coordinates.py
+++ b/src/cryojax/image/_map_coordinates.py
@@ -1,6 +1,8 @@
 """
 These versions of the scipy function map_coordinates is modified from Louis Desdoigts's
-version: https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py
+version: https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py.
+
+This code was developed for the project dLux: https://louisdesdoigts.github.io/dLux/.
 """
 
 import functools
@@ -27,9 +29,10 @@ def map_coordinates(
     cval: ArrayLike = 0.0,
 ):
     """
-    Similar to scipy.map_coordinates, but diverges from the API.
+    Similar to `scipy.map_coordinates`, but diverges from the API.
 
-    Adapted from https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py.
+    Adapted from https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py,
+    which was developed for the project [dLux](https://louisdesdoigts.github.io/dLux/).
 
     Arguments
     ---------
@@ -56,7 +59,8 @@ def map_coordinates_with_cubic_spline(
     """
     Similar to scipy.map_coordinates, but takes cubic spline coefficients as input.
 
-    Adapted from https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py.
+    Adapted from https://github.com/LouisDesdoigts/jax/blob/cubic-spline-updated/jax/_src/scipy/ndimage.py,
+    which was developed for the project [dLux](https://louisdesdoigts.github.io/dLux/).
 
     Arguments
     ---------

--- a/src/cryojax/image/operators/_fourier_operator.py
+++ b/src/cryojax/image/operators/_fourier_operator.py
@@ -16,6 +16,7 @@ from equinox import field
 
 import jax.numpy as jnp
 
+from ...core import error_if_negative
 from ._operator import AbstractImageOperator
 from ...typing import (
     Real_,
@@ -141,7 +142,7 @@ class FourierExp2D(AbstractFourierOperator, strict=True):
     """
 
     amplitude: Real_ = field(default=1.0, converter=jnp.asarray)
-    length_scale: Real_ = field(default=1.0, converter=jnp.asarray)
+    length_scale: Real_ = field(default=1.0, converter=error_if_negative)
 
     @override
     def __call__(self, freqs: ImageCoords) -> RealImage:
@@ -172,7 +173,7 @@ class Lorenzian(AbstractFourierOperator, strict=True):
     """
 
     amplitude: Real_ = field(default=1.0, converter=jnp.asarray)
-    length_scale: Real_ = field(default=1.0, converter=jnp.asarray)
+    length_scale: Real_ = field(default=1.0, converter=error_if_negative)
 
     @overload
     def __call__(self, freqs: ImageCoords) -> RealImage: ...
@@ -217,7 +218,7 @@ class FourierGaussian(AbstractFourierOperator, strict=True):
     """
 
     amplitude: Real_ = field(default=1.0, converter=jnp.asarray)
-    b_factor: Real_ = field(default=1.0, converter=jnp.asarray)
+    b_factor: Real_ = field(default=1.0, converter=error_if_negative)
 
     @overload
     def __call__(self, freqs: ImageCoords) -> RealImage: ...

--- a/src/cryojax/image/operators/_real_operator.py
+++ b/src/cryojax/image/operators/_real_operator.py
@@ -12,6 +12,7 @@ import jax.numpy as jnp
 
 from ._operator import AbstractImageOperator
 from ...typing import ImageCoords, VolumeCoords, RealImage, RealVolume, Real_
+from ...core import error_if_negative
 
 
 class AbstractRealOperator(AbstractImageOperator, strict=True):
@@ -68,7 +69,7 @@ class Gaussian2D(AbstractRealOperator, strict=True):
     """
 
     amplitude: Real_ = field(default=1.0, converter=jnp.asarray)
-    b_factor: Real_ = field(default=1.0, converter=jnp.asarray)
+    b_factor: Real_ = field(default=1.0, converter=error_if_negative)
     offset: Float[Array, "2"] = field(default=(0.0, 0.0), converter=jnp.asarray)
 
     @override

--- a/src/cryojax/simulator/_config.py
+++ b/src/cryojax/simulator/_config.py
@@ -20,6 +20,7 @@ from ..image import (
     irfftn,
     rfftn,
 )
+from ..core import error_if_negative
 
 
 class ImageConfig(Module, strict=True):
@@ -67,7 +68,7 @@ class ImageConfig(Module, strict=True):
     """
 
     shape: tuple[int, int] = field(static=True)
-    pixel_size: Real_ = field(converter=jnp.asarray)
+    pixel_size: Real_ = field(converter=error_if_negative)
 
     padded_shape: tuple[int, int] = field(static=True)
     pad_mode: Union[str, Callable] = field(static=True)

--- a/src/cryojax/simulator/_conformation.py
+++ b/src/cryojax/simulator/_conformation.py
@@ -5,10 +5,10 @@ Representations of conformational variables.
 from typing import Any
 from equinox import AbstractVar, field
 
-import jax.numpy as jnp
 from equinox import Module
 
 from ..typing import Int_
+from ..core import error_if_negative
 
 
 class AbstractConformation(Module, strict=True):
@@ -24,4 +24,4 @@ class DiscreteConformation(AbstractConformation, strict=True):
     A conformational variable wrapped in a Module.
     """
 
-    value: Int_ = field(converter=jnp.asarray)
+    value: Int_ = field(converter=error_if_negative)

--- a/src/cryojax/simulator/_detector.py
+++ b/src/cryojax/simulator/_detector.py
@@ -17,6 +17,7 @@ from ._config import ImageConfig
 from ..image.operators import AbstractFourierOperatorInPixels
 from ..image import irfftn, rfftn
 from ..typing import ComplexImage, RealImage, ImageCoords, Real_
+from ..core import error_if_not_fractional
 
 
 class AbstractDQE(AbstractFourierOperatorInPixels, strict=True):
@@ -53,7 +54,9 @@ class IdealDQE(AbstractDQE, strict=True):
     for details.
     """
 
-    fraction_detected_electrons: Real_ = field(default=1.0, converter=jnp.asarray)
+    fraction_detected_electrons: Real_ = field(
+        default=1.0, converter=error_if_not_fractional
+    )
 
     @override
     def __call__(self, frequency_grid: ImageCoords) -> RealImage:

--- a/src/cryojax/simulator/_optics.py
+++ b/src/cryojax/simulator/_optics.py
@@ -5,7 +5,7 @@ Models of instrument optics.
 from abc import abstractmethod
 from typing import ClassVar, Optional
 from typing_extensions import override
-from equinox import AbstractClassVar, AbstractVar, Module, field
+from equinox import AbstractClassVar, AbstractVar, Module, field, error_if
 
 import jax.numpy as jnp
 
@@ -17,6 +17,7 @@ from ..image.operators import (
 )
 from ..coordinates import cartesian_to_polar
 from ..typing import Real_, RealImage, ComplexImage, Image, ImageCoords
+from ..core import error_if_negative, error_if_not_fractional
 
 
 class CTF(AbstractFourierOperatorInAngstroms, strict=True):
@@ -43,12 +44,14 @@ class CTF(AbstractFourierOperatorInAngstroms, strict=True):
               in degrees or radians.
     """
 
-    defocus_u_in_angstroms: Real_ = field(default=10000.0, converter=jnp.asarray)
-    defocus_v_in_angstroms: Real_ = field(default=10000.0, converter=jnp.asarray)
+    defocus_u_in_angstroms: Real_ = field(default=10000.0, converter=error_if_negative)
+    defocus_v_in_angstroms: Real_ = field(default=10000.0, converter=error_if_negative)
     astigmatism_angle: Real_ = field(default=0.0, converter=jnp.asarray)
-    voltage_in_kilovolts: Real_ = field(default=300.0, converter=jnp.asarray)
-    spherical_aberration_in_mm: Real_ = field(default=2.7, converter=jnp.asarray)
-    amplitude_contrast_ratio: Real_ = field(default=0.1, converter=jnp.asarray)
+    voltage_in_kilovolts: Real_ = field(default=300.0, converter=error_if_negative)
+    spherical_aberration_in_mm: Real_ = field(default=2.7, converter=error_if_negative)
+    amplitude_contrast_ratio: Real_ = field(
+        default=0.1, converter=error_if_not_fractional
+    )
     phase_shift: Real_ = field(default=0.0, converter=jnp.asarray)
 
     degrees: bool = field(static=True, default=True)

--- a/src/cryojax/simulator/_potential/_voxel_potential.py
+++ b/src/cryojax/simulator/_potential/_voxel_potential.py
@@ -23,6 +23,7 @@ import numpy as np
 from ._scattering_potential import AbstractScatteringPotential
 from .._pose import AbstractPose
 from ...io import get_form_factor_params
+from ...core import error_if_negative
 
 from ...image.operators import AbstractFilter
 from ...image import (
@@ -217,7 +218,7 @@ class FourierVoxelGridPotential(AbstractFourierVoxelGridPotential):
 
     fourier_voxel_grid: ComplexCubicVolume = field(converter=jnp.asarray)
     wrapped_frequency_slice: FrequencySlice
-    voxel_size: Real_ = field(converter=jnp.asarray)
+    voxel_size: Real_ = field(converter=error_if_negative)
 
     is_real: ClassVar[bool] = False
 
@@ -252,7 +253,7 @@ class FourierVoxelGridPotentialInterpolator(AbstractFourierVoxelGridPotential):
 
     coefficients: ComplexCubicVolume = field(converter=jnp.asarray)
     wrapped_frequency_slice: FrequencySlice
-    voxel_size: Real_ = field(converter=jnp.asarray)
+    voxel_size: Real_ = field(converter=error_if_negative)
 
     is_real: ClassVar[bool] = False
 
@@ -298,7 +299,7 @@ class RealVoxelGridPotential(AbstractVoxelPotential, strict=True):
 
     real_voxel_grid: RealCubicVolume = field(converter=jnp.asarray)
     wrapped_coordinate_grid: CoordinateGrid
-    voxel_size: Real_ = field(converter=jnp.asarray)
+    voxel_size: Real_ = field(converter=error_if_negative)
 
     is_real: ClassVar[bool] = True
 
@@ -451,7 +452,7 @@ class RealVoxelCloudPotential(AbstractVoxelPotential, strict=True):
 
     voxel_weights: RealCloud = field(converter=jnp.asarray)
     wrapped_coordinate_list: CoordinateList
-    voxel_size: Real_ = field(converter=jnp.asarray)
+    voxel_size: Real_ = field(converter=error_if_negative)
 
     is_real: ClassVar[bool] = True
 


### PR DESCRIPTION
This sub-module will include utility functions that wrap `equinox` functions. Here, this includes

- Runtime error checking. For example, here we have error checking positive quantities and quantities that should be between 0 and 1.
- Utility function for creating a `filter_spec` given a `where`, where `where` (lol) is to be used with `tree_at`
- Wrappers for `equinox.filter_grad`, `eqx.filter_value_and_grad`, and `eqx.filter_vmap` to accept an optional `where` or `filter_spec`. This way, the user does not have to interact with `eqx.partition` and `eqx.combine` if they want something that just works.
- Serialization (to be included later)

The utilities for filters and jax transformations is inspired from the package `zodiax`. This is experimental, so tests to come at a later time.