### PR TITLE
Convert back to standard FFT convention

### DIFF
--- a/docs/examples/read-dataset.ipynb
+++ b/docs/examples/read-dataset.ipynb
@@ -354,13 +354,14 @@
     "\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(4, 4))\n",
+    "n_pixels = relion_particle.instrument_config.n_pixels\n",
     "spectrum, frequencies = compute_radially_averaged_powerspectrum(\n",
     "    fourier_image,\n",
     "    radial_frequency_grid_in_angstroms,\n",
     "    pixel_size,\n",
     "    maximum_frequency=1 / (2 * pixel_size),\n",
     ")\n",
-    "ax.plot(frequencies, spectrum, color=\"k\")\n",
+    "ax.plot(frequencies, spectrum / n_pixels, color=\"k\")\n",
     "ax.set(\n",
     "    xlabel=\"frequency magnitude $[\\AA^{-1}]$\",\n",
     "    ylabel=\"radially averaged power spectrum\",\n",
@@ -392,7 +393,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.1.-1"
   }
  },
  "nbformat": 4,

--- a/src/cryojax/image/_downsample.py
+++ b/src/cryojax/image/_downsample.py
@@ -1,6 +1,5 @@
 """Routines for downsampling arrays"""
 
-import math
 from typing import overload
 
 import jax.numpy as jnp
@@ -123,11 +122,8 @@ def downsample_to_shape_with_fourier_cropping(
     the downsampled array in fourier space assuming hermitian symmetry,
     with the zero frequency component in the corner.
     """
-    n_pixels, new_n_pixels = image_or_volume.size, math.prod(downsampled_shape)
     fourier_array = jnp.fft.fftshift(fftn(image_or_volume))
-    cropped_fourier_array = jnp.sqrt(n_pixels / new_n_pixels) * crop_to_shape(
-        fourier_array, downsampled_shape
-    )
+    cropped_fourier_array = crop_to_shape(fourier_array, downsampled_shape)
     if get_real:
         return ifftn(jnp.fft.ifftshift(cropped_fourier_array))
     else:

--- a/src/cryojax/image/_fft.py
+++ b/src/cryojax/image/_fft.py
@@ -26,7 +26,7 @@ def ifftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.ifftn(ft, s=s, axes=axes, norm="ortho"), axes=axes)
+    ift = jnp.fft.fftshift(jnp.fft.ifftn(ft, s=s, axes=axes), axes=axes)
 
     return ift
 
@@ -49,7 +49,7 @@ def fftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.fftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes, norm="ortho")
+    ft = jnp.fft.fftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
 
     return ft
 
@@ -72,7 +72,7 @@ def irfftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.irfftn(ft, s=s, axes=axes, norm="ortho"), axes=axes)
+    ift = jnp.fft.fftshift(jnp.fft.irfftn(ft, s=s, axes=axes), axes=axes)
 
     return ift
 
@@ -94,6 +94,6 @@ def rfftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.rfftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes, norm="ortho")
+    ft = jnp.fft.rfftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
 
     return ft

--- a/src/cryojax/simulator/_detector.py
+++ b/src/cryojax/simulator/_detector.py
@@ -172,7 +172,7 @@ class AbstractDetector(Module, strict=True):
         electrons_per_image = N_pix * electrons_per_pixel
         # Normalize the squared wavefunction to a set of probabilities
         fourier_squared_wavefunction_at_detector_plane /= (
-            fourier_squared_wavefunction_at_detector_plane[0, 0] * jnp.sqrt(N_pix)
+            fourier_squared_wavefunction_at_detector_plane[0, 0]
         )
         # Compute the noiseless signal by applying the DQE to the squared wavefunction
         fourier_signal = fourier_squared_wavefunction_at_detector_plane * jnp.sqrt(

--- a/src/cryojax/simulator/_potential_integrator/fourier_voxel_extract.py
+++ b/src/cryojax/simulator/_potential_integrator/fourier_voxel_extract.py
@@ -289,5 +289,4 @@ def _extract_surface_from_voxel_grid(
     # Set last line of frequencies to zero if image dimension is even
     if N % 2 == 0:
         projection = projection.at[:, -1].set(0.0 + 0.0j).at[N // 2, :].set(0.0 + 0.0j)
-    # Re-scale projection to account for "ortho" FFT normalization convention
-    return projection * N ** (1 / 2)
+    return projection

--- a/src/cryojax/simulator/_potential_integrator/nufft_project.py
+++ b/src/cryojax/simulator/_potential_integrator/nufft_project.py
@@ -129,5 +129,4 @@ def _project_with_nufft(weights, coordinate_list, shape, eps=1e-6):
         projection = projection.at[:, -1].set(0.0 + 0.0j)
     if M1 % 2 == 0:
         projection = projection.at[M1 // 2, :].set(0.0 + 0.0j)
-    # Return projection in "ortho" FFT normalization convention
-    return projection / jnp.sqrt(M1 * M2)
+    return projection

--- a/src/cryojax/simulator/_solvent.py
+++ b/src/cryojax/simulator/_solvent.py
@@ -72,10 +72,11 @@ class GaussianIce(AbstractIce, strict=True):
         Array, "{instrument_config.padded_y_dim} {instrument_config.padded_x_dim//2+1}"
     ]:
         """Sample a realization of the ice phase shifts as colored gaussian noise."""
+        n_pixels = instrument_config.padded_n_pixels
         frequency_grid_in_angstroms = instrument_config.padded_frequency_grid_in_angstroms
         # Compute standard deviation, scaling up by the variance by the number
         # of pixels to make the realization independent pixel-independent in real-space.
-        std = jnp.sqrt(self.variance_function(frequency_grid_in_angstroms))
+        std = jnp.sqrt(n_pixels * self.variance_function(frequency_grid_in_angstroms))
         ice_integrated_potential_at_exit_plane = std * jr.normal(
             key,
             shape=frequency_grid_in_angstroms.shape[0:-1],

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -69,12 +69,12 @@ def test_gaussian_limit():
     np.testing.assert_allclose(
         irfftn(
             jnp.abs(fourier_gaussian_detector_readout) ** 2
-            / (jnp.sqrt(n_pixels) * electrons_per_pixel**2),
+            / (n_pixels * electrons_per_pixel**2),
             s=config.padded_shape,
         ),
         irfftn(
             jnp.abs(fourier_poisson_detector_readout) ** 2
-            / (jnp.sqrt(n_pixels) * electrons_per_pixel**2),
+            / (n_pixels * electrons_per_pixel**2),
             s=config.padded_shape,
         ),
         rtol=1e-2,

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -15,9 +15,10 @@ def test_fourier_vs_real_normalized_image(noisy_model):
         normalize_image(
             noisy_model.render(get_real=False),
             is_real=False,
+            shape_in_real_space=im1.shape,
         ),
         s=noisy_model.instrument_config.shape,
     )  # type: ignore
     for im in [im1, im2]:
-        np.testing.assert_allclose(jnp.std(im), jnp.asarray(1.0), atol=1e-2)
+        np.testing.assert_allclose(jnp.std(im), jnp.asarray(1.0), rtol=1e-3)
         np.testing.assert_allclose(jnp.mean(im), jnp.asarray(0.0), atol=1e-8)


### PR DESCRIPTION
@ehthiede I changed to the "ortho" convention, but started to have some second thoughts.

A big reason is that I am not so sure that fourier amplitudes are independent of sample size in the "ortho" convention. I think this is true of variances / power spectra, but not the amplitudes themselves (the "forward" normalization convention I think does this).

Among other reasons, another is that I think the code is turning out to be simpler. Take a look and let me know what you think.