### PR TITLE
Change recommendation for how to instantiate pytrees with vmap

### DIFF
--- a/docs/examples/simulate-micrograph.ipynb
+++ b/docs/examples/simulate-micrograph.ipynb
@@ -107,14 +107,14 @@
    "source": [
     "from functools import partial\n",
     "\n",
-    "from jaxtyping import PRNGKeyArray\n",
+    "import equinox as eqx\n",
+    "import equinox.internal as eqxi\n",
+    "from jaxtyping import PRNGKeyArray, PyTree\n",
     "\n",
     "\n",
-    "@partial(jax.vmap, in_axes=[0, None])\n",
-    "def make_poses(\n",
-    "    key: PRNGKeyArray,\n",
-    "    config: cs.ImageConfig,\n",
-    "):\n",
+    "@partial(eqx.filter_vmap, in_axes=(0, None), out_axes=eqxi.if_mapped(axis=0))\n",
+    "def make_pipeline(key: PRNGKeyArray, no_vmap: tuple[PyTree, ...]) -> cs.ImagePipeline:\n",
+    "    config, potential, integrator, instrument = no_vmap\n",
     "    # ... instantiate rotations\n",
     "    rotation = SO3.sample_uniform(key)\n",
     "    # ... now in-plane translation\n",
@@ -127,10 +127,25 @@
     "    # ... convert 2D in-plane translation to 3D, setting the out-of-plane translation to\n",
     "    # zero\n",
     "    offset_in_angstroms = jnp.pad(in_plane_offset_in_angstroms, ((0, 1),))\n",
-    "    # Build the pose and return\n",
-    "    return cs.QuaternionPose.from_rotation_and_translation(\n",
+    "    # ... build the pose\n",
+    "    pose = cs.QuaternionPose.from_rotation_and_translation(\n",
     "        rotation, offset_in_angstroms\n",
-    "    )"
+    "    )\n",
+    "    # ... build the Specimen and ImagePipeline as usual and return\n",
+    "    specimen = cs.Specimen(potential, integrator, pose)\n",
+    "    return cs.ImagePipeline(config, specimen, instrument)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "!!! info \"What's with the `out_axes=eqxi.if_mapped(axis=0)`?\"\n",
+    "    \n",
+    "    When we create a pytree with `eqx.filter_vmap` (or `jax.vmap`), `out_axes` should have the same structure as the output pytree. If `out_axes` is set to `None` at a particular leaf, this\n",
+    "    says that we do not want to broadcast that leaf (of course, this only works for unmapped leaves). By default `jax.vmap` sets `out_axes=0`, so all unmapped leaves get broadcasted. `equinox` allows us to pass `out_axes=eqxi.if_mapped(axes=0)`, which specifies *not* to broadcast pytree leaves unless the leaves are directly mapped.\n",
+    "\n",
+    "    When building an `ImagePipeline`, it is very important that we do not broadcast arbitrary leaves! For example, an `ImageConfig` stores the coordinate systems for our image. Without the `out_axes=eqxi.if_mapped(axes=0)` specification, the `make_pipeline` would output an `ImagePipeline.config` whose coordinate systems have a batch dimension. This takes up unecessary memory."
    ]
   },
   {
@@ -143,21 +158,17 @@
     "number_of_poses = 20\n",
     "keys = jax.random.split(jax.random.PRNGKey(12345), number_of_poses)\n",
     "\n",
-    "# ... instantiate the poses\n",
-    "poses = make_poses(keys, config)\n",
-    "\n",
-    "# ... build the Specimen and ImagePipeline as usual\n",
-    "specimen = cs.Specimen(potential, integrator, poses)\n",
-    "pipeline = cs.ImagePipeline(config, specimen, instrument)"
+    "# ... instantiate the pipeline\n",
+    "pipeline = make_pipeline(keys, (config, potential, integrator, instrument))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This may be a little odd at first. We have contructed a pipeline, where if we were to directly call its `render` method, it would not work. Think of it this way: because we created our `pose`s with a `vmap`, functions can now only be called after crossing `vmap` boundaries. There is very good reason for this! To learn more, read the section of the equinox documentation on [model ensembling](https://docs.kidger.site/equinox/tricks/#ensembling).\n",
+    "This may be a little odd at first. We have contructed a pipeline, where if we were to directly call its `render` method, it would not work. Think of it this way: because we created our `pipeline`s with a `vmap`, functions can now only be called after crossing `vmap` boundaries. There is very good reason for this! To learn more, read the section of the equinox documentation on [model ensembling](https://docs.kidger.site/equinox/tricks/#ensembling).\n",
     "\n",
-    "Now that we have an `ImagePipeline` with a batched set of poses, we need some way of telling our `vmap` exactly what pytree leaves are batched. One way `equinox` does this is by using pointers to particular pytree leaves to create what is called a `filter_spec`."
+    "Now that we have an `ImagePipeline` with a batched set of poses, we need some way of telling our `vmap` exactly what pytree leaves have batch dimensions. One way `equinox` does this is by using pointers to particular pytree leaves to create what is called a `filter_spec`."
    ]
   },
   {

--- a/src/cryojax/image/operators/_fourier_operator.py
+++ b/src/cryojax/image/operators/_fourier_operator.py
@@ -59,7 +59,7 @@ FourierOperatorLike = AbstractFourierOperator | AbstractImageOperator
 class ZeroMode(AbstractFourierOperator, strict=True):
     """This operator returns a constant in the zero mode."""
 
-    value: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
+    value: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
     @override
     def __call__(
@@ -95,10 +95,8 @@ class FourierExp2D(AbstractFourierOperator, strict=True):
     scale.
     """
 
-    amplitude: Float[Array, "..."] = field(default=1.0, converter=jnp.asarray)
-    length_scale: Float[Array, "..."] = field(
-        default=1.0, converter=error_if_not_positive
-    )
+    amplitude: Float[Array, ""] = field(default=1.0, converter=jnp.asarray)
+    length_scale: Float[Array, ""] = field(default=1.0, converter=error_if_not_positive)
 
     @override
     def __call__(
@@ -129,10 +127,8 @@ class Lorenzian(AbstractFourierOperator, strict=True):
     scale.
     """
 
-    amplitude: Float[Array, "..."] = field(default=1.0, converter=jnp.asarray)
-    length_scale: Float[Array, "..."] = field(
-        default=1.0, converter=error_if_not_positive
-    )
+    amplitude: Float[Array, ""] = field(default=1.0, converter=jnp.asarray)
+    length_scale: Float[Array, ""] = field(default=1.0, converter=error_if_not_positive)
 
     @overload
     def __call__(
@@ -181,8 +177,8 @@ class FourierGaussian(AbstractFourierOperator, strict=True):
     where :math:`r^2 = x^2 + y^2`.
     """
 
-    amplitude: Float[Array, "..."] = field(default=1.0, converter=jnp.asarray)
-    b_factor: Float[Array, "..."] = field(default=1.0, converter=error_if_not_positive)
+    amplitude: Float[Array, ""] = field(default=1.0, converter=jnp.asarray)
+    b_factor: Float[Array, ""] = field(default=1.0, converter=error_if_not_positive)
 
     @overload
     def __call__(

--- a/src/cryojax/image/operators/_real_operator.py
+++ b/src/cryojax/image/operators/_real_operator.py
@@ -60,9 +60,9 @@ class Gaussian2D(AbstractRealOperator, strict=True):
     where $r^2 = x^2 + y^2$.
     """
 
-    amplitude: Float[Array, "..."] = field(default=1.0, converter=jnp.asarray)
-    b_factor: Float[Array, "..."] = field(default=1.0, converter=error_if_not_positive)
-    offset: Float[Array, "... 2"] = field(default=(0.0, 0.0), converter=jnp.asarray)
+    amplitude: Float[Array, ""] = field(default=1.0, converter=jnp.asarray)
+    b_factor: Float[Array, ""] = field(default=1.0, converter=error_if_not_positive)
+    offset: Float[Array, "2"] = field(default=(0.0, 0.0), converter=jnp.asarray)
 
     @override
     def __call__(

--- a/src/cryojax/inference/distributions/_gaussian_distributions.py
+++ b/src/cryojax/inference/distributions/_gaussian_distributions.py
@@ -26,13 +26,13 @@ class IndependentFourierGaussian(AbstractDistribution, strict=True):
 
     pipeline: AbstractPipeline
     variance: FourierOperatorLike
-    contrast_scale: Float[Array, "..."] = field(converter=error_if_not_positive)
+    contrast_scale: Float[Array, ""] = field(converter=error_if_not_positive)
 
     def __init__(
         self,
         pipeline: AbstractPipeline,
         variance: Optional[FourierOperatorLike] = None,
-        contrast_scale: float | Float[Array, "..."] = 1.0,
+        contrast_scale: float | Float[Array, ""] = 1.0,
     ):
         """**Arguments:**
 

--- a/src/cryojax/rotations/_lie_group.py
+++ b/src/cryojax/rotations/_lie_group.py
@@ -81,7 +81,7 @@ class SO3(AbstractMatrixLieGroup, strict=True):
     tangent_dimension: ClassVar[int] = 3
     matrix_dimension: ClassVar[int] = 3
 
-    wxyz: Float[Array, "... 4"] = field(converter=jnp.asarray)
+    wxyz: Float[Array, "4"] = field(converter=jnp.asarray)
 
     @override
     def apply(self, target: Float[Array, "3"]) -> Float[Array, "3"]:
@@ -359,7 +359,7 @@ class SE3(AbstractMatrixLieGroup, strict=True):
     matrix_dimension: ClassVar[int] = 4
 
     rotation: SO3
-    xyz: Float[Array, "... 3"]
+    xyz: Float[Array, "3"]
 
     @override
     def apply(self, target: Float[Array, "3"]) -> Float[Array, "3"]:

--- a/src/cryojax/simulator/_assembly/_helix.py
+++ b/src/cryojax/simulator/_assembly/_helix.py
@@ -29,8 +29,8 @@ class Helix(AbstractAssembly, strict=True):
     """
 
     subunit: AbstractSpecimen
-    rise: Float[Array, "..."]
-    twist: Float[Array, "..."]
+    rise: Float[Array, ""]
+    twist: Float[Array, ""]
 
     pose: AbstractPose
     conformation: Optional[AbstractConformation]
@@ -41,8 +41,8 @@ class Helix(AbstractAssembly, strict=True):
     def __init__(
         self,
         subunit: AbstractSpecimen,
-        rise: Float[Array, "..."] | float,
-        twist: Float[Array, "..."] | float,
+        rise: Float[Array, ""] | float,
+        twist: Float[Array, ""] | float,
         pose: Optional[AbstractPose] = None,
         conformation: Optional[AbstractConformation] = None,
         n_start: int = 1,

--- a/src/cryojax/simulator/_config.py
+++ b/src/cryojax/simulator/_config.py
@@ -60,7 +60,7 @@ class ImageConfig(Module, strict=True):
     """
 
     shape: tuple[int, int] = field(static=True)
-    pixel_size: Float[Array, "..."] = field(converter=error_if_not_positive)
+    pixel_size: Float[Array, ""] = field(converter=error_if_not_positive)
 
     padded_shape: tuple[int, int] = field(static=True)
     pad_mode: Union[str, Callable] = field(static=True)
@@ -74,7 +74,7 @@ class ImageConfig(Module, strict=True):
     def __init__(
         self,
         shape: tuple[int, int],
-        pixel_size: float | Float[Array, "..."],
+        pixel_size: float | Float[Array, ""],
         padded_shape: Optional[tuple[int, int]] = None,
         *,
         pad_scale: float = 1.0,

--- a/src/cryojax/simulator/_conformation.py
+++ b/src/cryojax/simulator/_conformation.py
@@ -23,4 +23,4 @@ class DiscreteConformation(AbstractConformation, strict=True):
     A conformational variable wrapped in a Module.
     """
 
-    value: Int[Array, "..."] = field(converter=error_if_negative)
+    value: Int[Array, ""] = field(converter=error_if_negative)

--- a/src/cryojax/simulator/_detector.py
+++ b/src/cryojax/simulator/_detector.py
@@ -21,7 +21,7 @@ from ._config import ImageConfig
 class AbstractDQE(AbstractFourierOperator, strict=True):
     r"""Base class for a detector DQE."""
 
-    fraction_detected_electrons: AbstractVar[Float[Array, "..."]]
+    fraction_detected_electrons: AbstractVar[Float[Array, ""]]
 
     @abstractmethod
     def __call__(
@@ -49,7 +49,7 @@ class IdealDQE(AbstractDQE, strict=True):
     transmission electron microscopy." (2013) for details.
     """
 
-    fraction_detected_electrons: Float[Array, "..."] = field(
+    fraction_detected_electrons: Float[Array, ""] = field(
         default=1.0, converter=error_if_not_fractional
     )
 

--- a/src/cryojax/simulator/_dose.py
+++ b/src/cryojax/simulator/_dose.py
@@ -16,6 +16,6 @@ class ElectronDose(Module, strict=True):
     `electrons_per_angstrom_squared`: The integrated electron flux.
     """
 
-    electrons_per_angstrom_squared: Float[Array, "..."] = field(
+    electrons_per_angstrom_squared: Float[Array, ""] = field(
         converter=error_if_not_positive
     )

--- a/src/cryojax/simulator/_instrument.py
+++ b/src/cryojax/simulator/_instrument.py
@@ -30,14 +30,14 @@ class Instrument(Module, strict=True):
     - `detector` : The model of the detector.
     """
 
-    voltage_in_kilovolts: Float[Array, "..."] = field(converter=error_if_not_positive)
+    voltage_in_kilovolts: Float[Array, ""] = field(converter=error_if_not_positive)
     dose: Optional[ElectronDose]
     optics: Optional[AbstractOptics]
     detector: Optional[AbstractDetector]
 
     def __init__(
         self,
-        voltage_in_kilovolts: float | Float[Array, "..."],
+        voltage_in_kilovolts: float | Float[Array, ""],
         *,
         dose: Optional[ElectronDose] = None,
         optics: Optional[AbstractOptics] = None,

--- a/src/cryojax/simulator/_optics.py
+++ b/src/cryojax/simulator/_optics.py
@@ -26,24 +26,24 @@ class CTF(AbstractFourierOperator, strict=True):
     scattering specimen.
     """
 
-    defocus_u_in_angstroms: Float[Array, "..."] = field(
+    defocus_u_in_angstroms: Float[Array, ""] = field(
         default=10000.0, converter=error_if_not_positive
     )
-    defocus_v_in_angstroms: Float[Array, "..."] = field(
+    defocus_v_in_angstroms: Float[Array, ""] = field(
         default=10000.0, converter=error_if_not_positive
     )
-    astigmatism_angle: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
+    astigmatism_angle: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
     voltage_in_kilovolts: Float[Array, ""] | float = field(
         default=300.0, static=True
     )  # Mark `static=True` so that the voltage is not part of the model pytree
     # It is treated as part of the pytree upstream, in the Instrument!
-    spherical_aberration_in_mm: Float[Array, "..."] = field(
+    spherical_aberration_in_mm: Float[Array, ""] = field(
         default=2.7, converter=error_if_negative
     )
-    amplitude_contrast_ratio: Float[Array, "..."] = field(
+    amplitude_contrast_ratio: Float[Array, ""] = field(
         default=0.1, converter=error_if_not_fractional
     )
-    phase_shift: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
+    phase_shift: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
     def __call__(
         self,

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -29,9 +29,9 @@ class AbstractPose(Module, strict=True):
            `AbstractPose.from_rotation` class method.
     """
 
-    offset_x_in_angstroms: AbstractVar[Float[Array, "..."]]
-    offset_y_in_angstroms: AbstractVar[Float[Array, "..."]]
-    offset_z_in_angstroms: AbstractVar[Float[Array, "..."]]
+    offset_x_in_angstroms: AbstractVar[Float[Array, ""]]
+    offset_y_in_angstroms: AbstractVar[Float[Array, ""]]
+    offset_z_in_angstroms: AbstractVar[Float[Array, ""]]
 
     @overload
     def rotate_coordinates(
@@ -135,19 +135,13 @@ class EulerAnglePose(AbstractPose, strict=True):
     given by a zyz extrinsic rotations.
     """
 
-    offset_x_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_y_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_z_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
+    offset_x_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_y_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_z_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
-    view_phi: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
-    view_theta: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
-    view_psi: Float[Array, "..."] = field(default=0.0, converter=jnp.asarray)
+    view_phi: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    view_theta: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    view_psi: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
     @cached_property
     @override
@@ -192,19 +186,11 @@ EulerAnglePose.__init__.__doc__ = """**Arguments:**
 class QuaternionPose(AbstractPose, strict=True):
     """An `AbstractPose` represented by unit quaternions."""
 
-    offset_x_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_y_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_z_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
+    offset_x_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_y_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_z_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
-    wxyz: Float[Array, "... 4"] = field(
-        default=(1.0, 0.0, 0.0, 0.0), converter=jnp.asarray
-    )
+    wxyz: Float[Array, "4"] = field(default=(1.0, 0.0, 0.0, 0.0), converter=jnp.asarray)
 
     @cached_property
     @override
@@ -242,17 +228,11 @@ class AxisAnglePose(AbstractPose, strict=True):
     the matrix exponential.
     """
 
-    offset_x_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_y_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
-    offset_z_in_angstroms: Float[Array, "..."] = field(
-        default=0.0, converter=jnp.asarray
-    )
+    offset_x_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_y_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
+    offset_z_in_angstroms: Float[Array, ""] = field(default=0.0, converter=jnp.asarray)
 
-    euler_vector: Float[Array, "... 3"] = field(
+    euler_vector: Float[Array, "3"] = field(
         default=(0.0, 0.0, 0.0), converter=jnp.asarray
     )
 

--- a/src/cryojax/simulator/_potential/_voxel_potential.py
+++ b/src/cryojax/simulator/_potential/_voxel_potential.py
@@ -37,7 +37,7 @@ from ._scattering_potential import AbstractScatteringPotential
 class AbstractVoxelPotential(AbstractScatteringPotential, strict=True):
     """Abstract interface for a voxel-based scattering potential representation."""
 
-    voxel_size: AbstractVar[Float[Array, "..."]]
+    voxel_size: AbstractVar[Float[Array, ""]]
     is_real: AbstractClassVar[bool]
 
     @property
@@ -86,9 +86,9 @@ class AbstractFourierVoxelGridPotential(AbstractVoxelPotential, strict=True):
     @abstractmethod
     def __init__(
         self,
-        fourier_voxel_grid: Complex[Array, "... dim dim dim"],
+        fourier_voxel_grid: Complex[Array, "dim dim dim"],
         wrapped_frequency_slice_in_pixels: FrequencySlice,
-        voxel_size: Float[Array, "..."] | float,
+        voxel_size: Float[Array, ""] | float,
     ):
         raise NotImplementedError
 
@@ -208,18 +208,18 @@ class AbstractFourierVoxelGridPotential(AbstractVoxelPotential, strict=True):
 class FourierVoxelGridPotential(AbstractFourierVoxelGridPotential):
     """A 3D scattering potential voxel grid in fourier-space."""
 
-    fourier_voxel_grid: Complex[Array, "... dim dim dim"]
+    fourier_voxel_grid: Complex[Array, "dim dim dim"]
     wrapped_frequency_slice_in_pixels: FrequencySlice
-    voxel_size: Float[Array, "..."] = field(converter=error_if_not_positive)
+    voxel_size: Float[Array, ""] = field(converter=error_if_not_positive)
 
     is_real: ClassVar[bool] = False
 
     @override
     def __init__(
         self,
-        fourier_voxel_grid: Complex[Array, "... dim dim dim"],
+        fourier_voxel_grid: Complex[Array, "dim dim dim"],
         wrapped_frequency_slice_in_pixels: FrequencySlice,
-        voxel_size: Float[Array, "..."] | float,
+        voxel_size: Float[Array, ""] | float,
     ):
         """**Arguments:**
 
@@ -242,17 +242,17 @@ class FourierVoxelGridPotentialInterpolator(AbstractFourierVoxelGridPotential):
     by spline coefficients.
     """
 
-    coefficients: Float[Array, "... coeff_dim coeff_dim coeff_dim"]
+    coefficients: Float[Array, "coeff_dim coeff_dim coeff_dim"]
     wrapped_frequency_slice_in_pixels: FrequencySlice
-    voxel_size: Float[Array, "..."] = field(converter=error_if_not_positive)
+    voxel_size: Float[Array, ""] = field(converter=error_if_not_positive)
 
     is_real: ClassVar[bool] = False
 
     def __init__(
         self,
-        fourier_voxel_grid: Float[Array, "... dim dim dim"],
+        fourier_voxel_grid: Float[Array, "dim dim dim"],
         wrapped_frequency_slice_in_pixels: FrequencySlice,
-        voxel_size: Float[Array, "..."] | float,
+        voxel_size: Float[Array, ""] | float,
     ):
         """
         !!! note
@@ -275,13 +275,7 @@ class FourierVoxelGridPotentialInterpolator(AbstractFourierVoxelGridPotential):
                                                wrapped in a `FrequencySlice` object.
         - `voxel_size`: The voxel size.
         """
-        n_batch_dims = fourier_voxel_grid.ndim - 3
-        compute_spline_coefficients_3d = compute_spline_coefficients
-        for _ in range(n_batch_dims):
-            compute_spline_coefficients_3d = jax.vmap(compute_spline_coefficients_3d)
-        self.coefficients = compute_spline_coefficients_3d(
-            jnp.asarray(fourier_voxel_grid)
-        )
+        self.coefficients = compute_spline_coefficients(jnp.asarray(fourier_voxel_grid))
         self.wrapped_frequency_slice_in_pixels = wrapped_frequency_slice_in_pixels
         self.voxel_size = jnp.asarray(voxel_size)
 
@@ -295,17 +289,17 @@ class FourierVoxelGridPotentialInterpolator(AbstractFourierVoxelGridPotential):
 class RealVoxelGridPotential(AbstractVoxelPotential, strict=True):
     """Abstraction of a 3D scattering potential voxel grid in real-space."""
 
-    real_voxel_grid: Float[Array, "... dim dim dim"]
+    real_voxel_grid: Float[Array, "dim dim dim"]
     wrapped_coordinate_grid_in_pixels: CoordinateGrid
-    voxel_size: Float[Array, "..."] = field(converter=error_if_not_positive)
+    voxel_size: Float[Array, ""] = field(converter=error_if_not_positive)
 
     is_real: ClassVar[bool] = True
 
     def __init__(
         self,
-        real_voxel_grid: Float[Array, "... dim dim dim"],
+        real_voxel_grid: Float[Array, "dim dim dim"],
         wrapped_coordinate_grid_in_pixels: CoordinateGrid,
-        voxel_size: Float[Array, "..."] | float,
+        voxel_size: Float[Array, ""] | float,
     ):
         """**Arguments:**
 
@@ -447,17 +441,17 @@ class RealVoxelCloudPotential(AbstractVoxelPotential, strict=True):
         voxel values.
     """
 
-    voxel_weights: Float[Array, "... size"]
+    voxel_weights: Float[Array, " size"]
     wrapped_coordinate_list_in_pixels: CoordinateList
-    voxel_size: Float[Array, "..."] = field(converter=error_if_not_positive)
+    voxel_size: Float[Array, ""] = field(converter=error_if_not_positive)
 
     is_real: ClassVar[bool] = True
 
     def __init__(
         self,
-        voxel_weights: Float[Array, "... size"],
+        voxel_weights: Float[Array, " size"],
         wrapped_coordinate_list_in_pixels: CoordinateList,
-        voxel_size: Float[Array, "..."] | float,
+        voxel_size: Float[Array, ""] | float,
     ):
         """**Arguments:**
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -24,7 +24,9 @@ def test_conformation_vmap(potential, pose, integrator, config):
         stacked_potential,
         integrator,
         pose,
-        conformation=DiscreteConformation(jnp.asarray((0, 1, 2, 1, 0))),
+        conformation=jax.vmap(lambda value: DiscreteConformation(value))(
+            jnp.asarray((0, 1, 2, 1, 0))
+        ),
     )
     # Setup vmap
     is_vmap = lambda x: isinstance(x, DiscreteConformation)

--- a/tests/test_helix.py
+++ b/tests/test_helix.py
@@ -49,7 +49,7 @@ def build_helix_with_conformation(
         subunit_pose,
         conformation=cs.DiscreteConformation(0),
     )
-    conformation = cs.DiscreteConformation(
+    conformation = jax.vmap(lambda value: cs.DiscreteConformation(value))(
         np.random.choice(2, n_start * n_subunits_per_start)
     )
     return cs.Helix(


### PR DESCRIPTION
`equinox.internal.if_mapped` changes everything! Specifying `out_axes` with this in a call to `eqx.filter_vmap` makes it so non-mapped pytree leaves do not get broadcasted. See the simulate-micrograph.ipynb for an example and description of this.