### PR TITLE
One particle in stack

### DIFF
--- a/src/cryojax/data/_relion/_starfile_reading.py
+++ b/src/cryojax/data/_relion/_starfile_reading.py
@@ -636,7 +636,11 @@ def _get_image_stack_from_mrc(
         particle_index = np.asarray(relion_particle_index, dtype=int) - 1
 
         with mrcfile.mmap(path_to_image_stack, mode="r", permissive=True) as mrc:
-            image_stack = np.asarray(mrc.data[particle_index])  # type: ignore
+            #check if the mrcfile only contains one image.
+            if len(np.shape(mrc.data)) == 2:
+                image_stack = np.asarray(mrc.data)
+            else:
+                image_stack = np.asarray(mrc.data[particle_index])  # type: ignore
 
     elif isinstance(image_stack_index_and_name_series_or_str, pd.Series):
         # In this block, the user most likely used fancy indexing, like
@@ -682,7 +686,10 @@ def _get_image_stack_from_mrc(
                 mode="r",
                 permissive=True,
             ) as mrc:
-                image_stack[filtered_df.index] = np.asarray(mrc.data[particle_index])
+                if len(np.shape(mrc.data)) == 2:
+                    image_stack[filtered_df.index] = np.asarray(mrc.data)
+                else:
+                    image_stack[filtered_df.index] = np.asarray(mrc.data[particle_index])
 
     else:
         raise IOError(

--- a/src/cryojax/data/_relion/_starfile_reading.py
+++ b/src/cryojax/data/_relion/_starfile_reading.py
@@ -638,7 +638,7 @@ def _get_image_stack_from_mrc(
         with mrcfile.mmap(path_to_image_stack, mode="r", permissive=True) as mrc:
             mrc_data = np.asarray(mrc.data)
             if mrc_data.ndim == 2:
-                image_stack = mrc_data[None, ...]
+                image_stack = mrc_data
             else:
                 image_stack = mrc_data[particle_index]
 

--- a/src/cryojax/data/_relion/_starfile_writing.py
+++ b/src/cryojax/data/_relion/_starfile_writing.py
@@ -31,7 +31,7 @@ def write_starfile_with_particle_parameters(
     mrc_batch_size: Optional[int] = None,
     overwrite: bool = False,
 ) -> None:
-    """Generate a STAR file from a RelionParticleStack object.
+    """Generate a STAR file from a RelionParticleParameters object.
 
     This function does not generate particles, it merely populates the starfile.
 
@@ -45,7 +45,7 @@ def write_starfile_with_particle_parameters(
         The filename of the STAR file to write.
     - `mrc_batch_size`:
         The number of images to write to each MRC file. If `None`, the number of
-        images in the `RelionParticleStack` is used.
+        images in the `RelionParticleParameters` is used.
     - `overwrite`:
         Whether to overwrite the STAR file if it already exists.
     """
@@ -59,8 +59,11 @@ def write_starfile_with_particle_parameters(
             f"Overwrite was set to False, but STAR file {filename} already exists."
         )
 
-    n_images = particle_parameters.pose.offset_x_in_angstroms.shape[0]
-
+    if particle_parameters.pose.offset_x_in_angstroms.shape == ():
+        n_images = 1
+    else:
+        n_images = particle_parameters.pose.offset_x_in_angstroms.shape[0]
+    
     if mrc_batch_size is None:
         mrc_batch_size = n_images
 

--- a/src/cryojax/data/_relion/_starfile_writing.py
+++ b/src/cryojax/data/_relion/_starfile_writing.py
@@ -31,11 +31,10 @@ def write_starfile_with_particle_parameters(
     mrc_batch_size: Optional[int] = None,
     overwrite: bool = False,
 ) -> None:
-    """Generate a STAR file from a RelionParticleParameters object.
+    """Generate a STAR file from a `RelionParticleParameters` object.
 
-    This function does not generate particles, it merely populates the starfile.
-
-    The starfile is written to disc at the location specified by filename.
+    This function does not generate particles, it merely populates a starfile
+    and writes it to disc at the location specified by filename.
 
     **Arguments:**
 
@@ -63,7 +62,7 @@ def write_starfile_with_particle_parameters(
         n_images = 1
     else:
         n_images = particle_parameters.pose.offset_x_in_angstroms.shape[0]
-    
+
     if mrc_batch_size is None:
         mrc_batch_size = n_images
 
@@ -119,19 +118,20 @@ def write_starfile_with_particle_parameters(
         particles_df["rlnCtfScalefactor"] = (
             particle_parameters.transfer_theory.envelope.amplitude
         )
-
     elif isinstance(particle_parameters.transfer_theory.envelope, Constant):
         particles_df["rlnCtfBfactor"] = 0.0
         particles_df["rlnCtfScalefactor"] = (
             particle_parameters.transfer_theory.envelope.value
         )
-
     elif particle_parameters.transfer_theory.envelope is None:
         particles_df["rlnCtfBfactor"] = 0.0
-
+        particles_df["rlnCtfScalefactor"] = 0.0
     else:
         raise NotImplementedError(
-            "Only FourierGaussian and Constant envelopes are supported"
+            "The envelope function in `RelionParticleParameters` must either be "
+            "`cryojax.image.operators.FourierGaussian` or "
+            "`cryojax.image.operators.Constant`. Got "
+            f"{type(particle_parameters.transfer_theory.envelope).__name__}."
         )
 
     particles_df["rlnPhaseShift"] = particle_parameters.transfer_theory.ctf.phase_shift

--- a/src/cryojax/data/_relion/_starfile_writing.py
+++ b/src/cryojax/data/_relion/_starfile_writing.py
@@ -126,6 +126,9 @@ def write_starfile_with_particle_parameters(
             particle_parameters.transfer_theory.envelope.value
         )
 
+    elif particle_parameters.transfer_theory.envelope is None:
+        particles_df["rlnCtfBfactor"] = 0.0
+
     else:
         raise NotImplementedError(
             "Only FourierGaussian and Constant envelopes are supported"


### PR DESCRIPTION
I noticed that when one tries to write a particle stack with just one image, there is a bug in the writer function. A simple if statement avoids an indexation error. 