### PR TITLE
cryoJAX pose convention documentation and small change

### DIFF
--- a/src/cryojax/data/_relion/_starfile_dataset.py
+++ b/src/cryojax/data/_relion/_starfile_dataset.py
@@ -457,15 +457,17 @@ def _make_pytrees_from_starfile(
     # each key is present
     particle_keys = particle_blocks.keys()
     pose_parameter_names_and_values = []
+    # read the pose, fipping the sign of the translations. RELION's convention
+    # thinks about "undoing" a translation, opposed to simulating an image at a coordinate
     if "rlnOriginXAngst" in particle_keys:
         pose_parameter_names_and_values.append(
-            ("offset_x_in_angstroms", particle_blocks["rlnOriginXAngst"])
+            ("offset_x_in_angstroms", -particle_blocks["rlnOriginXAngst"])
         )
     else:
         pose_parameter_names_and_values.append(("offset_x_in_angstroms", 0.0))
     if "rlnOriginYAngst" in particle_keys:
         pose_parameter_names_and_values.append(
-            ("offset_y_in_angstroms", particle_blocks["rlnOriginYAngst"])
+            ("offset_y_in_angstroms", -particle_blocks["rlnOriginYAngst"])
         )
     else:
         pose_parameter_names_and_values.append(("offset_y_in_angstroms", 0.0))

--- a/src/cryojax/data/_relion/_starfile_writing.py
+++ b/src/cryojax/data/_relion/_starfile_writing.py
@@ -97,17 +97,19 @@ def write_starfile_with_particle_parameters(
     # Generate particles group
     particles_df = pd.DataFrame()
 
-    # fixed values
+    # Fixed value parameters
     particles_df["rlnCtfMaxResolution"] = np.zeros(n_images)
     particles_df["rlnCtfFigureOfMerit"] = np.zeros(n_images)
     particles_df["rlnClassNumber"] = np.ones(n_images)
     particles_df["rlnOpticsGroup"] = np.ones(n_images)
-
-    particles_df["rlnOriginXAngst"] = particle_parameters.pose.offset_x_in_angstroms
-    particles_df["rlnOriginYAngst"] = particle_parameters.pose.offset_y_in_angstroms
+    # Pose (flipping the sign of the translations); RELION's convention
+    # thinks about "undoing" a translation, opposed to simulating an image at a coordinate
+    particles_df["rlnOriginXAngst"] = -particle_parameters.pose.offset_x_in_angstroms
+    particles_df["rlnOriginYAngst"] = -particle_parameters.pose.offset_y_in_angstroms
     particles_df["rlnAngleRot"] = particle_parameters.pose.phi_angle
     particles_df["rlnAngleTilt"] = particle_parameters.pose.theta_angle
     particles_df["rlnAnglePsi"] = particle_parameters.pose.psi_angle
+    # CTF
     particles_df["rlnDefocusU"] = (
         particle_parameters.transfer_theory.ctf.defocus_in_angstroms
         + particle_parameters.transfer_theory.ctf.astigmatism_in_angstroms / 2

--- a/src/cryojax/simulator/_pose.py
+++ b/src/cryojax/simulator/_pose.py
@@ -97,7 +97,7 @@ class AbstractPose(Module, strict=True):
         grid of in-plane phase shifts $\\exp{(- 2 \\pi i (t_x q_x + t_y q_y))}$.
         """
         xy = self.offset_in_angstroms[0:2]
-        return jnp.exp(1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid_in_angstroms, xy)))
+        return jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid_in_angstroms, xy)))
 
     @cached_property
     def offset_in_angstroms(self) -> Float[Array, "2"]:


### PR DESCRIPTION
Recently, we changed the pose convention for the xy in-plane translation as we learned that our convention is different from RELION. It turns out that the reason for this is because RELION considers a translation to be TO the center of an image (positive translation means -x direction), whereas we considered a translation to be the opposite (positive means +x direction). The latter feels more natural for a forward simulator, so this PR switches back to this. We will instead just flip the sign when doing I/O to other softwares in `cryojax.data`.

Additionally, this PR should make pose conventions well-documented; it would even be good to mathematically work out the difference with other softwares.