### PR TITLE
removed b factor as default relion stack option

### DIFF
--- a/docs/examples/simulate-relion-dataset.ipynb
+++ b/docs/examples/simulate-relion-dataset.ipynb
@@ -151,7 +151,7 @@
     "    # now generate your non-random values\n",
     "    spherical_aberration_in_mm = 2.7\n",
     "    amplitude_contrast_ratio = 0.1\n",
-    "    b_factor = 170.0\n",
+    "    b_factor = 0.0\n",
     "    ctf_scale_factor = 1.0\n",
     "\n",
     "    # ... build the CTF\n",


### PR DESCRIPTION
keeping a default bfactor in the default example is probably going to confuse people.