### PR TITLE
`make_image_model` upgrades: create `AutoVolumeProjection` and add overloads

### DIFF
--- a/cryojax/simulator/__init__.py
+++ b/cryojax/simulator/__init__.py
@@ -61,6 +61,7 @@ from ._volume import (
     AbstractVolumeRenderFn as AbstractVolumeRenderFn,
     AbstractVolumeRepresentation as AbstractVolumeRepresentation,
     AbstractVoxelVolume as AbstractVoxelVolume,
+    AutoVolumeProjection as AutoVolumeProjection,
     FFTAtomProjection as FFTAtomProjection,
     FFTAtomRenderFn as FFTAtomRenderFn,
     FourierSliceExtraction as FourierSliceExtraction,

--- a/cryojax/simulator/_api_utils.py
+++ b/cryojax/simulator/_api_utils.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, overload
 
 from jaxtyping import Bool
 
@@ -19,16 +19,93 @@ from ._transfer_theory import ContrastTransferTheory
 from ._volume import (
     AbstractVolumeIntegrator,
     AbstractVolumeParametrization,
-    FFTAtomProjection,
-    FourierSliceExtraction,
-    FourierVoxelGridVolume,
-    FourierVoxelSplineVolume,
-    GaussianMixtureProjection,
-    GaussianMixtureVolume,
-    IndependentAtomVolume,
-    RealVoxelGridVolume,
-    RealVoxelProjection,
+    AutoVolumeProjection,
 )
+
+
+@overload
+def make_image_model(
+    volume_parametrization: AbstractVolumeParametrization,
+    image_config: AbstractImageConfig,
+    pose: AbstractPose,
+    transfer_theory: None = None,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
+    detector: AbstractDetector | None = None,
+    *,
+    quantity_mode: None = None,
+    applies_translation: bool = True,
+    normalizes_signal: bool = False,
+    signal_region: Bool[NDArrayLike, "_ _"] | None = None,
+    translate_mode: Literal["fft", "atom"] = "fft",
+) -> ProjectionImageModel: ...
+
+
+@overload
+def make_image_model(  # pyright: ignore[reportOverlappingOverload]
+    volume_parametrization: AbstractVolumeParametrization,
+    image_config: AbstractImageConfig,
+    pose: AbstractPose,
+    transfer_theory: ContrastTransferTheory,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
+    detector: AbstractDetector | None = None,
+    *,
+    quantity_mode: None = None,
+    applies_translation: bool = True,
+    normalizes_signal: bool = False,
+    signal_region: Bool[NDArrayLike, "_ _"] | None = None,
+    translate_mode: Literal["fft", "atom"] = "fft",
+) -> LinearImageModel: ...
+
+
+@overload
+def make_image_model(
+    volume_parametrization: AbstractVolumeParametrization,
+    image_config: AbstractImageConfig,
+    pose: AbstractPose,
+    transfer_theory: ContrastTransferTheory,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
+    detector: AbstractDetector | None = None,
+    *,
+    quantity_mode: Literal["contrast"] = "contrast",
+    applies_translation: bool = True,
+    normalizes_signal: bool = False,
+    signal_region: Bool[NDArrayLike, "_ _"] | None = None,
+    translate_mode: Literal["fft", "atom"] = "fft",
+) -> ContrastImageModel: ...
+
+
+@overload
+def make_image_model(
+    volume_parametrization: AbstractVolumeParametrization,
+    image_config: AbstractImageConfig,
+    pose: AbstractPose,
+    transfer_theory: ContrastTransferTheory,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
+    detector: AbstractDetector | None = None,
+    *,
+    quantity_mode: Literal["intensity"] = "intensity",
+    applies_translation: bool = True,
+    normalizes_signal: bool = False,
+    signal_region: Bool[NDArrayLike, "_ _"] | None = None,
+    translate_mode: Literal["fft", "atom"] = "fft",
+) -> IntensityImageModel: ...
+
+
+@overload
+def make_image_model(
+    volume_parametrization: AbstractVolumeParametrization,
+    image_config: AbstractImageConfig,
+    pose: AbstractPose,
+    transfer_theory: ContrastTransferTheory,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
+    detector: AbstractDetector | None = None,
+    *,
+    quantity_mode: Literal["counts"] = "counts",
+    applies_translation: bool = True,
+    normalizes_signal: bool = False,
+    signal_region: Bool[NDArrayLike, "_ _"] | None = None,
+    translate_mode: Literal["fft", "atom"] = "fft",
+) -> ElectronCountsImageModel: ...
 
 
 def make_image_model(
@@ -36,14 +113,13 @@ def make_image_model(
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory | None = None,
-    volume_integrator: AbstractVolumeIntegrator | None = None,
+    volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
     detector: AbstractDetector | None = None,
     *,
+    quantity_mode: Literal["contrast", "intensity", "counts"] | None = None,
     applies_translation: bool = True,
     normalizes_signal: bool = False,
     signal_region: Bool[NDArrayLike, "_ _"] | None = None,
-    simulates_quantity: bool = False,
-    quantity_mode: Literal["contrast", "intensity", "counts"] = "contrast",
     translate_mode: Literal["fft", "atom"] = "fft",
 ) -> AbstractImageModel:
     """Construct an `AbstractImageModel` for most common use-cases.
@@ -80,12 +156,9 @@ def make_image_model(
         A boolean array that is 1 where there is signal,
         and 0 otherwise used to normalize the image.
         Must have shape equal to `AbstractImageConfig.shape`.
-    - `simulates_quantity`:
-        If `True`, the image simulated is a physical quantity, which is
-        chosen with the `quantity_mode` argument. Otherwise, simulate an image without
-        scaling to absolute units.
     - `quantity_mode`:
-        The physical observable to simulate. Not used if `simulates_quantity = False`.
+        The physical observable to simulate. If `None`, simulate without scaling
+        to physical units using the `LinearImageModel`.
         Options are
         - 'contrast':
             Uses the `ContrastImageModel` to simulate contrast. This is
@@ -110,11 +183,6 @@ def make_image_model(
     image = image_model.simulate()
     ```
     """
-    # Select default integrator
-    if volume_integrator is None:
-        volume_integrator = _select_default_integrator(
-            volume_parametrization, simulates_quantity
-        )
     if transfer_theory is None:
         # Image model for projections
         image_model = ProjectionImageModel(
@@ -129,7 +197,7 @@ def make_image_model(
         )
     else:
         # Simulate physical observables
-        if simulates_quantity:
+        if quantity_mode is not None:
             scattering_theory = WeakPhaseScatteringTheory(
                 volume_integrator, transfer_theory
             )
@@ -199,23 +267,3 @@ def make_image_model(
             )
 
     return image_model
-
-
-def _select_default_integrator(
-    volume: AbstractVolumeParametrization, simulates_quantity: bool
-) -> AbstractVolumeIntegrator:
-    if isinstance(volume, (FourierVoxelGridVolume, FourierVoxelSplineVolume)):
-        integrator = FourierSliceExtraction(outputs_integral=simulates_quantity)
-    elif isinstance(volume, GaussianMixtureVolume):
-        integrator = GaussianMixtureProjection(sampling_mode="average")
-    elif isinstance(volume, RealVoxelGridVolume):
-        integrator = RealVoxelProjection()
-    elif isinstance(volume, IndependentAtomVolume):
-        integrator = FFTAtomProjection()
-    else:
-        raise ValueError(
-            "Could not select default integrator for volume of "
-            f"type {type(volume).__name__}. If using a custom potential "
-            "please directly pass an integrator."
-        )
-    return integrator

--- a/cryojax/simulator/_volume/__init__.py
+++ b/cryojax/simulator/_volume/__init__.py
@@ -1,3 +1,4 @@
+from .auto_select import AutoVolumeProjection as AutoVolumeProjection
 from .base_volume import (
     AbstractAtomVolume as AbstractAtomVolume,
     AbstractVolumeIntegrator as AbstractVolumeIntegrator,

--- a/cryojax/simulator/_volume/auto_select.py
+++ b/cryojax/simulator/_volume/auto_select.py
@@ -1,0 +1,81 @@
+from typing import Any, ClassVar
+from typing_extensions import override
+
+import equinox as eqx
+
+from .._image_config import AbstractImageConfig
+from .base_volume import (
+    AbstractVolumeIntegrator,
+    AbstractVolumeRepresentation,
+    ProjectionArray,
+    VolRep,
+)
+from .fourier_voxels import (
+    FourierSliceExtraction,
+    FourierVoxelGridVolume,
+    FourierVoxelSplineVolume,
+)
+from .gaussian_volume import GaussianMixtureProjection, GaussianMixtureVolume
+from .independent_atom_volume import FFTAtomProjection, IndependentAtomVolume
+from .real_voxels import RealVoxelGridVolume, RealVoxelProjection
+
+
+class AutoVolumeProjection(AbstractVolumeIntegrator[VolRep]):
+    options: dict[str, Any] = eqx.field(default_factory=dict)
+
+    is_projection_approximation: ClassVar[bool] = True
+
+    def _select_projection_method(
+        self, volume: AbstractVolumeRepresentation
+    ) -> AbstractVolumeIntegrator:
+        if isinstance(volume, (FourierVoxelGridVolume, FourierVoxelSplineVolume)):
+            integrator = FourierSliceExtraction(**self.options)
+        elif isinstance(volume, GaussianMixtureVolume):
+            integrator = GaussianMixtureProjection(**self.options)
+        elif isinstance(volume, RealVoxelGridVolume):
+            integrator = RealVoxelProjection(**self.options)
+        elif isinstance(volume, IndependentAtomVolume):
+            integrator = FFTAtomProjection(**self.options)
+        else:
+            raise ValueError(
+                "Could not use `AutoVolumeProjection` for volume of "
+                f"type {type(volume).__name__}. If using a custom volume, "
+                "please directly pass an integrator."
+            )
+        return integrator
+
+    @override
+    def integrate(
+        self,
+        volume_representation: VolRep,
+        image_config: AbstractImageConfig,
+        outputs_real_space: bool = False,
+    ) -> ProjectionArray:
+        """Automatically select volume projection method given a
+        volume representation.
+
+        **Arguments:**
+
+        - `volume_representation`:
+            The volume representation.
+        - `image_config`:
+            The image configuration.
+        - `outputs_real_space`:
+            If `True`, return the image in real space. Otherwise,
+            return in Fourier.
+
+        **Returns:**
+
+        The volume projection in real or Fourier space at the
+        `AbstractImageConfig.padded_shape` and the `image_config.pixel_size`.
+        """
+        volume_integrator = self._select_projection_method(volume_representation)
+        return volume_integrator.integrate(
+            volume_representation, image_config, outputs_real_space=outputs_real_space
+        )
+
+
+AutoVolumeProjection.__init__.__doc__ = """**Arguments:**
+
+- `options`: Keyword arguments passed to `AbstractVolumeIntegrator.__init__`.
+"""

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -14,6 +14,27 @@ VolRep = TypeVar("VolRep", bound="AbstractVolumeRepresentation")
 T = TypeVar("T")
 
 
+ProjectionOrEwaldSphereArray = (
+    Complex[
+        Array,
+        "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
+    ]
+    | Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+    | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+)
+ProjectionArray = (
+    Complex[
+        Array,
+        "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
+    ]
+    | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+)
+EwaldSphereArray = (
+    Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+    | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+)
+
+
 class AbstractVolumeParametrization(eqx.Module, strict=True):
     """Abstract interface for a parametrization of a volume. Specifically,
     the cryo-EM image formation process typically starts with a *scattering potential*.
@@ -164,14 +185,7 @@ class AbstractVolumeIntegrator(eqx.Module, Generic[VolRep], strict=True):
         volume_representation: VolRep,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ]
-        | Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> ProjectionOrEwaldSphereArray:
         raise NotImplementedError
 
 

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -26,7 +26,12 @@ from ...ndimage import (
 )
 from .._image_config import AbstractImageConfig
 from .._pose import AbstractPose
-from .base_volume import AbstractVolumeIntegrator, AbstractVoxelVolume
+from .base_volume import (
+    AbstractVolumeIntegrator,
+    AbstractVoxelVolume,
+    EwaldSphereArray,
+    ProjectionArray,
+)
 
 
 class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
@@ -275,13 +280,7 @@ class FourierSliceExtraction(
         volume_representation: FourierVoxelGridVolume | FourierVoxelSplineVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> ProjectionArray:
         """Integrate the volume at the `AbstractImageConfig` settings
         of a voxel-based representation in fourier-space,
         using fourier slice extraction.
@@ -291,15 +290,15 @@ class FourierSliceExtraction(
         - `volume_representation`:
             The volume representation.
         - `image_config`:
-            The configuration of the resulting image.
+            The image configuration.
         - `outputs_real_space`:
             If `True`, return the image in real space. Otherwise,
-            return in fourier.
+            return in Fourier.
 
         **Returns:**
 
-        The extracted fourier voxels of the `volume_representation`,
-        at the `image_config.padded_shape` and the `image_config.pixel_size`.
+        The volume projection in real or Fourier space at the
+        `AbstractImageConfig.padded_shape` and the `image_config.pixel_size`.
         """
         frequency_slice = volume_representation.frequency_slice_in_pixels
         N = frequency_slice.shape[1]
@@ -474,23 +473,25 @@ class EwaldSphereExtraction(
         volume_representation: FourierVoxelGridVolume | FourierVoxelSplineVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> EwaldSphereArray:
         """Integrate the volume at the `AbstractImageConfig` settings
         of a voxel-based representation in fourier-space, using fourier
         slice extraction.
 
         **Arguments:**
 
-        - `volume_representation`: The volume representation.
-        - `image_config`: The configuration of the resulting image.
+        - `volume_representation`:
+            The volume representation.
+        - `image_config`:
+            The image configuration.
+        - `outputs_real_space`:
+            If `True`, return the Ewald sphere surface in
+            real space. Otherwise, return in Fourier.
 
         **Returns:**
 
-        The extracted fourier voxels of the `volume_representation`, at the
-        `image_config.padded_shape` and the `image_config.pixel_size`.
+        The Ewald sphere surface in real or Fourier space at the
+        `AbstractImageConfig.padded_shape` and the `image_config.pixel_size`.
         """
         frequency_slice = volume_representation.frequency_slice_in_pixels
         N = frequency_slice.shape[1]

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -7,7 +7,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
-from jaxtyping import Array, Complex, Float, PyTree
+from jaxtyping import Array, Float, Inexact, PyTree
 
 from ...constants import (
     PengScatteringFactorParameters,
@@ -22,6 +22,7 @@ from .base_volume import (
     AbstractAtomVolume,
     AbstractVolumeIntegrator,
     AbstractVolumeRenderFn,
+    ProjectionArray,
 )
 
 
@@ -304,13 +305,7 @@ class GaussianMixtureProjection(
         volume_representation: GaussianMixtureVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> ProjectionArray:
         """Compute a projection from gaussians.
 
         **Arguments:**
@@ -318,15 +313,15 @@ class GaussianMixtureProjection(
         - `volume_representation`:
             The volume representation.
         - `image_config`:
-            The configuration of the resulting image.
+            The image configuration.
         - `outputs_real_space`:
             If `True`, return the image in real space. Otherwise,
-            return in fourier.
+            return in Fourier.
 
         **Returns:**
 
-        The integrated volume in real or fourier space at the
-        `AbstractImageConfig.padded_shape`.
+        The volume projection in real or Fourier space at the
+        `AbstractImageConfig.padded_shape` and the `image_config.pixel_size`.
         """  # noqa: E501
         # Grab the image configuration
         shape = image_config.padded_shape if self.shape is None else self.shape
@@ -443,7 +438,7 @@ class GaussianMixtureRenderFn(AbstractVolumeRenderFn[GaussianMixtureVolume], str
         outputs_real_space: bool = True,
         outputs_rfft: bool = False,
         fftshifted: bool = False,
-    ) -> Float[Array, "{self.shape[0]} {self.shape[1]} {self.shape[2]}"]:
+    ) -> Inexact[Array, "{self.shape[0]} {self.shape[1]} {self.shape[2]}"]:
         """**Arguments:**
 
         - `volume_representation`:

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -5,7 +5,7 @@ from typing_extensions import Self, override
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Complex, Float, PyTree
+from jaxtyping import Array, Float, Inexact, PyTree
 
 from ...constants import PengScatteringFactorParameters
 from ...jax_util import FloatLike, NDArrayLike, error_if_not_positive
@@ -26,6 +26,7 @@ from .base_volume import (
     AbstractAtomVolume,
     AbstractVolumeIntegrator,
     AbstractVolumeRenderFn,
+    ProjectionArray,
 )
 
 
@@ -218,6 +219,13 @@ class FFTAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], strict=True
             See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
             for documentation.
         """
+        if sampling_mode not in ["average", "point"]:
+            raise ValueError(
+                "`sampling_mode` in `FFTAtomRenderFn` "
+                "must be either 'average' for averaging within a "
+                "pixel or 'point' for point sampling. Got "
+                f"`sampling_mode = {sampling_mode}`."
+            )
         self.shape = shape
         self.voxel_size = error_if_not_positive(jnp.asarray(voxel_size, dtype=float))
         self.frequency_grid = frequency_grid
@@ -233,7 +241,7 @@ class FFTAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], strict=True
         outputs_real_space: bool = True,
         outputs_rfft: bool = False,
         fftshifted: bool = False,
-    ) -> Float[Array, "{self.shape[0]} {self.shape[1]} {self.shape[2]}"]:
+    ) -> Inexact[Array, "{self.shape[0]} {self.shape[1]} {self.shape[2]}"]:
         """**Arguments:**
 
         - `volume_representation`:
@@ -383,13 +391,7 @@ class FFTAtomProjection(
         volume_representation: IndependentAtomVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> ProjectionArray:
         """Compute a projection from scattering factors per atom type
         from the `IndependentAtomVolume`.
 
@@ -405,8 +407,8 @@ class FFTAtomProjection(
 
         **Returns:**
 
-        The integrated volume in real or fourier space at the
-        `AbstractImageConfig.padded_shape`.
+        The volume projection in real or Fourier space at the
+        `AbstractImageConfig.padded_shape` and the `image_config.pixel_size`.
         """  # noqa: E501
         u = self.upsample_factor
         pixel_size = image_config.pixel_size

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -8,13 +8,13 @@ from typing_extensions import Self, override
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, Complex, Float
+from jaxtyping import Array, Float
 
 from ...jax_util import NDArrayLike
 from ...ndimage import convert_fftn_to_rfftn, crop_to_shape, irfftn, make_coordinate_grid
 from .._image_config import AbstractImageConfig
 from .._pose import AbstractPose
-from .base_volume import AbstractVolumeIntegrator, AbstractVoxelVolume
+from .base_volume import AbstractVolumeIntegrator, AbstractVoxelVolume, ProjectionArray
 
 
 try:
@@ -142,28 +142,24 @@ class RealVoxelProjection(
         volume_representation: RealVoxelGridVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
-    ) -> (
-        Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ]
-        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
-    ):
+    ) -> ProjectionArray:
         """Integrate the volume at the `AbstractImageConfig` settings
         of a voxel-based representation in real-space, using non-uniform FFTs.
 
         **Arguments:**
 
-        - `volume_representation`: The volume representation.
-        - `image_config`: The configuration of the resulting image.
+        - `volume_representation`:
+            The volume representation.
+        - `image_config`:
+            The image configuration.
         - `outputs_real_space`:
             If `True`, return the image in real space. Otherwise,
-            return in fourier.
+            return in Fourier.
 
         **Returns:**
 
-        The projection integral of the `volume_representation` in fourier space, at the
-        `image_config.padded_shape` and the `image_config.pixel_size`.
+        The volume projection in real or Fourier space, at the
+        `image_config.padded_shape`.
         """
         n_voxels = math.prod(volume_representation.shape)
         fourier_projection = _project_with_nufft(

--- a/docs/api/ndimage.md
+++ b/docs/api/ndimage.md
@@ -28,6 +28,12 @@ This documentation is a collection of functions used to work with coordinate sys
 
 ## Image transforms (filters and masks)
 
+??? abstract "`cryojax.ndimage.AbstractImageTransform`"
+    ::: cryojax.ndimage.AbstractImageTransform
+        options:
+            members:
+                - __init__
+
 ### Filters
 
 ??? abstract "`cryojax.ndimage.AbstractFilter`"

--- a/docs/api/simulator/config.md
+++ b/docs/api/simulator/config.md
@@ -2,10 +2,9 @@
 
 The `AbstractImageConfig` is an object at the core of simulating images in `cryojax`. It stores a configuration for the simulated image and the electron microscope, such as the shape of the desired image and the wavelength of the incident electron beam.
 
-::: cryojax.simulator.AbstractImageConfig
-        options:
+??? abstract "`cryojax.simulator.AbstractImageConfig`"
+    ::: cryojax.simulator.AbstractImageConfig
             members:
-                - __init__
                 - wavelength_in_angstroms
                 - wavenumber_in_inverse_angstroms
                 - lorentz_factor
@@ -31,3 +30,23 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
                 - crop_to_shape
                 - pad_to_padded_shape
                 - crop_or_pad_to_padded_shape
+
+
+---
+
+::: cryojax.simulator.BasicImageConfig
+        options:
+            members:
+                - __init__
+
+---
+
+::: cryojax.simulator.DoseImageConfig
+        options:
+            members:
+                - __init__
+
+::: cryojax.simulator.GridHelper
+        options:
+            members:
+                - __init__

--- a/docs/api/simulator/detector.md
+++ b/docs/api/simulator/detector.md
@@ -1,0 +1,13 @@
+# Detectors
+
+???+ abstract "`cryojax.simulator.AbstractDetector`"
+    ::: cryojax.simulator.AbstractDetector
+        options:
+            members:
+                - sample_readout_from_expected_events
+
+??? abstract "`cryojax.simulator.AbstractDQE`"
+    ::: cryojax.simulator.AbstractDQE
+        options:
+            members:
+                - __call__

--- a/docs/api/simulator/entry-point.md
+++ b/docs/api/simulator/entry-point.md
@@ -1,1 +1,3 @@
 # Your entry point
+
+::: cryojax.simulator.make_image_model

--- a/docs/api/simulator/image_model.md
+++ b/docs/api/simulator/image_model.md
@@ -1,1 +1,54 @@
-# Rendering an image
+# Image formation models
+
+???+ abstract "`cryojax.simulator.AbstractImageModel`"
+    ::: cryojax.simulator.AbstractImageModel
+        options:
+            members:
+                - compute_fourier_image
+                - get_pose
+                - get_signal_region
+                - get_image_config
+
+::: cryojax.simulator.LinearImageModel
+        options:
+            members:
+                - __init__
+                - simulate
+                - postprocess
+
+---
+
+::: cryojax.simulator.ProjectionImageModel
+        options:
+            members:
+                - __init__
+                - simulate
+                - postprocess
+
+
+---
+
+::: cryojax.simulator.ContrastImageModel
+        options:
+            members:
+                - __init__
+                - simulate
+                - postprocess
+
+---
+
+::: cryojax.simulator.IntensityImageModel
+        options:
+            members:
+                - __init__
+                - simulate
+                - postprocess
+
+---
+
+::: cryojax.simulator.ElectronCountsImageModel
+        options:
+            members:
+                - __init__
+                - simulate
+                - postprocess

--- a/docs/api/simulator/integrator.md
+++ b/docs/api/simulator/integrator.md
@@ -8,6 +8,13 @@
             members:
                 - integrate
 
+
+::: cryojax.simulator.AutoVolumeProjection
+        options:
+            members:
+                - __init__
+                - integrate
+
 ## Integration methods for voxel-based structures
 
 ::: cryojax.simulator.FourierSliceExtraction

--- a/docs/api/simulator/scattering_theory.md
+++ b/docs/api/simulator/scattering_theory.md
@@ -1,1 +1,8 @@
 # Scattering approximations
+
+??? abstract "`cryojax.simulator.AbstractScatteringTheory`"
+    ::: cryojax.simulator.AbstractScatteringTheory
+        options:
+            members:
+                - compute_contrast_spectrum
+                - compute_intensity_spectrum

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
                 - 'api/simulator/integrator.md'
                 - 'api/simulator/transfer_theory.md'
                 - 'api/simulator/scattering_theory.md'
+                - 'api/simulator/detector.md'
             - Putting it all together:
                 - 'api/simulator/config.md'
                 - 'api/simulator/image_model.md'

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -102,7 +102,7 @@ def test_even_vs_odd_image_shape(extra_dim_y, extra_dim_x, volume_and_pixel_size
     np.testing.assert_allclose(
         crop_to_shape(model_test.simulate(), control_shape),
         model_control.simulate(),
-        atol=1e-4,
+        atol=1e-3,
     )
 
 


### PR DESCRIPTION
Adds:

- `AutoVolumeProjection` for integrator auto selection. This deprecates `make_image_model(..., volume_integrator=None)`
-  Overloads for `make_image_model`. To implement these, needed to remove `simulates_quantity` keyword.

Also adds `make_image_model` to documentation.