### PR TITLE
Change `AbstractVolumeParametrization.compute_representation` to `AbstractVolumeParametrization.get_representation`

### DIFF
--- a/cryojax/simulator/_image_model/base_image_model.py
+++ b/cryojax/simulator/_image_model/base_image_model.py
@@ -278,10 +278,10 @@ class LinearImageModel(AbstractImageModel, strict=True):
     ) -> PaddedFourierImageArray:
         # Get the representation of the volume
         if rng_key is None:
-            volume_representation = self.volume_parametrization.compute_representation()
+            volume_representation = self.volume_parametrization.get_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.compute_representation(
+            volume_representation = self.volume_parametrization.get_representation(
                 rng_key=this_key
             )
         # Rotate it to the lab frame
@@ -378,10 +378,10 @@ class ProjectionImageModel(AbstractImageModel, strict=True):
     ) -> ImageArray | PaddedImageArray:
         # Get the representation of the volume
         if rng_key is None:
-            volume_representation = self.volume_parametrization.compute_representation()
+            volume_representation = self.volume_parametrization.get_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.compute_representation(
+            volume_representation = self.volume_parametrization.get_representation(
                 rng_key=this_key
             )
         # Rotate it to the lab frame

--- a/cryojax/simulator/_image_model/physical_image_model.py
+++ b/cryojax/simulator/_image_model/physical_image_model.py
@@ -102,10 +102,10 @@ class ContrastImageModel(AbstractPhysicalImageModel, strict=True):
         # Get the volume representation. Its data should be a scattering potential
         # to simulate in physical units
         if rng_key is None:
-            volume_representation = self.volume_parametrization.compute_representation()
+            volume_representation = self.volume_parametrization.get_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.compute_representation(
+            volume_representation = self.volume_parametrization.get_representation(
                 rng_key=this_key
             )
         # Rotate it to the lab frame
@@ -200,10 +200,10 @@ class IntensityImageModel(AbstractPhysicalImageModel, strict=True):
         # Get the volume representation. Its data should be a scattering potential
         # to simulate in physical units
         if rng_key is None:
-            volume_representation = self.volume_parametrization.compute_representation()
+            volume_representation = self.volume_parametrization.get_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.compute_representation(
+            volume_representation = self.volume_parametrization.get_representation(
                 rng_key=this_key
             )
         # Rotate it to the lab frame
@@ -300,7 +300,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
         if rng_key is None:
             # Get the volume representation. Its data should be a scattering potential
             # to simulate in physical units
-            volume_representation = self.volume_parametrization.compute_representation()
+            volume_representation = self.volume_parametrization.get_representation()
             # Rotate it to the lab frame
             volume_representation = volume_representation.rotate_to_pose(self.pose)
             # Compute the intensity
@@ -323,7 +323,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
             keys = jr.split(rng_key, 3)
             # Get the volume representation. Its data should be a scattering potential
             # to simulate in physical units
-            volume_representation = self.volume_parametrization.compute_representation(
+            volume_representation = self.volume_parametrization.get_representation(
                 keys[0]
             )
             # Rotate it to the lab frame

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -58,7 +58,7 @@ class AbstractVolumeParametrization(eqx.Module, strict=True):
     """  # noqa: E501
 
     @abc.abstractmethod
-    def compute_representation(
+    def get_representation(
         self, rng_key: PRNGKeyArray | None = None
     ) -> "AbstractVolumeRepresentation":
         """Core interface for computing the representation of
@@ -87,7 +87,7 @@ class AbstractVolumeRepresentation(AbstractVolumeParametrization, strict=True):
         raise NotImplementedError
 
     @override
-    def compute_representation(self, rng_key: PRNGKeyArray | None = None) -> Self:
+    def get_representation(self, rng_key: PRNGKeyArray | None = None) -> Self:
         """Since this class is itself an
         `AbstractVolumeRepresentation`, this function maps to the identity.
 

--- a/docs/api/simulator/volume.md
+++ b/docs/api/simulator/volume.md
@@ -8,7 +8,7 @@ There are many different volume representations of biological structures for cry
     ::: cryojax.simulator.AbstractVolumeParametrization
         options:
             members:
-                - compute_representation
+                - get_representation
 
 
 ???+ abstract "`cryojax.simulator.AbstractVolumeRepresentation`"
@@ -32,7 +32,7 @@ There are many different volume representations of biological structures for cry
         members:
             - __init__
             - from_tabulated_parameters
-            - compute_representation
+            - get_representation
             - rotate_to_pose
             - translate_to_pose
 
@@ -53,7 +53,7 @@ There are many different volume representations of biological structures for cry
             members:
                 - __init__
                 - from_real_voxel_grid
-                - compute_representation
+                - get_representation
                 - rotate_to_pose
                 - frequency_slice_in_pixels
                 - shape
@@ -65,7 +65,7 @@ There are many different volume representations of biological structures for cry
             members:
                 - __init__
                 - from_real_voxel_grid
-                - compute_representation
+                - get_representation
                 - rotate_to_pose
                 - frequency_slice_in_pixels
                 - shape
@@ -78,7 +78,7 @@ There are many different volume representations of biological structures for cry
             members:
                 - __init__
                 - from_real_voxel_grid
-                - compute_representation
+                - get_representation
                 - rotate_to_pose
                 - coordinate_grid_in_pixels
                 - shape

--- a/docs/examples/simulate-relion-dataset.ipynb
+++ b/docs/examples/simulate-relion-dataset.ipynb
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +200,7 @@
     "        self.conformation = conformation\n",
     "\n",
     "    @override\n",
-    "    def compute_representation(\n",
+    "    def get_representation(\n",
     "        self, rng_key: PRNGKeyArray | None = None\n",
     "    ) -> cxs.AbstractVolumeRepresentation:\n",
     "        return self.sampled_volume\n",


### PR DESCRIPTION
Often this method is implemented just as a getter. This is a more general + accurate name.

No deprecation warning is given because at this stage I would still consider this internal API.