### PR TITLE
Fsc frc

### DIFF
--- a/src/cryojax/coordinates/__init__.py
+++ b/src/cryojax/coordinates/__init__.py
@@ -4,5 +4,6 @@ from ._make_coordinate_grids import (
     make_1d_frequency_grid as make_1d_frequency_grid,
     make_coordinate_grid as make_coordinate_grid,
     make_frequency_grid as make_frequency_grid,
+    make_radial_frequency_grid as make_radial_frequency_grid,
     make_frequency_slice as make_frequency_slice,
 )

--- a/src/cryojax/coordinates/_make_coordinate_grids.py
+++ b/src/cryojax/coordinates/_make_coordinate_grids.py
@@ -74,6 +74,7 @@ def make_radial_frequency_grid(
     
     return radial_frequency_grid
 
+@eqx.filter_jit
 def make_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
@@ -227,6 +228,7 @@ def make_1d_frequency_grid(
     return frequency_array
 
 
+@eqx.filter_jit
 def _make_coordinates_or_frequencies(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,

--- a/src/cryojax/coordinates/_make_coordinate_grids.py
+++ b/src/cryojax/coordinates/_make_coordinate_grids.py
@@ -5,6 +5,7 @@ Functions for creating coordinate systems.
 from typing import Optional
 
 import jax.numpy as jnp
+import equinox as eqx
 import numpy as np
 from jaxtyping import Array, Float
 
@@ -33,6 +34,7 @@ def make_coordinate_grid(
     )
     return coordinate_grid
 
+@eqx.filter_jit
 def make_radial_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,

--- a/src/cryojax/coordinates/_make_coordinate_grids.py
+++ b/src/cryojax/coordinates/_make_coordinate_grids.py
@@ -69,8 +69,7 @@ def make_radial_frequency_grid(
                                         get_rfftfreqs=get_rfftfreqs)
     
     # now make it radially symmetric with the origin in the center. 
-    radial_frequency_grid = jnp.fft.ifftshift(
-                    jnp.linalg.norm(frequency_grid, axis=-1))
+    radial_frequency_grid = jnp.linalg.norm(frequency_grid, axis=-1)
     
     return radial_frequency_grid
 

--- a/src/cryojax/coordinates/_make_coordinate_grids.py
+++ b/src/cryojax/coordinates/_make_coordinate_grids.py
@@ -33,6 +33,44 @@ def make_coordinate_grid(
     )
     return coordinate_grid
 
+def make_radial_frequency_grid(
+    shape: tuple[int, ...],
+    grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
+    get_rfftfreqs: bool = False,
+) -> Float[Array, "*shape ndim"]:
+    """Create a fourier-space cartesian coordinate system on a grid.
+    The zero-frequency component is in the center.
+
+    This will help us do things like calculate fourier shell
+    correlations and power spectrums.
+
+    **Arguments:**
+
+    - `shape`:
+        Shape of the grid, with `ndim = len(shape)`.
+    - `grid_spacing`:
+        The grid spacing (i.e. pixel/voxel size),
+        in units of length.
+    - `get_rfftfreqs`:
+        Return a frequency grid for use with `jax.numpy.fft.rfftn`.
+        `shape[-1]` is the axis on which the negative
+        frequencies are omitted.
+
+    **Returns:**
+
+    A cartesian coordinate system in frequency space.
+    """
+    
+    # make a cartesian grid
+    frequency_grid = make_frequency_grid(shape = shape, 
+                                        grid_spacing=grid_spacing, 
+                                        get_rfftfreqs=get_rfftfreqs)
+    
+    # now make it radially symmetric with the origin in the center. 
+    radial_frequency_grid = jnp.fft.ifftshift(
+                    jnp.linalg.norm(frequency_grid, axis=-1))
+    
+    return radial_frequency_grid
 
 def make_frequency_grid(
     shape: tuple[int, ...],

--- a/src/cryojax/image/__init__.py
+++ b/src/cryojax/image/__init__.py
@@ -36,3 +36,7 @@ from ._spectrum import (
 from ._fourier_correlation import (
     compute_radial_fourier_correlation  as compute_radial_fourier_correlation ,
 )
+
+from ._fourier_correlation import (
+    compute_radial_fourier_correlation  as compute_radial_fourier_correlation ,
+)

--- a/src/cryojax/image/__init__.py
+++ b/src/cryojax/image/__init__.py
@@ -32,3 +32,7 @@ from ._rescale_pixel_size import (
 from ._spectrum import (
     compute_radially_averaged_powerspectrum as compute_radially_averaged_powerspectrum,
 )
+
+from ._fourier_correlation import (
+    compute_radial_fourier_correlation  as compute_radial_fourier_correlation ,
+)

--- a/src/cryojax/image/_fourier_correlation.py
+++ b/src/cryojax/image/_fourier_correlation.py
@@ -62,9 +62,9 @@ def compute_radial_fourier_correlation(
 
     # Compute bins
     start = 0
-    stop = sqrt2 / (2.0 * pixel_size)
+    stop = 1 / (2.0 * pixel_size)
     
-    frequency_bins = jnp.linspace(0, stop, 1 + int(sqrt2 * image_1.shape[0]/2) + 1)
+    frequency_bins = jnp.linspace(0, stop, 1 + int(image_1.shape[0]/2) + 1)
 
     # Compute radially averaged FSC as a 1D profile
     correlation_curve = jnp.real(compute_binned_radial_average(
@@ -73,6 +73,7 @@ def compute_radial_fourier_correlation(
     normalisation_curve = jnp.real(compute_binned_radial_average(
         normalisation_voxel_map, radial_frequency_grid, frequency_bins
     ))
+
     FSC_curve = correlation_curve /normalisation_curve
 
     #remove nans and infs.
@@ -102,4 +103,4 @@ def compute_radial_fourier_correlation(
     threshold_crossing_index = eqx.error_if(threshold_crossing_index, threshold_crossing_index == dummy_index, "Error message...")
     frequency_threshold = frequency_bins[threshold_crossing_index]
 
-    return frequency_bins, frequency_threshold, correlation_curve
+    return frequency_bins, frequency_threshold, FSC_curve

--- a/src/cryojax/image/_fourier_correlation.py
+++ b/src/cryojax/image/_fourier_correlation.py
@@ -1,0 +1,94 @@
+"""
+Helper routines to compute power spectra.
+"""
+
+from typing import Optional
+
+import jax.numpy as jnp
+from jaxtyping import Array, Complex, Float
+
+from ._average import compute_binned_radial_average
+
+def shell_correlation(
+    shell1: Complex[Array, "y_dim x_dim"],
+    shell2: Complex[Array, "y_dim x_dim"]
+    ) -> Float:
+
+
+def compute_radial_fourier_correlation(
+    image_1: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"],
+    image_2: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"],
+    radial_frequency_grid: (
+        Float[Array, "y_dim x_dim"] | Float[Array, "z_dim y_dim x_dim"]
+    ),
+    pixel_size: Float[Array, ""] | float = 1.0,
+    threshold: Float[Array, ""] | float = 0.5, #default is 0.5 for two 'known' volumes, change for refinement to 0.143
+                                               #todo: add van heel criterion.
+    *,
+    minimum_frequency: Optional[Float[Array, ""] | float] = None,
+    maximum_frequency: Optional[Float[Array, ""] | float] = None,
+) -> tuple[Float[Array, " n_bins"], Float]:
+    """compute the fourier ring correlation or fourier shell correlation for two images or two maps.
+
+    **Arguments:**
+
+    `image_1`:
+        An image in real or fourier space.
+    `image_2`:
+        An image in real or fourier space.
+    `radial_frequency_grid`:
+        The radial frequency coordinate system of `images 1 and 2. These must match.`.
+    `pixel_size`:
+        The pixel size of `the images`.
+    `minimum_frequency`:
+        Minimum frequency bin. By default, `0.0`.
+    `minimum_frequency`:
+        Maximum frequency bin. By default, `1 / (2 * pixel_size)` nyquist frequency.
+
+    **Returns:**
+
+    A tuple where the first element is the coefficients of the FSC/FRC as a function of 
+    frequency and the second element is the last value after which the corrleation
+    drops below the threshold value. 
+    """
+    if image_1.shape != image_2.shape:
+        raise ValueError('Calculating fourier correlations for two images or volumes is only supported when they have the same shape.')
+
+    if type(image_1) == Complex:
+        fourier_image_1 = image_1
+    else:
+        fourier_image_1 = jnp.fft.fftshift(jnp.fft.fftn(image_1))
+    if type(image_2) == Complex:
+        fourier_image_2 = image_2
+    else:
+        fourier_image_2 = jnp.fft.fftshift(jnp.fft.fftn(image_2))
+
+
+    correlation_voxel_map = (fourier_image_1 * jnp.conjugate(fourier_image_2))
+    correlation_voxel_map = correlation_voxel_map 
+
+    abs1 = jnp.abs(fourier_image_1)
+    abs2 = jnp.abs(fourier_image_2)
+
+    #if radial_frequency_grid is None:
+    #    radial_frequency_grid = jnp.fftshift(jnp.fftfreq(map_1))
+
+    # Compute bins
+    q_min = 0.0 if minimum_frequency is None else minimum_frequency
+    q_max = (
+        jnp.sqrt(2) / (pixel_size * 2.0)
+        if maximum_frequency is None
+        else maximum_frequency
+    )
+    q_step = 1.0 / (pixel_size * max(*normalisation.shape))
+    frequency_bins = jnp.linspace(q_min, q_max, 1 + int((q_max - q_min) / q_step))
+
+     
+
+    # Compute radially averaged FSC as a 1D profile
+        
+    #FSC_curve = compute_binned_radial_average(
+    #    correlation_voxel_map , radial_frequency_grid, frequency_bins
+    #)
+    frequency_threshold = [FSC_curve < threshold][0]
+    return FSC_curve, frequency_bins, frequency_threshold

--- a/src/cryojax/image/_fourier_correlation.py
+++ b/src/cryojax/image/_fourier_correlation.py
@@ -55,6 +55,8 @@ def compute_radial_fourier_correlation(
 
     radial_frequency_grid = cc.make_radial_frequency_grid(image_1.shape, grid_spacing=pixel_size, get_rfftfreqs=False)
 
+    # hard code constant to avoid problems in linspace shape size.
+    # jnp.sqrt(2) will get traced sadly.
     sqrt2 = 1.4142135623730951
 
     # Compute bins

--- a/src/cryojax/image/_fourier_correlation.py
+++ b/src/cryojax/image/_fourier_correlation.py
@@ -2,7 +2,7 @@
 Helper routines to compute power spectra.
 """
 
-from typing import Optional
+from typing import Union, Optional
 
 import jax.numpy as jnp
 from jaxtyping import Array, Complex, Float
@@ -10,23 +10,39 @@ from jaxtyping import Array, Complex, Float
 from ._average import compute_binned_radial_average
 import cryojax.coordinates as cc
 
-def shell_correlation(
-    shell1: Complex[Array, "y_dim x_dim"],
-    shell2: Complex[Array, "y_dim x_dim"]
-    ) -> Float:
-    pass
+def _handle_fourier_transform (
+    image_1: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"] | Float[Array, "y_dim x_dim z_dim"] | Complex[Array, "y_dim x_dim z_dim"],
+    image_2: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"] | Float[Array, "y_dim x_dim z_dim"] | Complex[Array, "y_dim x_dim z_dim"],
+    ):
+    
+    if jnp.iscomplexobj(image_1):
+        fourier_image_1 = image_1
+    else:
+        fourier_image_1 = jnp.fft.fftshift(jnp.fft.fftn(image_1))
+    if jnp.iscomplexobj(image_2):
+        fourier_image_2 = image_2
+    else:
+        fourier_image_2 = jnp.fft.fftshift(jnp.fft.fftn(image_2))
+    return fourier_image_1, fourier_image_2
 
 def compute_radial_fourier_correlation(
-    image_1: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"],
-    image_2: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"],
+    # TODO make jit compatible.
+    image_1: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"] | Float[Array, "y_dim x_dim z_dim"] | Complex[Array, "y_dim x_dim z_dim"],
+    image_2: Float[Array, "y_dim x_dim"] | Complex[Array, "y_dim x_dim"] | Float[Array, "y_dim x_dim z_dim"] | Complex[Array, "y_dim x_dim z_dim"],
     pixel_size: Float[Array, ""] | float = 1.0,
-    threshold: Float[Array, ""] | float = 0.5, #default is 0.5 for two 'known' volumes, change for refinement to 0.143
-                                               #todo: add van heel criterion.
-    *,
+    #default threshold is 0.5 for two 'known' volumes according to the half-bit criterion.
+    # However, for half maps derived from ab initio refinemnts. The threshold is 0.143 by convention.
+    # todo: add van heel criterion.
+    threshold: Float | float = 0.5, 
+                                               
     minimum_frequency: Optional[Float[Array, ""] | float] = None,
     maximum_frequency: Optional[Float[Array, ""] | float] = None,
-) -> tuple[Float[Array, " n_bins"], Float]:
-    """compute the fourier ring correlation or fourier shell correlation for two images or two maps.
+    real_space_mask: Optional[Float[Array, "y_dim x_dim z_dim"]] = None,
+    fourier_space_mask: Optional[Float[Array, "y_dim x_dim z_dim"]] = None
+   
+) -> tuple[Float[Array, "n_bins"], Float]:
+
+    """compute the fourier ring correlation or fourier shell correlation for two images or two voxel maps.
 
     **Arguments:**
 
@@ -38,43 +54,62 @@ def compute_radial_fourier_correlation(
         The pixel size of `the images`.
     `minimum_frequency`:
         Minimum frequency bin. By default, `0.0`.
-    `minimum_frequency`:
+    `maximum_frequency`:
         Maximum frequency bin. By default, `1 / (2 * pixel_size)` nyquist frequency.
+    `mask`:
+        mask for input volumes.
 
     **Returns:**
 
-    A tuple where the first element is the coefficients of the FSC/FRC as a function of 
+    A tuple where the first element is the coefficients of the FSC/FRC as a function of
     frequency and the second element is the last value after which the corrleation
-    drops below the threshold value. 
+    drops below the threshold value.
     """
+
+    # check that maps have the same dimension. 
     if image_1.shape != image_2.shape:
         raise ValueError('Calculating fourier correlations for two images or volumes is only supported when they have the same shape.')
 
-    if type(image_1) == Complex:
-        fourier_image_1 = image_1
-    else:
-        fourier_image_1 = jnp.fft.fftshift(jnp.fft.fftn(image_1))
-    if type(image_2) == Complex:
-        fourier_image_2 = image_2
-    else:
-        fourier_image_2 = jnp.fft.fftshift(jnp.fft.fftn(image_2))
+    if real_space_mask is not None:
+        if jnp.any(real_space_mask > 1) or jnp.any(real_space_mask)  < 0:
+            raise ValueError('mask values are outside valid range [0,1].')
+        
+    if fourier_space_mask is not None:
+        if jnp.any(fourier_space_mask) < 0 or jnp.any(fourier_space_mask) > 1:
+            raise ValueError('mask values are outside valid range [0,1].')
 
+    # choose which mask to apply if any.
+    if real_space_mask is None and fourier_space_mask is None:
+        #no mask applied
+        fourier_image_1, fourier_image_2 = _handle_fourier_transform(image_1, image_2)
+    elif real_space_mask is not None and fourier_space_mask is None:
+        # real space mask applied
+        if real_space_mask.shape != image_1.shape:
+            raise ValueError('mask and map must have same dimensions')
+        image_1 = real_space_mask*image_1
+        image_2 = real_space_mask*image_2
+        fourier_image_1, fourier_image_2 = _handle_fourier_transform(image_1, image_2)
+    elif real_space_mask is None and fourier_space_mask is not None:
+        if fourier_space_mask.shape != image_1.shape:
+            raise ValueError('mask and map must have same dimensions')
+        fourier_image_1, fourier_image_2 = _handle_fourier_transform(image_1, image_2)
 
-    grid = cc.make_frequency_grid(jnp.array(image_1.shape), pixel_size,get_rfftfreqs=False)
+        # fourier mask applied
+        fourier_image_1 = fourier_space_mask*fourier_image_1
+        fourier_image_2 = fourier_space_mask*fourier_image_2
+    else:
+        raise ValueError('Specifying both a real space mask and a fourier mask is not supported.')
 
     correlation_voxel_map = (fourier_image_1 * jnp.conjugate(fourier_image_2))
     normalisation_voxel_map = jnp.sqrt(jnp.abs(fourier_image_1)**2 * jnp.abs(fourier_image_2)**2)
 
-
-    frequency_grid = cc.make_frequency_grid(jnp.array(image_1.shape), pixel_size,get_rfftfreqs=False)
+    frequency_grid = cc.make_frequency_grid(jnp.array(image_1.shape), pixel_size, get_rfftfreqs=False)
     radial_frequency_grid = jnp.fft.ifftshift(jnp.linalg.norm(frequency_grid, axis=-1))
-
-
 
     # Compute bins
     q_min = 0.0 if minimum_frequency is None else minimum_frequency
     q_max = (
-        # set maximum at nyquist
+        # set maximum at nyquist, ignore corners by default.
         1 / (pixel_size * 2.0)
         if maximum_frequency is None
         else maximum_frequency
@@ -85,24 +120,22 @@ def compute_radial_fourier_correlation(
 
      
     # Compute radially averaged FSC as a 1D profile
-        
-    correlation_curve = compute_binned_radial_average(
-        correlation_voxel_map , radial_frequency_grid, frequency_bins
-    )
+    FSC_curve = jnp.real(compute_binned_radial_average(
+        correlation_voxel_map/normalisation_voxel_map , radial_frequency_grid, frequency_bins
+    ))
 
-    normalisation_curve = compute_binned_radial_average(
-        normalisation_voxel_map , radial_frequency_grid, frequency_bins
-    )
-
-
-
-    FSC_curve = jnp.real(correlation_curve / normalisation_curve)
-    #remove nans and infinities which could happen if there are 0s.
+    #remove nans and infs.
     FSC_curve = jnp.where(jnp.isnan(FSC_curve) | jnp.isinf(FSC_curve), 0.0, FSC_curve)
 
-    # return the index imeditaely before the threshold was crossed
-    # this appears to match the cryosparc conventions.
-    threshold_crossing_index = jnp.argmax(FSC_curve <= threshold)
-    frequency_threshold = frequency_bins[jnp.maximum(threshold_crossing_index - 1, 0)]       
+    # find threshold where radial correlation average drops below specified threshold.
+    threshold_crossing_index = -1
+    for i in jnp.arange(len(FSC_curve)):
+        if FSC_curve[i] <= threshold:
+            # max between index and 0 so that we handle the case where no good correlation exists, 
+            # we will return the DC component in that case
+            threshold_crossing_index = jnp.max(jnp.array((i, 0)))
+            break
 
+    # return the frequency where the threshold crosses over the threshold 
+    frequency_threshold = frequency_bins[threshold_crossing_index]
     return FSC_curve, frequency_threshold, frequency_bins

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -5,56 +5,55 @@ Helper routines to compute power spectra.
 from typing import Optional
 
 import jax.numpy as jnp
-from jaxtyping import Array, Complex, Float
-
-from ._average import compute_binned_radial_average
+from jaxtyping import Array, Complex, Float, Bool
 
 
+
+import jax.numpy as jnp
+import equinox as eqx
+from jax import Array
+from jaxtyping import Float, Complex
+from typing import Optional
+
+
+import cryojax.coordinates as cc
+from ._average import compute_binned_radial_average  # keep import inside jit-safe scope
+
+# -- This stays outside the JIT trace
+#def _compute_frequency_bins(
+#    shape: tuple[int, ...],
+#    pixel_size: float,
+#    minimum_frequency: Optional[float] = None,
+#    maximum_frequency: Optional[float] = None,
+#) -> Float[Array, "n_bins"]:
+#    q_min = 0.0 if minimum_frequency is None else minimum_frequency
+#    q_max = (jnp.sqrt(2) / (pixel_size * 2.0)) if maximum_frequency is None else maximum_frequency
+#    q_step = 1.0 / (pixel_size * max(shape))
+#    num_bins = 1 + jnp.array(shape[0]/2,int) 
+#    print(num_bins)
+#    return jnp.linspace(q_min, q_max, num_bins)
+
+
+# -- JIT-compatible inner function
+@eqx.filter_jit
 def compute_radially_averaged_powerspectrum(
-    fourier_image: Complex[Array, "y_dim x_dim"] | Complex[Array, "z_dim y_dim x_dim"],
-    radial_frequency_grid: (
-        Float[Array, "y_dim x_dim"] | Float[Array, "z_dim y_dim x_dim"]
-    ),
-    pixel_size: Float[Array, ""] | float = 1.0,
+    fourier_image: Complex[Array, "y x"] | Complex[Array, "z y x"],
+    pixel_size: float = 1.0,
     *,
     minimum_frequency: Optional[float] = None,
     maximum_frequency: Optional[float] = None,
-) -> tuple[Float[Array, " n_bins"], Float[Array, " n_bins"]]:
-    """Compute the power spectrum of an image averaged on a set
-    of radial bins.
+) -> tuple[Float[Array, "n_bins"], Float[Array, "n_bins"]]:
 
-    **Arguments:**
+    import cryojax.coordinates  as cc
 
-    `fourier_image`:
-        An image in Fourier space.
-    `radial_frequency_grid`:
-        The radial frequency coordinate system of `fourier_image`.
-    `pixel_size`:
-        The pixel size of `radial_frequency_grid`.
-    `minimum_frequency`:
-        Minimum frequency bin. By default, `0.0`.
-    `minimum_frequency`:
-        Maximum frequency bin. By default, `1 / (2 * pixel_size)`.
+    radial_frequency_grid = cc.make_radial_frequency_grid(fourier_image.shape,grid_spacing=pixel_size)
+    start = 0 
+    stop = jnp.sqrt(2) / (pixel_size*2.0) 
+    frequency_bins = jnp.linspace(start, stop, jnp.int32(fourier_image.shape[0]/2)+1)
+    squared_fourier_amplitudes = jnp.real(fourier_image * jnp.conjugate(fourier_image))
+    print(frequency_bins)
 
-    **Returns:**
+    spectrum = compute_binned_radial_average(squared_fourier_amplitudes, radial_frequency_grid, frequency_bins)
 
-    A tuple of the radially averaged power spectrum and the frequency bins
-    over which it is computed.
-    """
-    # Compute squared amplitudes
-    squared_fourier_amplitudes = (fourier_image * jnp.conjugate(fourier_image)).real
-    # Compute bins
-    q_min = 0.0 if minimum_frequency is None else minimum_frequency
-    q_max = (
-        jnp.sqrt(2) / (pixel_size * 2.0)
-        if maximum_frequency is None
-        else maximum_frequency
-    )
-    q_step = 1.0 / (pixel_size * max(*squared_fourier_amplitudes.shape))
-    frequency_bins = jnp.linspace(q_min, q_max, 1 + int((q_max - q_min) / q_step))
-    # Compute radially averaged power spectrum as a 1D profile
-    radially_averaged_powerspectrum = compute_binned_radial_average(
-        squared_fourier_amplitudes, radial_frequency_grid, frequency_bins
-    )
+    return spectrum, frequency_bins
 
-    return radially_averaged_powerspectrum, frequency_bins

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -17,8 +17,8 @@ def compute_radially_averaged_powerspectrum(
     ),
     pixel_size: Float[Array, ""] | float = 1.0,
     *,
-    minimum_frequency: Optional[Float[Array, ""] | float] = None,
-    maximum_frequency: Optional[Float[Array, ""] | float] = None,
+    minimum_frequency: Optional[float] = None,
+    maximum_frequency: Optional[float] = None,
 ) -> tuple[Float[Array, " n_bins"], Float[Array, " n_bins"]]:
     """Compute the power spectrum of an image averaged on a set
     of radial bins.

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -10,6 +10,7 @@ from jaxtyping import Array, Complex, Float, Bool
 
 
 import jax.numpy as jnp
+import math
 import equinox as eqx
 from jax import Array
 from jaxtyping import Float, Complex
@@ -25,17 +26,14 @@ def compute_radially_averaged_powerspectrum(
     pixel_size: float = 1.0,
 ) -> tuple[Float[Array, "n_bins"], Float[Array, "n_bins"]]:
 
-    import cryojax.coordinates  as cc
-
     radial_frequency_grid = cc.make_radial_frequency_grid(fourier_image.shape,grid_spacing=pixel_size)
     start = 0 
-    stop = jnp.sqrt(2) / (pixel_size*2.0) 
+    stop = math.sqrt(2) / (pixel_size*2.0) 
 
     # hard code constant to avoid problems in linspace shape size.
     # jnp.sqrt(2) will get traced sadly.
-    sqrt2 = 1.4142135623730951
 
-    frequency_bins = jnp.linspace(start, stop, int(fourier_image.shape[0]*sqrt2/2)+1)
+    frequency_bins = jnp.linspace(start, stop, int(fourier_image.shape[0]*math.sqrt(2)/2)+1)
     squared_fourier_amplitudes = jnp.real(fourier_image * jnp.conjugate(fourier_image))
 
     spectrum = compute_binned_radial_average(squared_fourier_amplitudes, radial_frequency_grid, frequency_bins)

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -19,22 +19,6 @@ from typing import Optional
 import cryojax.coordinates as cc
 from ._average import compute_binned_radial_average  # keep import inside jit-safe scope
 
-# -- This stays outside the JIT trace
-#def _compute_frequency_bins(
-#    shape: tuple[int, ...],
-#    pixel_size: float,
-#    minimum_frequency: Optional[float] = None,
-#    maximum_frequency: Optional[float] = None,
-#) -> Float[Array, "n_bins"]:
-#    q_min = 0.0 if minimum_frequency is None else minimum_frequency
-#    q_max = (jnp.sqrt(2) / (pixel_size * 2.0)) if maximum_frequency is None else maximum_frequency
-#    q_step = 1.0 / (pixel_size * max(shape))
-#    num_bins = 1 + jnp.array(shape[0]/2,int) 
-#    print(num_bins)
-#    return jnp.linspace(q_min, q_max, num_bins)
-
-
-# -- JIT-compatible inner function
 @eqx.filter_jit
 def compute_radially_averaged_powerspectrum(
     fourier_image: Complex[Array, "y x"] | Complex[Array, "z y x"],
@@ -49,10 +33,16 @@ def compute_radially_averaged_powerspectrum(
     radial_frequency_grid = cc.make_radial_frequency_grid(fourier_image.shape,grid_spacing=pixel_size)
     start = 0 
     stop = jnp.sqrt(2) / (pixel_size*2.0) 
-    frequency_bins = jnp.linspace(start, stop, int(fourier_image.shape[0]/2)+1)
+
+    # hard code constant to avoid problems in linspace shape size.
+    # jnp.sqrt(2) will get traced sadly.
+    sqrt2 = 1.4142135623730951
+
+    frequency_bins = jnp.linspace(start, stop, int(fourier_image.shape[0]*sqrt2/2)+1)
     squared_fourier_amplitudes = jnp.real(fourier_image * jnp.conjugate(fourier_image))
 
     spectrum = compute_binned_radial_average(squared_fourier_amplitudes, radial_frequency_grid, frequency_bins)
+    #return_spec = jnp.where(spectrum, )
 
     return spectrum, frequency_bins
 

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -49,9 +49,8 @@ def compute_radially_averaged_powerspectrum(
     radial_frequency_grid = cc.make_radial_frequency_grid(fourier_image.shape,grid_spacing=pixel_size)
     start = 0 
     stop = jnp.sqrt(2) / (pixel_size*2.0) 
-    frequency_bins = jnp.linspace(start, stop, jnp.int32(fourier_image.shape[0]/2)+1)
+    frequency_bins = jnp.linspace(start, stop, int(fourier_image.shape[0]/2)+1)
     squared_fourier_amplitudes = jnp.real(fourier_image * jnp.conjugate(fourier_image))
-    print(frequency_bins)
 
     spectrum = compute_binned_radial_average(squared_fourier_amplitudes, radial_frequency_grid, frequency_bins)
 

--- a/src/cryojax/image/_spectrum.py
+++ b/src/cryojax/image/_spectrum.py
@@ -23,9 +23,6 @@ from ._average import compute_binned_radial_average  # keep import inside jit-sa
 def compute_radially_averaged_powerspectrum(
     fourier_image: Complex[Array, "y x"] | Complex[Array, "z y x"],
     pixel_size: float = 1.0,
-    *,
-    minimum_frequency: Optional[float] = None,
-    maximum_frequency: Optional[float] = None,
 ) -> tuple[Float[Array, "n_bins"], Float[Array, "n_bins"]]:
 
     import cryojax.coordinates  as cc


### PR DESCRIPTION
Added support for calculating fourier shell or fourier ring correlations using existing infrastructure for calculating power spectrums. This seems to be working well. However, I don't believe the power spectrum API is jit compatible so this is not either. Is this intentional or should I raise an issue? 

Attached you'll find examples of comparing cryosparc derived half-maps. 
cryojax:
![image](https://github.com/user-attachments/assets/95b62753-fff0-49ab-a3d1-a45c6d8ade27)

cryosparc: 
![image](https://github.com/user-attachments/assets/8b4aa22d-a725-4f78-933c-6550cf9488e9)


I've also attached a zip file with the notebook and files I used to make this PR if you'd like to check it yourselves. 



