### PR TITLE
Support upsampling by even integers in `block_reduce_downsample` and `FFTAtomProjection`

### DIFF
--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -18,8 +18,12 @@ def block_reduce_downsample(
     downsample_factor: int,
     operation: Callable[[Array, Array], Array] = lax.add,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
-    """Downsample an array by pooling together blocks, keeping
-    the center position of the array unchanged. Wraps `equinox.nn.Pool`.
+    """Downsample an array by pooling together blocks.
+    Wraps `equinox.nn.Pool`.
+
+    !!! warning
+        If `downsample_factor` is even, the center of the array
+        is shifted.
 
     **Arguments:**
 
@@ -62,17 +66,10 @@ def block_reduce_downsample(
     # Pooling function downsamples array
     shape = array.shape
     kernel_size = array.ndim * (downsample_factor,)
-    if downsample_factor % 2 == 0:
-        raise ValueError(
-            "Called `block_reduce_downsample` with "
-            f"`downsample_factor = {downsample_factor}`, but "
-            "only odd-valued numbers are supported."
-        )
-    else:
-        padding = tuple(
-            ((k - 1) // 2, (k - 1) // 2) if s % 2 == 0 else (0, 0)
-            for k, s in zip(kernel_size, shape)
-        )
+    padding = tuple(
+        ((k - 1) // 2, (k - 1) // 2) if s % 2 == 0 else (0, 0)
+        for k, s in zip(kernel_size, shape)
+    )
     block_reduce_fn = lambda x: eqx.nn.Pool(
         init=jnp.asarray(0.0, array.dtype),
         operation=operation,

--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -9,6 +9,7 @@ from jax import lax
 from jaxtyping import Array, Complex, Float, Inexact
 
 from ..jax_util import NDArrayLike
+from ._coordinates import make_frequency_grid
 from ._edges import crop_to_shape
 from ._fft import fftn, ifftn, rfftn
 
@@ -17,13 +18,10 @@ def block_reduce_downsample(
     image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
     downsample_factor: int,
     operation: Callable[[Array, Array], Array] = lax.add,
+    center_correct: bool = True,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
     """Downsample an array by pooling together blocks.
     Wraps `equinox.nn.Pool`.
-
-    !!! warning
-        If `downsample_factor` is even, the center of the array
-        is shifted.
 
     **Arguments:**
 
@@ -38,14 +36,18 @@ def block_reduce_downsample(
         where `x` and `y` are JAX arrays. See [`equinox.nn.Pool`]
         (https://docs.kidger.site/equinox/api/nn/pool/#equinox.nn.Pool)
         for documentation.
+    - `center_correct`:
+        If `True`, apply a phase shift in the fourier domain to correct
+        the array center after downsampling. Applies only to even
+        `downsample_factor`.
 
     **Returns:**
 
     The downsampled `image_or_volume` at shape reduced by
     `downsample_factor`.
     """
-    array = image_or_volume
-    if downsample_factor < 1:
+    array, k = image_or_volume, downsample_factor
+    if k < 1:
         raise ValueError(
             "Called `block_reduce_downsample` with `downsample_factor` less than 1."
         )
@@ -55,7 +57,7 @@ def block_reduce_downsample(
             f"`ndim = {array.ndim}`, but this function "
             "only supports images and volumes as input."
         )
-    if any(s % downsample_factor != 0 for s in array.shape):
+    if any(s % k != 0 for s in array.shape):
         raise ValueError(
             "`block_reduce_downsample` only supports "
             "downsampling arrays with dimensions that "
@@ -65,11 +67,33 @@ def block_reduce_downsample(
         )
     # Pooling function downsamples array
     shape = array.shape
-    kernel_size = array.ndim * (downsample_factor,)
-    padding = tuple(
-        ((k - 1) // 2, (k - 1) // 2) if s % 2 == 0 else (0, 0)
-        for k, s in zip(kernel_size, shape)
-    )
+    target_shape = tuple(s // k for s in shape)
+    kernel_size = array.ndim * (k,)
+    if k % 2 == 1:
+        padding = tuple(
+            ((k - 1) // 2, (k - 1) // 2) if s % 2 == 0 else (0, 0)
+            for k, s in zip(kernel_size, shape)
+        )
+    else:
+        padding = tuple((0, 0) for _ in shape)
+        if center_correct:
+            is_complex = jnp.iscomplexobj(array)
+            q = make_frequency_grid(array.shape, outputs_rfftfreqs=False)
+            if len(set(target_shape)) > 1:
+                raise NotImplementedError(
+                    "Tried to call `block_reduce_downsample` "
+                    "with `center_correct = True`, even `downsample_factor`, "
+                    "and a non-square image/volume. This is not implemented."
+                )
+            dim = target_shape[0]
+            if dim % 2 == 0:
+                shift = jnp.full((array.ndim,), (k - 1) / 2)
+            else:
+                shift = jnp.full((array.ndim,), -0.5)
+            phase_shift = jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(q, shift)))
+            array = ifftn(phase_shift * fftn(array))
+            if not is_complex:
+                array = array.real
     block_reduce_fn = lambda x: eqx.nn.Pool(
         init=jnp.asarray(0.0, array.dtype),
         operation=operation,

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -490,15 +490,16 @@ class FFTAtomProjection(
         if self.sampling_mode == "average":
             antialias_fn = FourierSinc(box_width=pixel_size_u)
             fourier_projection *= antialias_fn(frequency_grid)
-        # Shift zero frequency component to corner and convert to
-        # rfft
+        # If upsample factor is even, need subpixel center correction
         if u is not None and u % 2 == 0:
-            fourier_projection = _half_pixel_shift(
+            fourier_projection = _apply_subpixel_shift(
                 shape,
                 fourier_projection,
                 pixel_size_u * frequency_grid,
                 u,
             )
+        # Shift zero frequency component to corner and convert to
+        # rfft
         fourier_projection = convert_fftn_to_rfftn(
             jnp.fft.ifftshift(fourier_projection), mode="real"
         )
@@ -579,21 +580,24 @@ def _project_with_nufft(shape, ps, pos, kernel, freqs, eps=1e-6, opts=None):
 
 
 def _block_average(x, factor):
-    return block_reduce_downsample(x, factor, jax.lax.add) / factor**x.ndim
+    return (
+        block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
+        / factor**x.ndim
+    )
 
 
-def _half_pixel_shift(target_shape, fourier_image, frequency_grid, k):
-    # TODO: not correct for non-square images
+def _apply_subpixel_shift(target_shape, fourier_image, frequency_grid, k):
     if len(set(target_shape)) > 1:
         raise NotImplementedError(
             "Even `upsample_factor` and non-square image shape not "
             f"supported in `FFTAtomProjection`. Got `upsample_factor = {k}` "
             f"and `shape = {target_shape}`."
         )
-    shift = jnp.asarray(
-        tuple((0.5 if s % 2 == 0 else -(k - 1) / 2) for s in target_shape), dtype=float
+    dim = target_shape[0]
+    if dim % 2 == 0:
+        shift = jnp.full((2,), (k - 1) / 2)
+    else:
+        shift = jnp.full((2,), -0.5)
+    return (
+        jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid, shift))) * fourier_image
     )
-    translation_operator = jnp.exp(
-        -1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid, shift))
-    )
-    return fourier_image * translation_operator

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -579,10 +579,7 @@ def _project_with_nufft(shape, ps, pos, kernel, freqs, eps=1e-6, opts=None):
 
 
 def _block_average(x, factor):
-    return (
-        block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
-        / factor**x.ndim
-    )
+    return block_reduce_downsample(x, factor, jax.lax.add) / factor**x.ndim
 
 
 def _half_pixel_shift(target_shape, fourier_image, frequency_grid, k):

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -428,14 +428,6 @@ class FFTAtomProjection(
         self.eps = eps
         self.opts = opts
 
-    def __check_init__(self):
-        if self.upsample_factor is not None:
-            if self.upsample_factor % 2 == 0:
-                raise ValueError(
-                    f"Set `upsample_factor = {self.upsample_factor}` when instantiating "
-                    "`FFTAtomProjection`, but only odd `upsample_factor` are supported."
-                )
-
     @override
     def integrate(
         self,
@@ -500,6 +492,13 @@ class FFTAtomProjection(
             fourier_projection *= antialias_fn(frequency_grid)
         # Shift zero frequency component to corner and convert to
         # rfft
+        if u is not None and u % 2 == 0:
+            fourier_projection = _half_pixel_shift(
+                shape,
+                fourier_projection,
+                pixel_size_u * frequency_grid,
+                u,
+            )
         fourier_projection = convert_fftn_to_rfftn(
             jnp.fft.ifftshift(fourier_projection), mode="real"
         )
@@ -580,4 +579,24 @@ def _project_with_nufft(shape, ps, pos, kernel, freqs, eps=1e-6, opts=None):
 
 
 def _block_average(x, factor):
-    return block_reduce_downsample(x, factor, jax.lax.add) / factor**x.ndim
+    return (
+        block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
+        / factor**x.ndim
+    )
+
+
+def _half_pixel_shift(target_shape, fourier_image, frequency_grid, k):
+    # TODO: not correct for non-square images
+    if len(set(target_shape)) > 1:
+        raise NotImplementedError(
+            "Even `upsample_factor` and non-square image shape not "
+            f"supported in `FFTAtomProjection`. Got `upsample_factor = {k}` "
+            f"and `shape = {target_shape}`."
+        )
+    shift = jnp.asarray(
+        tuple((0.5 if s % 2 == 0 else -(k - 1) / 2) for s in target_shape), dtype=float
+    )
+    translation_operator = jnp.exp(
+        -1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid, shift))
+    )
+    return fourier_image * translation_operator

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -56,8 +56,8 @@ def test_fft_atom_bad_instantiation():
             positions=np.zeros((10, 3)),
             scattering_factors=(im.FourierGaussian(),),
         )
-    with pytest.raises(ValueError):
-        _ = cxs.FFTAtomProjection(upsample_factor=2)
+    # with pytest.raises(ValueError):
+    #     _ = cxs.FFTAtomProjection(upsample_factor=2)
 
 
 @pytest.mark.parametrize(
@@ -138,6 +138,11 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 @pytest.mark.parametrize(
     "pixel_size, shape, upsample_factor",
     (
+        (0.25, (127, 127), 2),
+        (0.25, (128, 128), 6),
+        (0.25, (127, 127), 4),
+        (0.25, (128, 128), 6),
+        (0.25, (127, 127), 4),
         (0.25, (128, 128), 5),
         (0.25, (127, 127), 5),
         (0.25, (127, 128), 5),
@@ -173,7 +178,7 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsample_factor):
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_fft = compute_projection(atom_volume, fft_integrator, image_config)
-        np.testing.assert_allclose(proj_by_gaussians, proj_by_fft, atol=1e-3)
+        np.testing.assert_allclose(proj_by_gaussians, proj_by_fft, atol=5e-3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -138,9 +138,7 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 @pytest.mark.parametrize(
     "pixel_size, shape, upsample_factor",
     (
-        (0.25, (128, 128), 6),
-        (0.25, (127, 127), 4),
-        (0.25, (128, 128), 6),
+        (0.25, (128, 128), 4),
         (0.25, (127, 127), 4),
         (0.25, (128, 128), 5),
         (0.25, (127, 127), 5),

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -138,7 +138,6 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 @pytest.mark.parametrize(
     "pixel_size, shape, upsample_factor",
     (
-        (0.25, (127, 127), 2),
         (0.25, (128, 128), 6),
         (0.25, (127, 127), 4),
         (0.25, (128, 128), 6),


### PR DESCRIPTION
Add center correction when upsampling by even integers. Was too computationally burdensome to only support odd integers. Does not support rectangular images / volumes.