### PR TITLE
set jittable default to false for writing image starfile

### DIFF
--- a/src/cryojax/data/_relion/_starfile_writing.py
+++ b/src/cryojax/data/_relion/_starfile_writing.py
@@ -168,7 +168,7 @@ def write_simulated_image_stack_from_starfile(
         ]
     ),
     args: Any,
-    is_jittable: bool = True,
+    is_jittable: bool = False,
     batch_size_per_mrc: Optional[int] = None,
     seed: Optional[int] = None,  # seed for the noise
     overwrite: bool = False,


### PR DESCRIPTION
Seems to me like makign the default as false for image writing is safer, prevents opaque errors for new users. 