### PR TITLE
Add soft-edge rectangular masks 

### DIFF
--- a/docs/api/simulator/transfer_theory.md
+++ b/docs/api/simulator/transfer_theory.md
@@ -49,7 +49,7 @@ This documentation describes the elements of transfer theory in `cryojax`. More 
                 - __init__
                 - __call__
 
-::: cryojax.simulator.PerfectCTF
+::: cryojax.simulator.NullCTF
         options:
             members:
                 - __init__

--- a/src/cryojax/image/operators/__init__.py
+++ b/src/cryojax/image/operators/__init__.py
@@ -17,11 +17,14 @@ from ._fourier_operator import (
     ZeroMode as ZeroMode,
 )
 from ._masks import (
+    AbstractBooleanMask as AbstractBooleanMask,
     AbstractMask as AbstractMask,
     CircularCosineMask as CircularCosineMask,
     CustomMask as CustomMask,
     Cylindrical2DCosineMask as Cylindrical2DCosineMask,
     MaskLike as MaskLike,
+    Rectangular2DCosineMask as Rectangular2DCosineMask,
+    Rectangular3DCosineMask as Rectangular3DCosineMask,
     SphericalCosineMask as SphericalCosineMask,
     SquareCosineMask as SquareCosineMask,
 )

--- a/src/cryojax/image/operators/_filters.py
+++ b/src/cryojax/image/operators/_filters.py
@@ -28,7 +28,7 @@ class AbstractFilter(AbstractImageMultiplier, strict=True):
     ) -> Complex[Array, "y_dim x_dim"]: ...
 
     @overload
-    def __call__(
+    def __call__(  # type: ignore
         self, image: Complex[Array, "z_dim y_dim x_dim"]
     ) -> Complex[Array, "z_dim y_dim x_dim"]: ...
 
@@ -84,9 +84,6 @@ class LowpassFilter(AbstractFilter, strict=True):
 
     array: Inexact[Array, "y_dim x_dim"] | Inexact[Array, "z_dim y_dim x_dim"]
 
-    frequency_cutoff_fraction: Float[Array, ""]
-    rolloff_width_fraction: Float[Array, ""]
-
     def __init__(
         self,
         frequency_grid_in_angstroms_or_pixels: (
@@ -109,13 +106,11 @@ class LowpassFilter(AbstractFilter, strict=True):
             The rolloff width as a fraction of the Nyquist frequency.
             By default, ``0.05``.
         """
-        self.frequency_cutoff_fraction = jnp.asarray(frequency_cutoff_fraction)
-        self.rolloff_width_fraction = jnp.asarray(rolloff_width_fraction)
         self.array = _compute_lowpass_filter(
             frequency_grid_in_angstroms_or_pixels,
             jnp.asarray(grid_spacing),
-            self.frequency_cutoff_fraction,
-            self.rolloff_width_fraction,
+            jnp.asarray(frequency_cutoff_fraction),
+            jnp.asarray(rolloff_width_fraction),
         )
 
 
@@ -126,9 +121,6 @@ class HighpassFilter(AbstractFilter, strict=True):
 
     array: Inexact[Array, "y_dim x_dim"] | Inexact[Array, "z_dim y_dim x_dim"]
 
-    frequency_cutoff_fraction: Float[Array, ""]
-    rolloff_width_fraction: Float[Array, ""]
-
     def __init__(
         self,
         frequency_grid_in_angstroms_or_pixels: (
@@ -151,13 +143,11 @@ class HighpassFilter(AbstractFilter, strict=True):
             The rolloff width as a fraction of the Nyquist frequency.
             By default, ``0.05``.
         """
-        self.frequency_cutoff_fraction = jnp.asarray(frequency_cutoff_fraction)
-        self.rolloff_width_fraction = jnp.asarray(rolloff_width_fraction)
         self.array = 1.0 - _compute_lowpass_filter(
             frequency_grid_in_angstroms_or_pixels,
             jnp.asarray(grid_spacing),
-            self.frequency_cutoff_fraction,
-            self.rolloff_width_fraction,
+            jnp.asarray(frequency_cutoff_fraction),
+            jnp.asarray(rolloff_width_fraction),
         )
 
 

--- a/src/cryojax/image/operators/_masks.py
+++ b/src/cryojax/image/operators/_masks.py
@@ -4,9 +4,10 @@ Masks to apply to images in real space.
 
 from typing import Optional, overload
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Float
+from jaxtyping import Array, Bool, Float
 
 from ._operator import AbstractImageMultiplier
 
@@ -30,6 +31,19 @@ class AbstractMask(AbstractImageMultiplier, strict=True):
         return image * jax.lax.stop_gradient(self.array)
 
 
+class AbstractBooleanMask(AbstractMask, strict=True):
+    """Base class for computing and applying an image mask,
+    which takes on values equal to 1 where there are regions
+    of signal."""
+
+    is_not_masked: eqx.AbstractVar[
+        Bool[Array, "y_dim x_dim"] | Bool[Array, "z_dim y_dim x_dim"]
+    ]
+
+    def __post_init__(self):
+        self.is_not_masked = self.array == 1.0
+
+
 MaskLike = AbstractMask | AbstractImageMultiplier
 
 
@@ -44,12 +58,13 @@ class CustomMask(AbstractMask, strict=True):
         self.array = mask_array
 
 
-class CircularCosineMask(AbstractMask, strict=True):
+class CircularCosineMask(AbstractBooleanMask, strict=True):
     """Apply a circular mask to an image with a cosine
     soft-edge.
     """
 
     array: Float[Array, "y_dim x_dim"]
+    is_not_masked: Bool[Array, "y_dim x_dim"]
 
     def __init__(
         self,
@@ -73,12 +88,13 @@ class CircularCosineMask(AbstractMask, strict=True):
         )
 
 
-class SphericalCosineMask(AbstractMask, strict=True):
+class SphericalCosineMask(AbstractBooleanMask, strict=True):
     """Apply a spherical mask to a volume with a cosine
     soft-edge.
     """
 
     array: Float[Array, "z_dim y_dim x_dim"]
+    is_not_masked: Bool[Array, "z_dim y_dim x_dim"]
 
     def __init__(
         self,
@@ -102,12 +118,13 @@ class SphericalCosineMask(AbstractMask, strict=True):
         )
 
 
-class SquareCosineMask(AbstractMask, strict=True):
+class SquareCosineMask(AbstractBooleanMask, strict=True):
     """Apply a square mask to an image with a cosine
     soft-edge.
     """
 
     array: Float[Array, "y_dim x_dim"]
+    is_not_masked: Bool[Array, "y_dim x_dim"]
 
     def __init__(
         self,
@@ -129,13 +146,14 @@ class SquareCosineMask(AbstractMask, strict=True):
         )
 
 
-class Cylindrical2DCosineMask(AbstractMask, strict=True):
+class Cylindrical2DCosineMask(AbstractBooleanMask, strict=True):
     """Apply a cylindrical mask to an image with a cosine
     soft-edge. This implements an infinite in-plane cylinder,
     rotated at a given angle.
     """
 
     array: Float[Array, "y_dim x_dim"]
+    is_not_masked: Bool[Array, "y_dim x_dim"]
 
     def __init__(
         self,
@@ -177,12 +195,13 @@ class Cylindrical2DCosineMask(AbstractMask, strict=True):
             )
 
 
-class Rectangular2DCosineMask(AbstractMask, strict=True):
+class Rectangular2DCosineMask(AbstractBooleanMask, strict=True):
     """Apply a rectangular mask in 2D to an image with a cosine
     soft-edge. Optionally, rotate the rectangle by an angle.
     """
 
     array: Float[Array, "y_dim x_dim"]
+    is_not_masked: Bool[Array, "y_dim x_dim"]
 
     def __init__(
         self,
@@ -215,12 +234,13 @@ class Rectangular2DCosineMask(AbstractMask, strict=True):
         )
 
 
-class Rectangular3DCosineMask(AbstractMask, strict=True):
+class Rectangular3DCosineMask(AbstractBooleanMask, strict=True):
     """Apply a rectangular mask to a volume with a cosine
     soft-edge.
     """
 
     array: Float[Array, "z_dim y_dim x_dim"]
+    is_not_masked: Bool[Array, "z_dim y_dim x_dim"]
 
     def __init__(
         self,

--- a/src/cryojax/image/operators/_masks.py
+++ b/src/cryojax/image/operators/_masks.py
@@ -40,9 +40,6 @@ class AbstractBooleanMask(AbstractMask, strict=True):
         Bool[Array, "y_dim x_dim"] | Bool[Array, "z_dim y_dim x_dim"]
     ]
 
-    def __post_init__(self):
-        self.is_not_masked = self.array == 1.0
-
 
 MaskLike = AbstractMask | AbstractImageMultiplier
 
@@ -86,6 +83,7 @@ class CircularCosineMask(AbstractBooleanMask, strict=True):
             jnp.asarray(radius),
             jnp.asarray(rolloff_width),
         )
+        self.is_not_masked = self.array == 1.0
 
 
 class SphericalCosineMask(AbstractBooleanMask, strict=True):
@@ -116,6 +114,7 @@ class SphericalCosineMask(AbstractBooleanMask, strict=True):
             jnp.asarray(radius),
             jnp.asarray(rolloff_width),
         )
+        self.is_not_masked = self.array == 1.0
 
 
 class SquareCosineMask(AbstractBooleanMask, strict=True):
@@ -144,6 +143,7 @@ class SquareCosineMask(AbstractBooleanMask, strict=True):
         self.array = _compute_square_mask(
             coordinate_grid, jnp.asarray(side_length), jnp.asarray(rolloff_width)
         )
+        self.is_not_masked = self.array == 1.0
 
 
 class Cylindrical2DCosineMask(AbstractBooleanMask, strict=True):
@@ -193,6 +193,7 @@ class Cylindrical2DCosineMask(AbstractBooleanMask, strict=True):
                 jnp.asarray(in_plane_rotation_angle),
                 jnp.asarray(rolloff_width),
             )
+        self.is_not_masked = self.array == 1.0
 
 
 class Rectangular2DCosineMask(AbstractBooleanMask, strict=True):
@@ -232,6 +233,7 @@ class Rectangular2DCosineMask(AbstractBooleanMask, strict=True):
             jnp.asarray(in_plane_rotation_angle),
             jnp.asarray(rolloff_width),
         )
+        self.is_not_masked = self.array == 1.0
 
 
 class Rectangular3DCosineMask(AbstractBooleanMask, strict=True):
@@ -270,6 +272,7 @@ class Rectangular3DCosineMask(AbstractBooleanMask, strict=True):
             jnp.asarray(z_width),
             jnp.asarray(rolloff_width),
         )
+        self.is_not_masked = self.array == 1.0
 
 
 @overload

--- a/src/cryojax/image/operators/_masks.py
+++ b/src/cryojax/image/operators/_masks.py
@@ -226,6 +226,19 @@ class Rectangular3DCosineMask(AbstractMask, strict=True):
         z_width: float | Float[Array, ""],
         rolloff_width: float | Float[Array, ""],
     ):
+        """**Arguments:**
+
+        - `coordinate_grid`:
+            The image coordinates.
+        - `x_width`:
+            The width of the rectangle along the x-axis.
+        - `y_width`:
+            The width of the rectangle along the y-axis.
+        - `z_width`:
+            The width of the rectangle along the z-axis.
+        - `rolloff_width`:
+            The rolloff width of the soft edge.
+        """
         self.array = _compute_rectangular_mask_3d(
             coordinate_grid,
             jnp.asarray(x_width),

--- a/src/cryojax/image/operators/_masks.py
+++ b/src/cryojax/image/operators/_masks.py
@@ -178,7 +178,7 @@ class Cylindrical2DCosineMask(AbstractMask, strict=True):
 
 
 class Rectangular2DCosineMask(AbstractMask, strict=True):
-    """Apply a rectangular mask to an image with a cosine
+    """Apply a rectangular mask in 2D to an image with a cosine
     soft-edge. Optionally, rotate the rectangle by an angle.
     """
 
@@ -216,6 +216,10 @@ class Rectangular2DCosineMask(AbstractMask, strict=True):
 
 
 class Rectangular3DCosineMask(AbstractMask, strict=True):
+    """Apply a rectangular mask to a volume with a cosine
+    soft-edge.
+    """
+
     array: Float[Array, "z_dim y_dim x_dim"]
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,8 +123,8 @@ def filters(config):
 def masks(config):
     return op.CircularCosineMask(
         config.padded_coordinate_grid_in_angstroms,
-        radius_in_angstroms_or_pixels=20 * float(config.pixel_size),
-        rolloff_width_in_angstroms_or_pixels=3 * float(config.pixel_size),
+        radius=20 * float(config.pixel_size),
+        rolloff_width=3 * float(config.pixel_size),
     )
 
 


### PR DESCRIPTION
A few things

- Adds rectangular masks
- Removes filter and mask properties as parameters. It doesn't really make sense to store these as parameters since computation is only done on `__init__`.
- Adds new abstract class `AbstractBooleanMask`, which precomputes a boolean array for the region of signal. The `AbstractGaussianDistribution` computed this array on-the-fly, but there was no reason to not have this in precompute.
- More flexibility in applying filters and masks in the `AbstractGaussianDistribution`. In particular, now there's an option to normalize using the mask but not apply the mask.