### PR TITLE
Remove `image_model.simulate(..., removes_padding=...)` in favor of `image_model.raw_simulate(...)`

### DIFF
--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -78,7 +78,6 @@ class AbstractImageModel(eqx.Module, strict=True):
         self,
         rng_key: PRNGKeyArray | None = None,
         *,
-        removes_padding: bool = True,
         outputs_real_space: bool = True,
         mask: AbstractMask | None = None,
         filter: AbstractFilter | None = None,
@@ -90,11 +89,6 @@ class AbstractImageModel(eqx.Module, strict=True):
         - `rng_key`:
             The random number generator key. If not passed, render an image
             with no stochasticity.
-        - `removes_padding`:
-            If `True`, return an image cropped to `image_config.shape`.
-            Otherwise, return an image at the `image_config.padded_shape`.
-            If `removes_padding = False`, the `filter`, `mask`, and
-            `image_model.transform` are not applied.
         - `outputs_real_space`:
             If `True`, return the image in real space.
         - `mask`:
@@ -104,12 +98,12 @@ class AbstractImageModel(eqx.Module, strict=True):
         """
         fourier_image = self.raw_simulate(rng_key, outputs_real_space=False)
 
-        return self._maybe_postprocess(
+        return self.postprocess(
             fourier_image,
-            removes_padding=removes_padding,
             outputs_real_space=outputs_real_space,
             mask=mask,
             filter=filter,
+            apply_transform=True,
         )
 
     def postprocess(
@@ -218,31 +212,6 @@ class AbstractImageModel(eqx.Module, strict=True):
         image = (image - mean) / std
 
         return image
-
-    def _maybe_postprocess(
-        self,
-        image: Array,
-        *,
-        removes_padding: bool = True,
-        outputs_real_space: bool = True,
-        mask: AbstractMask | None = None,
-        filter: AbstractFilter | None = None,
-        apply_transform: bool = True,
-    ) -> Array:
-        if removes_padding:
-            return self.postprocess(
-                image,
-                outputs_real_space=outputs_real_space,
-                mask=mask,
-                filter=filter,
-                apply_transform=apply_transform,
-            )
-        else:
-            return (
-                irfftn(image, s=self.image_config.padded_shape)
-                if outputs_real_space
-                else image
-            )
 
 
 class LinearImageModel(AbstractImageModel, strict=True):

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -52,8 +52,8 @@ def image_model(voxel_volume, basic_config):
 def test_real_shape(model, request):
     """Make sure shapes are as expected in real space."""
     model = request.getfixturevalue(model)
-    image = model.simulate()
-    padded_image = model.simulate(removes_padding=False)
+    image = model.simulate(outputs_real_space=True)
+    padded_image = model.raw_simulate(outputs_real_space=True)
     assert image.shape == model.image_config.shape
     assert padded_image.shape == model.image_config.padded_shape
 
@@ -63,7 +63,7 @@ def test_fourier_shape(model, request):
     """Make sure shapes are as expected in fourier space."""
     model = request.getfixturevalue(model)
     image = model.simulate(outputs_real_space=False)
-    padded_image = model.simulate(removes_padding=False, outputs_real_space=False)
+    padded_image = model.raw_simulate(outputs_real_space=False)
     assert image.shape == model.image_config.frequency_grid_in_pixels.shape[0:2]
     assert (
         padded_image.shape


### PR DESCRIPTION
This option is from an older version of the code and is a bit confusing. Now that `image_model.raw_simulate` is a more mature interface, it should be removed.