### PR TITLE
Move `PengScatteringFactorParameters` from `cryojax.simulator` to `cryojax.constants`

### DIFF
--- a/cryojax/constants/__init__.py
+++ b/cryojax/constants/__init__.py
@@ -11,6 +11,6 @@ from ._physical_constants import (
     wavelength_from_kilovolts as wavelength_from_kilovolts,
 )
 from ._scattering_factor_parameters import (
-    get_tabulated_scattering_factor_parameters as get_tabulated_scattering_factor_parameters,  # noqa: E501
+    PengScatteringFactorParameters as PengScatteringFactorParameters,
     read_peng_scattering_factor_parameter_table as read_peng_scattering_factor_parameter_table,  # noqa: E501
 )

--- a/cryojax/constants/_scattering_factor_parameters.py
+++ b/cryojax/constants/_scattering_factor_parameters.py
@@ -6,41 +6,46 @@ Large amounts of the code are adapted from the ioSPI package
 import importlib.resources as pkg_resources
 import os
 
+import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
 import xarray as xr
 from jaxtyping import Float, Int
 
 
-def get_tabulated_scattering_factor_parameters(
-    atom_types: Int[np.ndarray, " n_atoms"],
-    scattering_factor_parameter_table: xr.Dataset | None = None,
-) -> dict[str, Float[np.ndarray, " n_atoms n_scattering_factors"]]:
-    """Gets the parameters for the scattering factor for each atom in
-    `atom_types`.
+class PengScatteringFactorParameters(eqx.Module, strict=True):
+    """A convenience wrapper for instantiating the
+    scattering factor parameters from Peng et al. (1996).
 
-    **Arguments:**
+    To access scattering factors $a_i$ and $b_i$ given in
+    the citation,
 
-    - `atom_identitites`:
-        Array containing the index of the one-hot encoded atom names.
-        By default, Hydrogen is "1", Carbon is "6", Nitrogen is "7", etc.
-    - `scattering_factor_parameter_table`:
-        The table of scattering factors as an `xarray.Dataset`. By default, this
-        is the tabulation from "Robust Parameterization of Elastic and
-        Absorptive Electron Atomic Scattering Factors" by Peng et al. (1996),
-        given by [`read_peng_element_scattering_factor_parameter_table`](https://michael-0brien.github.io/cryojax/api/constants/scattering_factor_parameters/#cryojax.constants.read_peng_element_scattering_factor_parameter_table).
+    ```python
+    from cryojax.io import read_atoms_from_pdb
+    from cryojax.constants import PengScatteringFactorParameters
 
-    **Returns:**
+    # Load positions of atoms and one-hot encoded atom names
+    atom_positions, atom_types = read_atoms_from_pdb(...)
+    parameters = PengScatteringFactorParameters(atom_types)
+    print(parameters.a, parameters.b)  # a_i and b_i
+    ```
+    """
 
-    The particular scattering factor parameters stored in
-    `scattering_factor_parameter_table` for `atom_types`.
-    """  # noqa: E501
-    if scattering_factor_parameter_table is None:
+    a: Float[np.ndarray, " n_atoms 5"]
+    b: Float[np.ndarray, " n_atoms 5"]
+
+    def __init__(self, atomic_numbers: Int[np.ndarray, " n_atoms"]):
+        """**Arguments:**
+
+        - `atomic_numbers`:
+            The atom types as an integer array.
+        """
         scattering_factor_parameter_table = read_peng_scattering_factor_parameter_table()
-    return {
-        str(k): np.asarray(v.data[np.asarray(atom_types), ...])
-        for k, v in scattering_factor_parameter_table.items()
-    }
+        parameter_dict = _get_tabulated_scattering_factor_parameters(
+            atomic_numbers, scattering_factor_parameter_table
+        )
+        self.a = parameter_dict["a"]
+        self.b = parameter_dict["b"]
 
 
 def read_peng_scattering_factor_parameter_table() -> xr.Dataset:
@@ -70,3 +75,34 @@ def read_peng_scattering_factor_parameter_table() -> xr.Dataset:
     )
 
     return scattering_factor_parameter_table
+
+
+def _get_tabulated_scattering_factor_parameters(
+    atom_types: Int[np.ndarray, " n_atoms"],
+    scattering_factor_parameter_table: xr.Dataset | None = None,
+) -> dict[str, Float[np.ndarray, " n_atoms n_scattering_factors"]]:
+    """Gets the parameters for the scattering factor for each atom in
+    `atom_types`.
+
+    **Arguments:**
+
+    - `atom_identitites`:
+        Array containing the index of the one-hot encoded atom names.
+        By default, Hydrogen is "1", Carbon is "6", Nitrogen is "7", etc.
+    - `scattering_factor_parameter_table`:
+        The table of scattering factors as an `xarray.Dataset`. By default, this
+        is the tabulation from "Robust Parameterization of Elastic and
+        Absorptive Electron Atomic Scattering Factors" by Peng et al. (1996),
+        given by [`read_peng_element_scattering_factor_parameter_table`](https://michael-0brien.github.io/cryojax/api/constants/scattering_factor_parameters/#cryojax.constants.read_peng_element_scattering_factor_parameter_table).
+
+    **Returns:**
+
+    The particular scattering factor parameters stored in
+    `scattering_factor_parameter_table` for `atom_types`.
+    """  # noqa: E501
+    if scattering_factor_parameter_table is None:
+        scattering_factor_parameter_table = read_peng_scattering_factor_parameter_table()
+    return {
+        str(k): np.asarray(v.data[np.asarray(atom_types), ...])
+        for k, v in scattering_factor_parameter_table.items()
+    }

--- a/cryojax/simulator/__init__.py
+++ b/cryojax/simulator/__init__.py
@@ -62,7 +62,6 @@ from ._volume import (
     FourierVoxelSplineVolume as FourierVoxelSplineVolume,
     GaussianMixtureVolume as GaussianMixtureVolume,
     PengAtomicVolume as PengAtomicVolume,
-    PengScatteringFactorParameters as PengScatteringFactorParameters,
     RealVoxelGridVolume as RealVoxelGridVolume,
 )
 from ._volume_integrator import (
@@ -91,6 +90,17 @@ def __getattr__(name: str):
             stacklevel=2,
         )
         return AstigmaticCTF
+    if name == "PengScatteringFactorParameters":
+        _warnings.warn(
+            "'PengScatteringFactorParameters' has been moved to `cryojax.constants` "
+            "will be removed from `cryojax.simulator` in "
+            "cryoJAX 0.6.0.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        from ..constants import PengScatteringFactorParameters
+
+        return PengScatteringFactorParameters
     # Deprecated in previous versions
     if name == "DiscreteStructuralEnsemble":
         raise ValueError(

--- a/cryojax/simulator/_volume/__init__.py
+++ b/cryojax/simulator/_volume/__init__.py
@@ -11,6 +11,5 @@ from .representations import (
     FourierVoxelSplineVolume as FourierVoxelSplineVolume,
     GaussianMixtureVolume as GaussianMixtureVolume,
     PengAtomicVolume as PengAtomicVolume,
-    PengScatteringFactorParameters as PengScatteringFactorParameters,
     RealVoxelGridVolume as RealVoxelGridVolume,
 )

--- a/cryojax/simulator/_volume/representations/__init__.py
+++ b/cryojax/simulator/_volume/representations/__init__.py
@@ -7,7 +7,6 @@ from .gmm_volume import GaussianMixtureVolume as GaussianMixtureVolume
 from .tabulated_volume import (
     AbstractTabulatedAtomicVolume as AbstractTabulatedAtomicVolume,
     PengAtomicVolume as PengAtomicVolume,
-    PengScatteringFactorParameters as PengScatteringFactorParameters,
 )
 from .voxel_volume import (
     FourierVoxelGridVolume as FourierVoxelGridVolume,

--- a/docs/api/constants/conventions.md
+++ b/docs/api/constants/conventions.md
@@ -4,4 +4,6 @@ Here, helper functions for converting between common conventions are described.
 
 ::: cryojax.constants.b_factor_to_variance
 
+---
+
 ::: cryojax.constants.variance_to_b_factor

--- a/docs/api/constants/scattering_factor_parameters.md
+++ b/docs/api/constants/scattering_factor_parameters.md
@@ -1,11 +1,14 @@
 # Scattering factor parameters
 
-Modeling the electron scattering amplitudes of individual atoms is an important component of modeling cryo-EM images, as these are typically used to approximate the electrostatic potential. Typically, the scattering factor for each individual atom is numerically approximated with a fixed functional form but varying parameters for different atoms. These parameters are stored in lookup tables in the literature. This documentation provides these lookup tables so that they may be used to compute electrostatic potentials in cryoJAX.
+Modeling the electron scattering amplitudes of individual atoms is an important component of modeling cryo-EM images, as these are typically used to approximate the electrostatic potential. Typically, the scattering factor for each individual atom is numerically approximated with a fixed functional form but varying parameters for different atoms. These parameters are stored in lookup tables in the literature. This documentation provides these lookup tables and utilities for extracting them so that they may be used to compute electrostatic potentials in cryoJAX.
 
-## Extracting parameters from a lookup table
+::: cryojax.constants.PengScatteringFactorParameters
+    options:
+        members:
+            - __init__
+            - a
+            - b
 
-::: cryojax.constants.get_tabulated_scattering_factor_parameters
-
-## Lookup tables
+---
 
 ::: cryojax.constants.read_peng_scattering_factor_parameter_table

--- a/docs/api/constants/units.md
+++ b/docs/api/constants/units.md
@@ -4,6 +4,10 @@ Here, convenience methods for working with physical units are described.
 
 ::: cryojax.constants.wavelength_from_kilovolts
 
+---
+
 ::: cryojax.constants.lorentz_factor_from_kilovolts
+
+---
 
 ::: cryojax.constants.interaction_constant_from_kilovolts

--- a/docs/api/simulator/integrator.md
+++ b/docs/api/simulator/integrator.md
@@ -10,12 +10,6 @@
 
 ## Integration methods for voxel-based structures
 
-???+ abstract "`cryojax.simulator.AbstractVoxelVolumeIntegrator`"
-    ::: cryojax.simulator.AbstractVoxelVolumeIntegrator
-        options:
-            members:
-                - outputs_integral
-
 ::: cryojax.simulator.FourierSliceExtraction
         options:
             members:

--- a/docs/api/simulator/volume.md
+++ b/docs/api/simulator/volume.md
@@ -45,11 +45,6 @@ There are many different volume representations of biological structures for cry
                 - atom_positions
                 - from_tabulated_parameters
 
-::: cryojax.simulator.PengScatteringFactorParameters
-    options:
-        members:
-            - __init__
-
 ::: cryojax.simulator.PengAtomicVolume
     options:
         members:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ plugins:
     - hippogriffe:
         extra_public_objects:
             - xarray.core.dataset.Dataset
+            - numpy.ndarray
     - mkdocstrings:
         handlers:
           python:

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -31,6 +31,11 @@ def test_future_deprecated(sample_pdb_path):
         assert not should_be_removed(record)
 
     with pytest.warns(DeprecationWarning) as record:
+        obj = cxs.PengScatteringFactorParameters
+        assert obj is cryojax.constants.PengScatteringFactorParameters
+        assert not should_be_removed(record)
+
+    with pytest.warns(DeprecationWarning) as record:
         _ = cryojax.io.read_atoms_from_pdb(
             sample_pdb_path,
             loads_b_factors=True,


### PR DESCRIPTION
The `cryojax.simulator` namespace is kept for deprecation.