### PR TITLE
Refactor transforms interface

### DIFF
--- a/src/cryojax/inference/__init__.py
+++ b/src/cryojax/inference/__init__.py
@@ -16,11 +16,9 @@ from ._transforms import (
     AbstractLieGroupTransform as AbstractLieGroupTransform,
     AbstractPyTreeTransform as AbstractPyTreeTransform,
     apply_updates_with_lie_transform as apply_updates_with_lie_transform,
-    ComposedTransform as ComposedTransform,
     CustomTransform as CustomTransform,
-    LogTransform as LogTransform,
-    RescalingTransform as RescalingTransform,
     resolve_transforms as resolve_transforms,
     SE3Transform as SE3Transform,
     SO3Transform as SO3Transform,
+    StopGradientTransform as StopGradientTransform,
 )

--- a/src/cryojax/inference/_transforms/__init__.py
+++ b/src/cryojax/inference/_transforms/__init__.py
@@ -6,9 +6,7 @@ from .lie_group_transforms import (
 )
 from .transforms import (
     AbstractPyTreeTransform as AbstractPyTreeTransform,
-    ComposedTransform as ComposedTransform,
     CustomTransform as CustomTransform,
-    LogTransform as LogTransform,
-    RescalingTransform as RescalingTransform,
     resolve_transforms as resolve_transforms,
+    StopGradientTransform as StopGradientTransform,
 )

--- a/src/cryojax/inference/_transforms/lie_group_transforms.py
+++ b/src/cryojax/inference/_transforms/lie_group_transforms.py
@@ -8,6 +8,9 @@ transformations, using `equinox`. The `jaxlie.manifold.grad` and
 wrappers for gradient transformations.
 """
 
+from typing import Generic, TypeVar
+from typing_extensions import override
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -20,12 +23,15 @@ from ...simulator import QuaternionPose
 from .transforms import AbstractPyTreeTransform
 
 
+T = TypeVar("T")
+
+
 def _apply_update_with_lie_transform(u, p):
     if u is None:
         return p
     elif isinstance(u, AbstractLieGroupTransform):
         lie_group = type(u.group_element)
-        local_tangent = u.transformed_pytree
+        local_tangent = u.local_tangent
         return eqx.tree_at(
             lambda p: p.group_element,
             p,
@@ -53,13 +59,14 @@ def apply_updates_with_lie_transform(model: PyTree, updates: PyTree) -> PyTree:
     )
 
 
-class AbstractLieGroupTransform(AbstractPyTreeTransform, strict=True):
+class AbstractLieGroupTransform(AbstractPyTreeTransform[T], Generic[T], strict=True):
     """An abstract base class for lie group transforms."""
 
+    local_tangent: AbstractVar[Array]
     group_element: AbstractVar[AbstractMatrixLieGroup]
 
 
-class SO3Transform(AbstractLieGroupTransform, strict=True):
+class SO3Transform(AbstractLieGroupTransform[Float[Array, "4"]], strict=True):
     """This class transforms a quaternion to the local
     tangent space of the corresponding SO3 element.
 
@@ -67,11 +74,11 @@ class SO3Transform(AbstractLieGroupTransform, strict=True):
 
     **Attributes:**
 
-    - `transformed_pytree`: The local tangent vector.
+    - `local_tangent`: The local tangent vector.
     - `group_element`: The element of SO3.
     """
 
-    transformed_pytree: Float[Array, "3"]
+    local_tangent: Float[Array, "3"]
     group_element: SO3
 
     def __init__(self, wxyz: Float[Array, "4"]):
@@ -80,17 +87,19 @@ class SO3Transform(AbstractLieGroupTransform, strict=True):
         - `wxyz`: A quaternion that parameterizes the SO3
                   group element.
         """
-        local_tangent = jnp.zeros(3, dtype=float)
-        self.transformed_pytree = local_tangent
+        self.local_tangent = jnp.zeros(3, dtype=float)
         self.group_element = SO3(wxyz).normalize()
 
-    def get(self) -> Float[Array, "4"]:
+    @property
+    @override
+    def value(self) -> Float[Array, "4"]:
         """An implementation of the `jaxlie.manifold.rplus`."""
-        local_tangent = self.transformed_pytree
-        return (jax.lax.stop_gradient(self.group_element) @ SO3.exp(local_tangent)).wxyz
+        return (
+            jax.lax.stop_gradient(self.group_element) @ SO3.exp(self.local_tangent)
+        ).wxyz
 
 
-class SE3Transform(AbstractLieGroupTransform, strict=True):
+class SE3Transform(AbstractLieGroupTransform[QuaternionPose], strict=True):
     """This class transforms a `QuaternionPose` to the local
     tangent space of the corresponding SE3 element.
 
@@ -98,11 +107,11 @@ class SE3Transform(AbstractLieGroupTransform, strict=True):
 
     **Attributes:**
 
-    - `transformed_pytree`: The local tangent vector.
+    - `local_tangent`: The local tangent vector.
     - `group_element`: The element of SE3.
     """
 
-    transformed_pytree: Float[Array, "6"]
+    local_tangent: Float[Array, "6"]
     group_element: SE3
 
     def __init__(self, quaternion_pose: QuaternionPose):
@@ -111,17 +120,19 @@ class SE3Transform(AbstractLieGroupTransform, strict=True):
         - `quaternion_pose`: A quaternion pose representation that parameterizes
                              the SE3 group element.
         """
-        local_tangent = jnp.zeros(6, dtype=float)
-        self.transformed_pytree = local_tangent
+        self.local_tangent = jnp.zeros(6, dtype=float)
         self.group_element = SE3(
             rotation=quaternion_pose.rotation,
             xyz=quaternion_pose.offset_in_angstroms,
         )
 
-    def get(self) -> Float[Array, "6"]:
+    @property
+    @override
+    def value(self) -> QuaternionPose:
         """An implementation of the `jaxlie.manifold.rplus`."""
-        local_tangent = self.transformed_pytree
-        group_element = jax.lax.stop_gradient(self.group_element) @ SE3.exp(local_tangent)
+        group_element = jax.lax.stop_gradient(self.group_element) @ SE3.exp(
+            self.local_tangent
+        )
         return QuaternionPose.from_rotation_and_translation(
             group_element.rotation, group_element.xyz
         )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,59 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+
+from cryojax.inference import CustomTransform, resolve_transforms, StopGradientTransform
+
+
+class Exp(eqx.Module):
+    a: Array = eqx.field(converter=jnp.asarray)
+
+    def __call__(self, x):
+        return jnp.exp(-self.a * x)
+
+
+def test_resolve_transform():
+    pytree = Exp(a=1.0)
+    pytree_with_transform = eqx.tree_at(
+        lambda fn: fn.a,
+        pytree,
+        replace_fn=lambda a: CustomTransform(jnp.exp, jnp.log(a)),
+    )
+    assert eqx.tree_equal(pytree, resolve_transforms(pytree_with_transform))
+
+
+def test_nested_resolve_transform():
+    pytree = Exp(a=1.0)
+    pytree_with_transform = eqx.tree_at(
+        lambda fn: fn.a,
+        pytree,
+        replace_fn=lambda a: CustomTransform(lambda b: 2 * b, a / 2),
+    )
+    pytree_with_nested_transform = eqx.tree_at(
+        lambda fn: fn.a.args[0],
+        pytree_with_transform,
+        replace_fn=lambda a_scaled: CustomTransform(jnp.exp, jnp.log(a_scaled)),
+    )
+    assert eqx.tree_equal(
+        pytree,
+        resolve_transforms(pytree_with_transform),
+        resolve_transforms(pytree_with_nested_transform),
+    )
+
+
+def test_stop_gradient():
+    @jax.value_and_grad
+    def objective_fn(pytree):
+        exp, x = resolve_transforms(pytree)
+        return exp(x)
+
+    x = jnp.asarray(np.random.random())
+    exp = Exp(a=1.0)
+    exp_with_stop_gradient = eqx.tree_at(
+        lambda fn: fn.a, exp, replace_fn=StopGradientTransform
+    )
+    _, grads = objective_fn((exp_with_stop_gradient, x))
+    grads = resolve_transforms(grads)
+    assert grads[0].a == 0.0


### PR DESCRIPTION
Revamped and simplified the API for the `AbstractPyTreeTransform` in `cryojax.inference`. These classes are included in `cryojax` to make it easier for users to follow `equinox`'s recommendations for attaining custom behavior on a per-leaf basis. This is very similar and takes parts from the package `paramax`: https://github.com/danielward27/paramax