### PR TITLE
Change `from_tabulated_parameters` to `from_peng_parameters`

### DIFF
--- a/cryojax/simulator/__init__.py
+++ b/cryojax/simulator/__init__.py
@@ -109,10 +109,11 @@ def __getattr__(name: str) -> _Any:
     if name == "PengAtomicVolume":
         _warnings.warn(
             "'PengAtomicVolume' is deprecated and will be removed in "
-            "cryoJAX 0.6.0. To achieve identical functionality, use "
-            "`GaussianMixtureVolume.from_tabulated_parameters`. "
-            "This is a breaking change if you are "
-            "directly using `PengAtomicVolume.__init__`.",
+            "cryoJAX 0.6.0. To achieve identical functionality as "
+            "'PengAtomicVolume.from_tabulated_parameters', use "
+            "`GaussianMixtureVolume.from_peng_parameters`. "
+            "Note that is a breaking change if are directly using "
+            "`PengAtomicVolume.__init__`.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/cryojax/simulator/_volume/representations/gaussian_volume.py
+++ b/cryojax/simulator/_volume/representations/gaussian_volume.py
@@ -42,7 +42,7 @@ class GaussianMixtureVolume(AbstractAtomVolume, strict=True):
         # Load positions of atoms and one-hot encoded atom names
         atom_positions, atom_types = read_atoms_from_pdb(...)
         parameters = PengScatteringFactorParameters(atom_types)
-        potential = GaussianMixtureVolume.from_tabulated_parameters(
+        potential = GaussianMixtureVolume.from_peng_parameters(
             atom_positions, parameters
         )
         ```
@@ -144,6 +144,14 @@ class GaussianMixtureVolume(AbstractAtomVolume, strict=True):
 
     @classmethod
     def from_tabulated_parameters(
+        cls,
+        *args,
+        **kwargs,
+    ) -> Self:
+        return cls.from_peng_parameters(*args, **kwargs)
+
+    @classmethod
+    def from_peng_parameters(
         cls,
         atom_positions: Float[NDArrayLike, "n_atoms 3"],
         parameters: PengScatteringFactorParameters,

--- a/cryojax/simulator/_volume_rendering/gaussian_rendering.py
+++ b/cryojax/simulator/_volume_rendering/gaussian_rendering.py
@@ -25,7 +25,7 @@ class GaussianMixtureRenderFn(AbstractVolumeRenderFn[GaussianMixtureVolume], str
     """Render a voxel grid from the `GaussianMixtureVolume`.
 
     If `GaussianMixtureVolume` is instantiated from electron scattering
-    factors via `from_tabulated_parameters`, this renders an electrostatic
+    factors via `from_peng_parameters`, this renders an electrostatic
     potential as tabulated in Peng et al. 1996. The elastic electron
     scattering factors defined in this work are
 

--- a/docs/api/simulator/volume.md
+++ b/docs/api/simulator/volume.md
@@ -31,7 +31,7 @@ There are many different volume representations of biological structures for cry
     options:
         members:
             - __init__
-            - from_tabulated_parameters
+            - from_peng_parameters
             - get_representation
             - rotate_to_pose
             - translate_to_pose

--- a/docs/examples/benchmark.py
+++ b/docs/examples/benchmark.py
@@ -96,7 +96,7 @@ def setup(num_images, path_to_pdb, path_to_starfile):
         selection_string="name CA",  # C-Alphas for simplicity
     )
     scattering_parameters = PengScatteringFactorParameters(atom_types)
-    volume_gmm = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+    volume_gmm = cxs.GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         scattering_parameters,
         extra_b_factors=atom_properties["b_factors"],

--- a/docs/examples/compute-potential.ipynb
+++ b/docs/examples/compute-potential.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
     "    center=True,\n",
     ")\n",
     "parameters = PengScatteringFactorParameters(atomic_numbers)\n",
-    "atom_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(\n",
+    "atom_volume = cxs.GaussianMixtureVolume.from_peng_parameters(\n",
     "    atom_positions,\n",
     "    parameters,\n",
     ")\n",

--- a/docs/examples/simulate-relion-dataset.ipynb
+++ b/docs/examples/simulate-relion-dataset.ipynb
@@ -219,7 +219,7 @@
     "        )\n",
     "\n",
     "        scattering_parameters = PengScatteringFactorParameters(atom_types)\n",
-    "        yield cxs.GaussianMixtureVolume.from_tabulated_parameters(\n",
+    "        yield cxs.GaussianMixtureVolume.from_peng_parameters(\n",
     "            atom_positions,\n",
     "            scattering_parameters,\n",
     "            extra_b_factors=atom_properties[\"b_factors\"],\n",

--- a/tests/test_scattering_theories.py
+++ b/tests/test_scattering_theories.py
@@ -45,7 +45,7 @@ def test_scattering_theories_no_pose(
         selection_string="not element H",
         loads_properties=True,
     )
-    atom_potential = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+    atom_potential = cxs.GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
         extra_b_factors=atom_properties["b_factors"],
@@ -165,7 +165,7 @@ def test_scattering_theories_pose(
         loads_properties=True,
     )
 
-    atom_potential = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+    atom_potential = cxs.GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
         extra_b_factors=atom_properties["b_factors"],

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -44,7 +44,7 @@ def test_projection_methods_no_pose(sample_pdb_path, pixel_size, shape):
         sample_pdb_path, center=True, loads_properties=True
     )
     scattering_factor_parameters = PengScatteringFactorParameters(atom_types)
-    base_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+    base_volume = cxs.GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         scattering_factor_parameters,
         extra_b_factors=atom_properties["b_factors"],

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -60,7 +60,7 @@ def test_atom_integrator_shape(sample_pdb_path, shape):
         selection_string="not element H",
         loads_properties=True,
     )
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
         extra_b_factors=atom_properties["b_factors"],
@@ -116,7 +116,7 @@ def test_fourier_vs_real_voxel_volume_agreement(sample_pdb_path):
         selection_string="not element H",
     )
     # Load atomistic volume
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
     )
@@ -158,7 +158,7 @@ def test_downsampled_voxel_volume_agreement(sample_pdb_path):
         selection_string="not element H",
     )
     # Load atomistic volume
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
     )
@@ -187,7 +187,7 @@ def test_downsampled_gmm_volume_agreement(sample_pdb_path):
         center=True,
         selection_string="not element H",
     )
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
     )
@@ -233,7 +233,7 @@ def test_compute_rectangular_voxel_grid(sample_pdb_path, shape):
         selection_string="not element H",
     )
     # Load atomistic volume
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
     )
@@ -261,7 +261,7 @@ def test_z_plane_batched_vs_non_batched_loop_agreement(
         selection_string="not element H",
     )
     # Load atomistic volume
-    atom_volume = GaussianMixtureVolume.from_tabulated_parameters(
+    atom_volume = GaussianMixtureVolume.from_peng_parameters(
         atom_positions,
         parameters=PengScatteringFactorParameters(atom_types),
     )


### PR DESCRIPTION
This is to avoid naming collisions in the constructor for the new `IndependentAtomVolume` class, which will need to be treated as totally distinct. `from_peng_parameters` is also a more specific name.