### PR TITLE
Simplify `IndependentAtomVolume` field names: `positions_pytree` -> `positions` and `scattering_factor_pytree` -> `scattering_factors`

### DIFF
--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -321,7 +321,7 @@ class LinearImageModel(AbstractImageModel, strict=True):
         fourier_image = self.transfer_theory.propagate_object(  # noqa: E501
             fourier_image,
             self.image_config,
-            is_projection_approximation=self.volume_integrator.is_projection_approximation,
+            input_is_ewald_sphere=self.volume_integrator.outputs_ewald_sphere,
             defocus_offset=self.pose.offset_z_in_angstroms,
         )
         # Now for the in-plane translation if using phase shifts

--- a/cryojax/simulator/_scattering_theory.py
+++ b/cryojax/simulator/_scattering_theory.py
@@ -147,7 +147,7 @@ class WeakPhaseScatteringTheory(AbstractScatteringTheory, strict=True):
                     rng_key,
                     fourier_in_plane_potential,
                     image_config,
-                    input_is_rfft=self.volume_integrator.is_projection_approximation,
+                    input_is_rfft=not self.volume_integrator.outputs_ewald_sphere,
                 )
 
         object_spectrum = image_config.interaction_constant * fourier_in_plane_potential
@@ -168,7 +168,7 @@ class WeakPhaseScatteringTheory(AbstractScatteringTheory, strict=True):
         contrast_spectrum = self.transfer_theory.propagate_object(  # noqa: E501
             object_spectrum,
             image_config,
-            is_projection_approximation=self.volume_integrator.is_projection_approximation,
+            input_is_ewald_sphere=self.volume_integrator.outputs_ewald_sphere,
             defocus_offset=defocus_offset,
         )
 
@@ -258,7 +258,7 @@ class StrongPhaseScatteringTheory(AbstractWaveScatteringTheory, strict=True):
         )
         # The integrated potential may not be from an rfft; this depends on
         # if it is a projection approx
-        is_projection_approx = self.volume_integrator.is_projection_approximation
+        is_projection_approx = not self.volume_integrator.outputs_ewald_sphere
         if rng_key is not None:
             # Get the potential of the specimen plus the ice
             if self.solvent is not None:

--- a/cryojax/simulator/_transfer_theory/transfer_theory.py
+++ b/cryojax/simulator/_transfer_theory/transfer_theory.py
@@ -65,7 +65,7 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
         image_config: AbstractImageConfig,
         *,
         defocus_offset: FloatLike | None = None,
-        is_projection_approximation: bool = True,
+        input_is_ewald_sphere: bool = False,
     ) -> Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]:
         """Apply the CTF directly to the phase shifts in the exit plane.
 
@@ -76,10 +76,10 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
             below it.
         - `image_config`:
             The configuration of the resulting image.
-        - `is_projection_approximation`:
-            If `True`, the `object_spectrum_in_exit_plane` is a projection
+        - `input_is_ewald_sphere`:
+            If `False`, the `object_spectrum_in_exit_plane` is a projection
             approximation and is therefore the fourier transform of a real-valued
-            array. If `False`, `object_spectrum_in_exit_plane` is extracted from
+            array. If `True`, `object_spectrum_in_exit_plane` is extracted from
             the ewald sphere and is therefore the fourier transform of a complex-valued
             array.
         - `defocus_offset`:
@@ -87,7 +87,7 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
             runtime.
         """
         frequency_grid = image_config.padded_frequency_grid_in_angstroms
-        if is_projection_approximation:
+        if not input_is_ewald_sphere:
             # Compute the CTF, including additional phase shifts
             ctf_array = self.ctf(
                 frequency_grid,

--- a/cryojax/simulator/_volume/auto_select.py
+++ b/cryojax/simulator/_volume/auto_select.py
@@ -23,7 +23,7 @@ from .real_voxels import RealVoxelGridVolume, RealVoxelProjection
 class AutoVolumeProjection(AbstractVolumeIntegrator[VolRep]):
     options: dict[str, Any] = eqx.field(default_factory=dict)
 
-    is_projection_approximation: ClassVar[bool] = True
+    outputs_ewald_sphere: ClassVar[bool] = False
 
     def _select_projection_method(
         self, volume: AbstractVolumeRepresentation

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -177,7 +177,7 @@ class AbstractVolumeIntegrator(eqx.Module, Generic[VolRep], strict=True):
     the exit plane.
     """
 
-    is_projection_approximation: eqx.AbstractClassVar[bool]
+    outputs_ewald_sphere: eqx.AbstractClassVar[bool]
 
     @abc.abstractmethod
     def integrate(

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -240,7 +240,7 @@ class FourierSliceExtraction(
     out_of_bounds_mode: str
     fill_value: complex
 
-    is_projection_approximation: ClassVar[bool] = True
+    outputs_ewald_sphere: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -433,7 +433,7 @@ class EwaldSphereExtraction(
     out_of_bounds_mode: str
     fill_value: complex
 
-    is_projection_approximation: ClassVar[bool] = False
+    outputs_ewald_sphere: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -246,7 +246,7 @@ class GaussianMixtureProjection(
     shape: tuple[int, int] | None
     n_batches: int
 
-    is_projection_approximation: ClassVar[bool] = True
+    outputs_ewald_sphere: ClassVar[bool] = False
 
     def __init__(
         self,

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -70,38 +70,43 @@ class PengScatteringFactor(AbstractFourierOperator, strict=True):
 
 
 class IndependentAtomVolume(AbstractAtomVolume, strict=True):
-    position_pytree: PyTree[Float[Array, "_ 3"]]
-    scattering_factor_pytree: PyTree[AbstractFourierOperator]
+    positions: PyTree[Float[Array, "_ 3"]]
+    scattering_factors: PyTree[AbstractFourierOperator]
 
     def __init__(
         self,
-        position_pytree: PyTree[Float[NDArrayLike, "_ 3"], "T"],
-        scattering_factor_pytree: PyTree[AbstractFourierOperator, "T"],
+        positions: PyTree[Float[NDArrayLike, "_ 3"], "T"],
+        scattering_factors: PyTree[AbstractFourierOperator, "T"],
     ):
-        self.position_pytree = jax.tree.map(
-            lambda x: jnp.asarray(x, dtype=float), position_pytree
-        )
-        self.scattering_factor_pytree = scattering_factor_pytree
+        """**Arguments:**
 
-    def __check_init__(self):
-        if jax.tree.structure(self.position_pytree) != jax.tree.structure(
-            self.scattering_factor_pytree,
+        - `positions`:
+            A pytree of atom positions.
+        - `scattering_factors`:
+            A pytree of scattering factors with the same tree structure
+            as `positions`, where each leaf is a
+            [`cryojax.ndimage.AbstractFourierOperator`][].
+        """
+        if jax.tree.structure(positions) != jax.tree.structure(
+            scattering_factors,
             is_leaf=lambda x: isinstance(x, AbstractFourierOperator),
         ):
             raise ValueError(
                 "When instantiating an `IndependentAtomVolume`, found "
-                "that the pytree structures of `positions_pytree` and "
-                "`scattering_factor_pytree` were not equal."
+                "that the pytree structures of `positions` and "
+                "`scattering_factors` were not equal."
             )
+        self.positions = jax.tree.map(lambda x: jnp.asarray(x, dtype=float), positions)
+        self.scattering_factors = scattering_factors
 
     @override
     def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
         """Return a new potential with rotated `positions`."""
         rotate_fn = lambda pos: pose.rotate_coordinates(pos, inverse=inverse)
         return eqx.tree_at(
-            lambda x: x.position_pytree,
+            lambda x: x.positions,
             self,
-            jax.tree.map(rotate_fn, self.position_pytree),
+            jax.tree.map(rotate_fn, self.positions),
         )
 
     @override
@@ -114,9 +119,9 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
             )
         translate_fn = lambda pos: pos + offset_in_angstroms
         return eqx.tree_at(
-            lambda x: x.position_pytree,
+            lambda x: x.positions,
             self,
-            jax.tree.map(translate_fn, self.position_pytree),
+            jax.tree.map(translate_fn, self.positions),
         )
 
     @classmethod
@@ -280,8 +285,8 @@ class FFTAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], strict=True
             lambda x, y: x + y,
             jax.tree.map(
                 proj_kernel,
-                volume_representation.position_pytree,
-                volume_representation.scattering_factor_pytree,
+                volume_representation.positions,
+                volume_representation.scattering_factors,
                 is_leaf=lambda x: isinstance(x, AbstractFourierOperator),
             ),
         )
@@ -438,8 +443,8 @@ class FFTAtomProjection(
             lambda x, y: x + y,
             jax.tree.map(
                 proj_kernel,
-                volume_representation.position_pytree,
-                volume_representation.scattering_factor_pytree,
+                volume_representation.positions,
+                volume_representation.scattering_factors,
                 is_leaf=lambda x: isinstance(x, AbstractFourierOperator),
             ),
         )

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -326,7 +326,7 @@ class FFTAtomProjection(
     eps: float
     opts: Any
 
-    is_projection_approximation: ClassVar[bool] = True
+    outputs_ewald_sphere: ClassVar[bool] = False
 
     def __init__(
         self,

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -112,7 +112,7 @@ class RealVoxelProjection(
     eps: float
     opts: Any
 
-    is_projection_approximation: ClassVar[bool] = True
+    outputs_ewald_sphere: ClassVar[bool] = False
 
     def __init__(self, *, eps: float = 1e-6, opts: Any = None):
         """**Arguments:**

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -62,8 +62,8 @@ def test_gmm_integrator_shape(sample_pdb_path, shape):
 def test_fft_atom_bad_instantiation():
     with pytest.raises(ValueError):
         _ = cxs.IndependentAtomVolume(
-            position_pytree=np.zeros((10, 3)),
-            scattering_factor_pytree=(im.FourierGaussian(),),
+            positions=np.zeros((10, 3)),
+            scattering_factors=(im.FourierGaussian(),),
         )
     with pytest.raises(ValueError):
         _ = cxs.FFTAtomProjection(upsample_factor=2)
@@ -92,8 +92,8 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
         )
         atom_volume, fft_integrator = (
             cxs.IndependentAtomVolume(
-                position_pytree=atom_positions,
-                scattering_factor_pytree=im.FourierGaussian(
+                positions=atom_positions,
+                scattering_factors=im.FourierGaussian(
                     amplitude=amplitude, b_factor=b_factor
                 ),
             ),
@@ -125,8 +125,8 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
             variances=width**2,
         )
         atom_volume = cxs.IndependentAtomVolume(
-            position_pytree=atom_positions,
-            scattering_factor_pytree=im.FourierGaussian(
+            positions=atom_positions,
+            scattering_factors=im.FourierGaussian(
                 amplitude=1.0, b_factor=width**2 * (8 * np.pi**2)
             ),
         )

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -169,8 +169,8 @@ def test_render_options(pdb_info):
     if jnufft is not None:
         volumes.append(
             cxs.IndependentAtomVolume(
-                position_pytree=atom_positions,
-                scattering_factor_pytree=im.FourierGaussian(
+                positions=atom_positions,
+                scattering_factors=im.FourierGaussian(
                     amplitude=1.0, b_factor=width**2 * (8 * np.pi**2)
                 ),
             )
@@ -209,8 +209,8 @@ def test_fft_atom_render(pdb_info, width, voxel_size, shape):
             variances=width**2,
         )
         atom_volume = cxs.IndependentAtomVolume(
-            position_pytree=atom_positions,
-            scattering_factor_pytree=im.FourierGaussian(
+            positions=atom_positions,
+            scattering_factors=im.FourierGaussian(
                 amplitude=1.0, b_factor=width**2 * (8 * np.pi**2)
             ),
         )


### PR DESCRIPTION
Even though the fields of `IndependentAtomVolume` are pytree-valued, it is easier to have them named `positions` and `scattering_factors` rather than including `*_pytree` as this will be more clear for the majority of users.