### PR TITLE
fix small bug in batched_map functions

### DIFF
--- a/docs/examples/compute-potential.ipynb
+++ b/docs/examples/compute-potential.ipynb
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
     "real_voxel_grid = atom_potential.as_real_voxel_grid(\n",
     "    shape,\n",
     "    voxel_size,\n",
-    "    z_planes_in_parallel=10,\n",
+    "    batch_size_for_z_planes=10,\n",
     ")"
    ]
   },

--- a/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
+++ b/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
@@ -279,8 +279,7 @@ def _compute_gaussians_for_all_atoms(
     return prefactor * gauss_x, gauss_y
 
 
-@eqx.filter_jit
-def _batched_map_with_contraction(fun, xs, batch_size):
+def _batched_map_with_contraction(fun, xs, n_batches):
     # ... reshape into an iterative dimension and a batching dimension
     batch_dim = jax.tree.leaves(xs)[0].shape[0]
     batch_size = batch_dim // n_batches

--- a/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
+++ b/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
@@ -24,7 +24,7 @@ class GaussianMixtureProjection(
 ):
     upsampling_factor: Optional[int]
     use_error_functions: bool
-    atom_groups_in_series: int
+    n_batches_of_atoms: int
 
     is_projection_approximation: ClassVar[bool] = True
 
@@ -33,7 +33,7 @@ class GaussianMixtureProjection(
         *,
         upsampling_factor: Optional[int] = None,
         use_error_functions: bool = False,
-        atom_groups_in_series: int = 1,
+        n_batches: int = 1,
     ):
         """**Arguments:**
 
@@ -47,15 +47,15 @@ class GaussianMixtureProjection(
             a pixel to be the average value within the pixel using gaussian
             integrals. If `False`, the potential at a pixel will simply be evaluated
             as a gaussian.
-        - `atom_groups_in_series`:
-            The number of iterations over groups of atoms
+        - `n_batches`:
+            The number of batches over groups of atoms
             used to evaluate the projection.
             This is useful if GPU memory is exhausted. By default,
             `1`, which computes a projection for all atoms at once.
         """  # noqa: E501
         self.upsampling_factor = upsampling_factor
         self.use_error_functions = use_error_functions
-        self.atom_groups_in_series = atom_groups_in_series
+        self.n_batches = n_batches
 
     def __check_init__(self):
         if self.upsampling_factor is not None and self.upsampling_factor < 1:
@@ -111,7 +111,7 @@ class GaussianMixtureProjection(
             gaussian_amplitudes,
             gaussian_widths,
             self.use_error_functions,
-            self.atom_groups_in_series,
+            self.n_batches,
         )
         if self.upsampling_factor is not None:
             # Downsample back to the original pixel size, rescaling so that the
@@ -136,7 +136,7 @@ def _compute_projected_potential_from_atoms(
     a: Float[Array, "n_atoms n_gaussians_per_atom"],
     b: Float[Array, "n_atoms n_gaussians_per_atom"],
     use_error_functions: bool,
-    atom_groups_in_series: int,
+    n_batches: int,
 ) -> Float[Array, "dim_y dim_x"]:
     # Make the grid on which to evaluate the result
     grid_x = make_1d_coordinate_grid(shape[1], pixel_size)
@@ -155,25 +155,25 @@ def _compute_projected_potential_from_atoms(
         )
     )
     # Compute projection with a call to `jax.lax.map` in batches
-    if atom_groups_in_series > atom_positions.shape[0]:
+    if n_batches > atom_positions.shape[0]:
         raise ValueError(
-            "The `atom_groups_in_series` when computing a projection must "
+            "The `n_batches` when computing a projection must "
             "be an integer less than or equal to the number of atoms, "
             f"which is equal to {atom_positions.shape[0]}. Got "
-            f"`atom_groups_in_series = {atom_groups_in_series}`."
+            f"`n_batches = {n_batches}`."
         )
-    elif atom_groups_in_series == 1:
+    elif n_batches == 1:
         projection = compute_potential_for_atom_group(xs)
-    elif atom_groups_in_series > 1:
+    elif n_batches > 1:
         projection = jnp.sum(
             _batched_map_with_contraction(
-                compute_potential_for_atom_group, xs, atom_groups_in_series
+                compute_potential_for_atom_group, xs, n_batches
             ),
             axis=0,
         )
     else:
         raise ValueError(
-            "The `atom_groups_in_series` when building a voxel grid must be an "
+            "The `n_batches` when building a voxel grid must be an "
             "integer greater than or equal to 1."
         )
     return projection

--- a/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
+++ b/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
@@ -24,7 +24,7 @@ class GaussianMixtureProjection(
 ):
     upsampling_factor: Optional[int]
     use_error_functions: bool
-    n_batches_of_atoms: int
+    n_batches: int
 
     is_projection_approximation: ClassVar[bool] = True
 

--- a/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
+++ b/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py
@@ -165,10 +165,9 @@ def _compute_projected_potential_from_atoms(
     elif atom_groups_in_series == 1:
         projection = compute_potential_for_atom_group(xs)
     elif atom_groups_in_series > 1:
-        batch_size = atom_positions.shape[0] // atom_groups_in_series
         projection = jnp.sum(
             _batched_map_with_contraction(
-                compute_potential_for_atom_group, xs, batch_size
+                compute_potential_for_atom_group, xs, atom_groups_in_series
             ),
             axis=0,
         )
@@ -286,10 +285,10 @@ def _compute_gaussians_for_all_atoms(
 
 
 @eqx.filter_jit
-def _batched_map_with_contraction(fun, xs, batch_size):
+def _batched_map_with_contraction(fun, xs, n_batches):
     # ... reshape into an iterative dimension and a batching dimension
     batch_dim = jax.tree.leaves(xs)[0].shape[0]
-    n_batches = batch_dim // batch_size
+    batch_size = batch_dim // n_batches
     xs_per_batch = jax.tree.map(
         lambda x: x[: batch_dim - batch_dim % batch_size, ...].reshape(
             (n_batches, batch_size, *x.shape[1:])

--- a/src/cryojax/simulator/_potential_representation/atom_potential.py
+++ b/src/cryojax/simulator/_potential_representation/atom_potential.py
@@ -156,8 +156,8 @@ class GaussianMixtureAtomicPotential(AbstractAtomicPotential, strict=True):
         shape: tuple[int, int, int],
         voxel_size: Float[Array, ""] | float,
         *,
-        z_planes_in_parallel: int = 1,
-        atom_groups_in_series: int = 1,
+        batch_size_for_z_planes: int = 1,
+        n_batches_of_atoms: int = 1,
     ) -> Float[Array, "{shape[0]} {shape[1]} {shape[2]}"]:
         """Return a voxel grid of the potential in real space.
 
@@ -168,13 +168,13 @@ class GaussianMixtureAtomicPotential(AbstractAtomicPotential, strict=True):
 
         - `shape`: The shape of the resulting voxel grid.
         - `voxel_size`: The voxel size of the resulting voxel grid.
-        - `z_planes_in_parallel`:
+        - `batch_size_for_z_planes`:
             The number of z-planes to evaluate in parallel with
             `jax.vmap`. By default, `1`.
-        - `atom_groups_in_series`:
+        - `n_batches_of_atoms`:
             The number of iterations used to evaluate the volume,
             where the iteration is taken over groups of atoms.
-            This is useful if `z_planes_in_parallel = 1`
+            This is useful if `batch_size_for_z_planes = 1`
             and GPU memory is exhausted. By default, `1`.
 
         **Returns:**
@@ -188,8 +188,8 @@ class GaussianMixtureAtomicPotential(AbstractAtomicPotential, strict=True):
             self.atom_positions,
             self.gaussian_amplitudes,
             self.gaussian_widths,
-            z_planes_in_parallel=z_planes_in_parallel,
-            atom_groups_in_series=atom_groups_in_series,
+            batch_size_for_z_planes=batch_size_for_z_planes,
+            n_batches_of_atoms=n_batches_of_atoms,
         )
 
 
@@ -290,8 +290,8 @@ class PengAtomicPotential(AbstractTabulatedAtomicPotential, strict=True):
         shape: tuple[int, int, int],
         voxel_size: Float[Array, ""] | float,
         *,
-        z_planes_in_parallel: int = 1,
-        atom_groups_in_series: int = 1,
+        batch_size_for_z_planes: int = 1,
+        n_batches_of_atoms: int = 1,
     ) -> Float[Array, "{shape[0]} {shape[1]} {shape[2]}"]:
         """Return a voxel grid of the potential in real space.
 
@@ -333,13 +333,13 @@ class PengAtomicPotential(AbstractTabulatedAtomicPotential, strict=True):
 
         - `shape`: The shape of the resulting voxel grid.
         - `voxel_size`: The voxel size of the resulting voxel grid.
-        - `z_planes_in_parallel`:
+        - `batch_size_for_z_planes`:
             The number of z-planes to evaluate in parallel with
             `jax.vmap`. By default, `1`.
-        - `atom_groups_in_series`:
+        - `n_batches_of_atoms`:
             The number of iterations used to evaluate the volume,
             where the iteration is taken over groups of atoms.
-            This is useful if `z_planes_in_parallel = 1`
+            This is useful if `batch_size_for_z_planes = 1`
             and GPU memory is exhausted. By default, `1`.
 
         **Returns:**
@@ -358,8 +358,8 @@ class PengAtomicPotential(AbstractTabulatedAtomicPotential, strict=True):
             self.atom_positions,
             gaussian_amplitudes,
             gaussian_widths,
-            z_planes_in_parallel=z_planes_in_parallel,
-            atom_groups_in_series=atom_groups_in_series,
+            batch_size_for_z_planes=batch_size_for_z_planes,
+            n_batches_of_atoms=n_batches_of_atoms,
         )
 
 
@@ -370,8 +370,8 @@ def _build_real_space_voxel_potential_from_atoms(
     atom_positions: Float[Array, "n_atoms 3"],
     a: Float[Array, "n_atoms n_gaussians_per_atom"],
     b: Float[Array, "n_atoms n_gaussians_per_atom"],
-    z_planes_in_parallel: int,
-    atom_groups_in_series: int,
+    batch_size_for_z_planes: int,
+    n_batches_of_atoms: int,
 ) -> Float[Array, "{shape[0]} {shape[1]} {shape[2]}"]:
     # Make coordinate systems for each of x, y, and z dimensions
     z_dim, y_dim, x_dim = shape
@@ -388,31 +388,31 @@ def _build_real_space_voxel_potential_from_atoms(
             xs[0],
             xs[1],
             xs[2],
-            z_planes_in_parallel,
+            batch_size_for_z_planes,
         )
     )
-    if atom_groups_in_series > atom_positions.shape[0]:
+    if n_batches_of_atoms > atom_positions.shape[0]:
         raise ValueError(
-            "The `atom_groups_in_series` when building a voxel grid must "
+            "The `n_batches_of_atoms` when building a voxel grid must "
             "be an integer less than or equal to the number of atoms, "
             f"which is equal to {atom_positions.shape[0]}. Got "
-            f"`atom_groups_in_series = {atom_groups_in_series}`."
+            f"`n_batches_of_atoms = {n_batches_of_atoms}`."
         )
-    elif atom_groups_in_series == 1:
+    elif n_batches_of_atoms == 1:
         potential_as_voxel_grid = compute_potential_for_atom_group((atom_positions, a, b))
-    elif atom_groups_in_series > 1:
+    elif n_batches_of_atoms > 1:
         potential_as_voxel_grid = jnp.sum(
-            _batched_map(
+            _batched_map_with_n_batches(
                 compute_potential_for_atom_group,
                 (atom_positions, a, b),
-                n_batches=atom_groups_in_series,
+                n_batches=n_batches_of_atoms,
                 is_batch_axis_contracted=True,
             ),
             axis=0,
         )
     else:
         raise ValueError(
-            "The `atom_groups_in_series` when building a voxel grid must be an "
+            "The `n_batches_of_atoms` when building a voxel grid must be an "
             "integer greater than or equal to 1."
         )
 
@@ -428,7 +428,7 @@ def _build_real_space_voxel_potential_from_atom_group(
     atom_positions: Float[Array, "n_atoms_in_batch 3"],
     a: Float[Array, "n_atoms_in_batch n_gaussians_per_atom"],
     b: Float[Array, "n_atoms_in_batch n_gaussians_per_atom"],
-    z_planes_in_parallel: int,
+    batch_size_for_z_planes: int,
 ) -> Float[Array, "dim_z dim_y dim_x"]:
     # Evaluate 1D gaussian integrals for each of x, y, and z dimensions
     (
@@ -447,29 +447,29 @@ def _build_real_space_voxel_potential_from_atom_group(
         )
     )
     # Map over z-planes
-    if z_planes_in_parallel > grid_z.size:
+    if batch_size_for_z_planes > grid_z.size:
         raise ValueError(
-            "The `z_planes_in_parallel` when building a voxel grid must be an "
+            "The `batch_size_for_z_planes` when building a voxel grid must be an "
             "integer less than or equal to the z-dimension of the grid, "
             f"which is equal to {grid_z.size}."
         )
-    elif z_planes_in_parallel == 1:
+    elif batch_size_for_z_planes == 1:
         # ... compute the volume iteratively
         potential_as_voxel_grid = jax.lax.map(
             compute_potential_at_z_plane, gaussian_integrals_per_interval_per_atom_z
         )
-    elif z_planes_in_parallel > 1:
+    elif batch_size_for_z_planes > 1:
         # ... compute the volume by tuning how many z-planes to batch over
         compute_potential_at_z_planes = jax.vmap(compute_potential_at_z_plane, in_axes=0)
-        potential_as_voxel_grid = _batched_map(
+        potential_as_voxel_grid = _batched_map_with_batch_size(
             compute_potential_at_z_planes,
             gaussian_integrals_per_interval_per_atom_z,
-            batch_size=z_planes_in_parallel,
+            batch_size=batch_size_for_z_planes,
             is_batch_axis_contracted=False,
         )
     else:
         raise ValueError(
-            "The `z_planes_in_parallel` when building a voxel grid must be an "
+            "The `batch_size_for_z_planes` when building a voxel grid must be an "
             "integer greater than or equal to 1."
         )
 
@@ -546,33 +546,17 @@ def _evaluate_gaussian_potential_at_z_plane(
 
 
 @eqx.filter_jit
-def _batched_map(
+def _batched_map_with_n_batches(
     fun: Callable,
     xs: PyTree[Array],
-    batch_size: Optional[int] = None,
-    n_batches: Optional[int] = None,
+    n_batches: int,
     is_batch_axis_contracted: bool = False,
 ):
-    """Like `jax.lax.map`, but map over leading axis of `xs` in
-    chunks of size `batch_size`. Assumes `fun` can be evaluated in
-    parallel over this leading axis.
-    """
-
-    if batch_size is None and n_batches is None:
-        raise ValueError("One of `batch_size` or `n_batches` must be provided.")
-
-    elif batch_size is not None and n_batches is not None:
-        raise ValueError("Only one of `batch_size` or `n_batches` can be provided.")
-
-    elif batch_size is not None:
-        result = _batched_map_with_batch_size(
-            fun, xs, batch_size, is_batch_axis_contracted
-        )
-
-    elif n_batches is not None:
-        result = _batched_map_with_n_batches(fun, xs, n_batches, is_batch_axis_contracted)
-
-    return result
+    batch_dim = jtu.tree_leaves(xs)[0].shape[0]
+    batch_size = batch_dim // n_batches
+    return _batched_map(
+        fun, xs, batch_dim, n_batches, batch_size, is_batch_axis_contracted
+    )
 
 
 @eqx.filter_jit
@@ -582,57 +566,27 @@ def _batched_map_with_batch_size(
     batch_size: int,
     is_batch_axis_contracted: bool = False,
 ):
-    """Like `jax.lax.map`, but map over leading axis of `xs` in
-    chunks of size `batch_size`. Assumes `fun` can be evaluated in
-    parallel over this leading axis.
-    """
     batch_dim = jtu.tree_leaves(xs)[0].shape[0]
     n_batches = batch_dim // batch_size
-
-    # ... reshape into an iterative dimension and a batching dimension
-
-    xs_per_batch = jtu.tree_map(
-        lambda x: x[: batch_dim - batch_dim % batch_size, ...].reshape(
-            (n_batches, batch_size, *x.shape[1:])
-        ),
-        xs,
+    return _batched_map(
+        fun, xs, batch_dim, n_batches, batch_size, is_batch_axis_contracted
     )
-    # .. compute the result and reshape back into one leading dimension
-    result_per_batch = jax.lax.map(fun, xs_per_batch)
-    if is_batch_axis_contracted:
-        result = result_per_batch
-    else:
-        result = result_per_batch.reshape(
-            (n_batches * batch_size, *result_per_batch.shape[2:])
-        )
-    # ... if the batch dimension is not divisible by the batch size, need
-    # to take care of the remainder
-    if batch_dim % batch_size != 0:
-        remainder = fun(
-            jtu.tree_map(lambda x: x[batch_dim - batch_dim % batch_size :, ...], xs)
-        )
-        if is_batch_axis_contracted:
-            remainder = remainder[None, ...]
-        result = jnp.concatenate([result, remainder], axis=0)
-    return result
 
 
 @eqx.filter_jit
-def _batched_map_with_n_batches(
+def _batched_map(
     fun: Callable,
     xs: PyTree[Array],
+    batch_dim: int,
     n_batches: int,
+    batch_size: int,
     is_batch_axis_contracted: bool = False,
 ):
     """Like `jax.lax.map`, but map over leading axis of `xs` in
     chunks of size `batch_size`. Assumes `fun` can be evaluated in
     parallel over this leading axis.
     """
-    batch_dim = jtu.tree_leaves(xs)[0].shape[0]
-    batch_size = batch_dim // n_batches
-
     # ... reshape into an iterative dimension and a batching dimension
-
     xs_per_batch = jtu.tree_map(
         lambda x: x[: batch_dim - batch_dim % batch_size, ...].reshape(
             (n_batches, batch_size, *x.shape[1:])

--- a/tests/test_voxels_from_atoms.py
+++ b/tests/test_voxels_from_atoms.py
@@ -87,11 +87,11 @@ def test_downsampled_voxel_potential_agreement(sample_pdb_path):
 
 
 @pytest.mark.parametrize(
-    "z_planes_in_parallel,atom_groups_in_series",
+    "batch_size_for_z_planes,n_batches_of_atoms",
     ((1, 1), (2, 1), (3, 1), (1, 2), (1, 3), (2, 2)),
 )
 def test_z_plane_batched_vs_non_batched_loop_agreement(
-    sample_pdb_path, z_planes_in_parallel, atom_groups_in_series
+    sample_pdb_path, batch_size_for_z_planes, n_batches_of_atoms
 ):
     shape = (128, 128, 128)
     voxel_size = 0.5
@@ -105,8 +105,8 @@ def test_z_plane_batched_vs_non_batched_loop_agreement(
     voxels_with_batching = atomic_potential.as_real_voxel_grid(
         shape,
         voxel_size,
-        z_planes_in_parallel=z_planes_in_parallel,
-        atom_groups_in_series=atom_groups_in_series,
+        batch_size_for_z_planes=batch_size_for_z_planes,
+        n_batches_of_atoms=n_batches_of_atoms,
     )
     np.testing.assert_allclose(voxels, voxels_with_batching)
 


### PR DESCRIPTION
Found that the way the batched map was implemented when going from [atoms to voxels](https://github.com/mjo22/cryojax/blob/124f957e1264f6935a7b085d2665f9c5aab4f6d1/src/cryojax/simulator/_potential_representation/atom_potential.py#L549) and when integrating an [atomic potential](https://github.com/mjo22/cryojax/blob/124f957e1264f6935a7b085d2665f9c5aab4f6d1/src/cryojax/simulator/_potential_integrator/atom_potential_integrator.py#L288) had a small bug. In some cases the function would not behave as expected, and the number of batches used was different.

For the second case, I simply changed the argument from batch_size to n_batches, as the function was never used with batch_size. For the first case, both instances were used, so I wrote a wrapper for the two cases.