### PR TITLE
Tweaks to finalize `cryojax.ndimage` namespace

### DIFF
--- a/cryojax/ndimage/__init__.py
+++ b/cryojax/ndimage/__init__.py
@@ -34,7 +34,7 @@ from ._fourier_statistics import (
 )
 from ._fourier_utils import (
     convert_fftn_to_rfftn as convert_fftn_to_rfftn,
-    enforce_self_conjugate_rfftn_components as enforce_self_conjugate_rfftn_components,
+    enforce_rfftn_self_conjugates as enforce_rfftn_self_conjugates,
 )
 from ._map_coordinates import (
     compute_spline_coefficients as compute_spline_coefficients,
@@ -44,7 +44,9 @@ from ._map_coordinates import (
 from ._normalize import (
     background_subtract_image as background_subtract_image,
     compute_edge_value as compute_edge_value,
+    rescale_fft as rescale_fft,
     rescale_image as rescale_image,
+    standardize_fft as standardize_fft,
     standardize_image as standardize_image,
 )
 from ._operators import (
@@ -76,10 +78,10 @@ from ._transforms import (
     CustomMask as CustomMask,
     Cylindrical2DCosineMask as Cylindrical2DCosineMask,
     HighpassFilter as HighpassFilter,
-    ImageScaling as ImageScaling,
     LowpassFilter as LowpassFilter,
     Rectangular2DCosineMask as Rectangular2DCosineMask,
     Rectangular3DCosineMask as Rectangular3DCosineMask,
+    ScaleImage as ScaleImage,
     SincCorrectionMask as SincCorrectionMask,
     SphericalCosineMask as SphericalCosineMask,
     SquareCosineMask as SquareCosineMask,

--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -25,7 +25,7 @@ def convert_fftn_to_rfftn(
     - `fftn_array`:
         The output of a call to `jax.numpy.fft.fftn`.
     - `mode`:
-        See the function`enforce_self_conjugate_rfftn_components`
+        See the function`enforce_rfftn_self_conjugates`
         for documentation. If this is `None`, do not call this
         function.
 
@@ -48,22 +48,22 @@ def convert_fftn_to_rfftn(
             f"Passed an array with `ndim = {fftn_array.ndim}`."
         )
     if mode is not None:
-        rfftn_array = enforce_self_conjugate_rfftn_components(
+        rfftn_array = enforce_rfftn_self_conjugates(
             rfftn_array,
-            shape,  # type: ignore
-            includes_zero_frequency=False,
-            mode=mode,
+            shape,
+            includes_dc=False,
+            mode=mode,  # type: ignore
         )
     return rfftn_array
 
 
-def enforce_self_conjugate_rfftn_components(
+def enforce_rfftn_self_conjugates(
     rfftn_array: (
         Complex[Array, "{shape[0]} {shape[1]}//2+1"]
         | Complex[Array, "{shape[0]} {shape[1]} {shape[2]}//2+1"]
     ),
     shape: tuple[int, int] | tuple[int, int, int],
-    includes_zero_frequency: bool = False,
+    includes_dc: bool = False,
     mode: Literal["zero", "one", "real"] = "zero",
 ) -> (
     Complex[Array, "{shape[0]} {shape[1]}//2+1"]
@@ -83,7 +83,7 @@ def enforce_self_conjugate_rfftn_components(
         component in the corner.
     - `shape`:
         The shape of the `rfftn_array` in real-space.
-    - `includes_zero_frequency`:
+    - `includes_dc`:
         If `True`, enforce that `rfftn_array[0, 0]` is real.
         Otherwise, leave this component unmodified.
     - `mode`:
@@ -110,13 +110,13 @@ def enforce_self_conjugate_rfftn_components(
     else:
         raise NotImplementedError(
             f"`mode = {mode}` not supported for function "
-            "`enforce_self_conjugate_rfftn_components`. "
+            "`enforce_rfftn_self_conjugates`. "
             "The supported modes are 'zero', 'one', and 'real'."
         )
     if rfftn_array.ndim == 2:
         assert len(shape) == 2
         y_dim, x_dim = shape
-        if includes_zero_frequency:
+        if includes_dc:
             rfftn_array = rfftn_array.at[0, 0].set(replace_fn(rfftn_array[0, 0]))
         if y_dim % 2 == 0:
             rfftn_array = rfftn_array.at[y_dim // 2, 0].set(
@@ -133,7 +133,7 @@ def enforce_self_conjugate_rfftn_components(
     elif rfftn_array.ndim == 3:
         assert len(shape) == 3
         z_dim, y_dim, x_dim = shape
-        if includes_zero_frequency:
+        if includes_dc:
             rfftn_array = rfftn_array.at[0, 0, 0].set(replace_fn(rfftn_array[0, 0, 0]))
         if z_dim % 2 == 0:
             rfftn_array = rfftn_array.at[0, z_dim // 2, 0].set(
@@ -166,7 +166,7 @@ def enforce_self_conjugate_rfftn_components(
     else:
         raise NotImplementedError(
             "Only 2D and 3D arrays are supported "
-            "in function `enforce_self_conjugate_rfftn_components`. "
+            "in function `enforce_rfftn_self_conjugates`. "
             f"Passed an array with `ndim = {rfftn_array.ndim}`."
         )
     return rfftn_array

--- a/cryojax/ndimage/_normalize.py
+++ b/cryojax/ndimage/_normalize.py
@@ -5,7 +5,7 @@ Image normalization routines.
 import math
 
 import jax.numpy as jnp
-from jaxtyping import Array, Bool, Float, Inexact
+from jaxtyping import Array, Bool, Complex, Float, Inexact
 
 from ..jax_util import FloatLike, NDArrayLike
 
@@ -15,10 +15,7 @@ def rescale_image(
     mean: FloatLike = 0.0,
     std: FloatLike = 1.0,
     *,
-    input_is_real_space: bool = True,
     where: Bool[Array, "y_dim x_dim"] | None = None,
-    input_is_rfft: bool = True,
-    shape_in_real_space: tuple[int, int] | None = None,
 ) -> Inexact[Array, "y_dim x_dim"]:
     """Normalize so that the image is mean `mean`
     and standard deviation `std` in real space.
@@ -26,17 +23,11 @@ def rescale_image(
     **Parameters:**
 
     - `image`:
-        The image in either the real or fourier domain.
-        If in fourier, pass `input_is_real_space = True`
-        and ensure the zero frequency
-        component is in the corner.
-    - `std`:
-        Rescale to this standard deviation.
+        The image in real-space.
     - `mean`:
         Rescale to this mean.
-    - `input_is_real_space`:
-        If `True`, the given `image` is in real
-        space. If `False`, it is in Fourier space.
+    - `std`:
+        Rescale to this standard deviation.
     - `where`:
         As `where` in `jax.numpy.std` and
         `jax.numpy.mean`. This argument is ignored if
@@ -47,51 +38,22 @@ def rescale_image(
 
     Image rescaled to the given mean and standard deviation.
     """
-    if where is not None and not input_is_real_space:
-        raise ValueError(
-            "`cryojax.ndimage.standardize_image` does "
-            "not support argument `where` if `input_is_real_space` "
-            "is `False`."
-        )
-    image, mean, std = jnp.asarray(image), jnp.asarray(mean), jnp.asarray(std)
+    image = jnp.asarray(image)
+    mean, std = jnp.asarray(mean), jnp.asarray(std)
     # First normalize image to zero mean and unit standard deviation
-    if input_is_real_space:
-        normalized_image = (image - jnp.mean(image, where=where)) / jnp.std(
-            image, where=where
-        )
-        rescaled_image = std * normalized_image + mean
-    else:
-        N1, N2 = image.shape
-        n_pixels = (
-            (
-                N1 * (2 * N2 - 1)
-                if shape_in_real_space is None
-                else math.prod(shape_in_real_space)
-            )
-            if input_is_rfft
-            else N1 * N2
-        )
-        image_with_zero_mean = image.at[0, 0].set(0.0)
-        image_std = (
-            jnp.sqrt(
-                jnp.sum(jnp.abs(image_with_zero_mean[:, 0]) ** 2)
-                + 2 * jnp.sum(jnp.abs(image_with_zero_mean[:, 1:]) ** 2)
-            )
-            if input_is_rfft
-            else jnp.linalg.norm(image_with_zero_mean)
-        ) / n_pixels
-        normalized_image = image_with_zero_mean / image_std
-        rescaled_image = (normalized_image * std).at[0, 0].set(mean * n_pixels)
+    normalized_image = (image - jnp.mean(image, where=where)) / jnp.std(
+        image, where=where
+    )
+    # Then rescale
+    rescaled_image = std * normalized_image + mean
+
     return rescaled_image
 
 
 def standardize_image(
     image: Inexact[NDArrayLike, "y_dim x_dim"],
     *,
-    input_is_real_space: bool = True,
     where: Bool[Array, "y_dim x_dim"] | None = None,
-    input_is_rfft: bool = True,
-    shape_in_real_space: tuple[int, int] | None = None,
 ) -> Inexact[Array, "y_dim x_dim"]:
     """Normalize so that the image is mean 0
     and standard deviation 1 in real space.
@@ -99,13 +61,7 @@ def standardize_image(
     **Parameters:**
 
     - `image`:
-        The image in either the real or fourier domain.
-        If in fourier, pass `input_is_real_space = True`
-        and ensure the zero frequency
-        component is in the corner.
-    - `input_is_real_space`:
-        If `True`, the given `image` is in real
-        space. If `False`, it is in Fourier space.
+        The image in real-space.
     - `where`:
         As `where` in `jax.numpy.std` and
         `jax.numpy.mean`. This argument is ignored if
@@ -114,14 +70,89 @@ def standardize_image(
 
     **Returns:**
 
-    The standardized image
+    The standardized image in real-space.
     """
-    return rescale_image(
-        image,
+    image = jnp.asarray(image)
+    return (image - jnp.mean(image, where=where)) / jnp.std(image, where=where)
+
+
+def rescale_fft(
+    fourier_image: Complex[NDArrayLike, "y_dim x_dim"],
+    mean: FloatLike = 0.0,
+    std: FloatLike = 1.0,
+    *,
+    input_is_rfft: bool = True,
+    shape_in_real_space: tuple[int, int] | None = None,
+) -> Complex[Array, "y_dim x_dim"]:
+    """Rescale so that the image is mean `mean`
+    and standard deviation `std` in real-space.
+
+    **Parameters:**
+
+    - `fourier_image`:
+        The image in the Fourier domain.
+        Ensure the zero frequency component is in the corner.
+    - `std`:
+        The real-space image is rescaled to this standard deviation.
+    - `mean`:
+        The real-space image is rescaled to this mean.
+
+
+    **Returns:**
+
+    Image in the Fourier domain rescaled to
+    the given mean and standard deviation.
+    """
+    fourier_image = jnp.asarray(fourier_image)
+    n1, n2 = fourier_image.shape
+    n_pixels = (
+        (
+            n1 * (2 * n2 - 1)
+            if shape_in_real_space is None
+            else math.prod(shape_in_real_space)
+        )
+        if input_is_rfft
+        else n1 * n2
+    )
+    fourier_image_zero_mean = fourier_image.at[0, 0].set(0.0)
+    image_std = (
+        jnp.sqrt(
+            jnp.sum(jnp.abs(fourier_image_zero_mean[:, 0]) ** 2)
+            + 2 * jnp.sum(jnp.abs(fourier_image_zero_mean[:, 1:]) ** 2)
+        )
+        if input_is_rfft
+        else jnp.linalg.norm(fourier_image_zero_mean)
+    ) / n_pixels
+    normalized_image = fourier_image_zero_mean / image_std
+    rescaled_image = (normalized_image * std).at[0, 0].set(mean * n_pixels)
+
+    return rescaled_image
+
+
+def standardize_fft(
+    fourier_image: Complex[NDArrayLike, "y_dim x_dim"],
+    *,
+    input_is_rfft: bool = True,
+    shape_in_real_space: tuple[int, int] | None = None,
+) -> Complex[Array, "y_dim x_dim"]:
+    """Standardize so that the image is mean 0
+    and standard deviation 1 in real-space.
+
+    **Parameters:**
+
+    - `fourier_image`:
+        The image in the Fourier domain.
+        Ensure the zero frequency component is in the corner.
+
+
+    **Returns:**
+
+    Standardized image in the Fourier domain.
+    """
+    return rescale_fft(
+        fourier_image,
         mean=0.0,
         std=1.0,
-        input_is_real_space=input_is_real_space,
-        where=where,
         input_is_rfft=input_is_rfft,
         shape_in_real_space=shape_in_real_space,
     )

--- a/cryojax/ndimage/_transforms/__init__.py
+++ b/cryojax/ndimage/_transforms/__init__.py
@@ -1,6 +1,6 @@
 from ._base_transform import (
     AbstractImageTransform as AbstractImageTransform,
-    ImageScaling as ImageScaling,
+    ScaleImage as ScaleImage,
 )
 from ._filters import (
     AbstractFilter as AbstractFilter,

--- a/cryojax/ndimage/_transforms/_base_transform.py
+++ b/cryojax/ndimage/_transforms/_base_transform.py
@@ -72,7 +72,7 @@ class _FourierProductImageTransform(_AbstractProductImageTransform):
     is_real_space: ClassVar[bool] = False
 
 
-class ImageScaling(AbstractImageTransform, strict=True):
+class ScaleImage(AbstractImageTransform, strict=True):
     scale: Float[Array, ""]
     offset: Float[Array, ""]
 

--- a/cryojax/ndimage/_transforms/_filters.py
+++ b/cryojax/ndimage/_transforms/_filters.py
@@ -150,10 +150,7 @@ class WhiteningFilter(AbstractFilter, strict=True):
 
     def __init__(
         self,
-        image_or_image_stack: (
-            Float[NDArrayLike, "image_y_dim image_x_dim"]
-            | Float[NDArrayLike, "n_images image_y_dim image_x_dim"]
-        ),
+        images: Float[NDArrayLike, "_ _"] | Float[NDArrayLike, "_ _ _"],
         shape: tuple[int, int] | None = None,
         *,
         interpolation_mode: str = "linear",
@@ -161,7 +158,7 @@ class WhiteningFilter(AbstractFilter, strict=True):
     ):
         """**Arguments:**
 
-        - `image_or_image_stack`:
+        - `images`:
             The image (or stack of images) from which to compute the power spectrum.
         - `shape`:
             The shape of the resulting filter. This downsamples or
@@ -173,13 +170,9 @@ class WhiteningFilter(AbstractFilter, strict=True):
             If `False`, the whitening filter is the inverse square root of the image
             power. If `True`, the filter is the inverse of the image power.
         """
-        image_stack = (
-            jnp.expand_dims(image_or_image_stack, 0)
-            if image_or_image_stack.ndim == 2
-            else jnp.asarray(image_or_image_stack)
-        )
+        images = jnp.expand_dims(images, 0) if images.ndim == 2 else jnp.asarray(images)
         self.array = _compute_whitening_filter(
-            image_stack,
+            images,
             shape,
             interpolation_mode=interpolation_mode,
             outputs_squared=outputs_squared,
@@ -228,9 +221,10 @@ def _compute_lowpass_filter(
 
 def _compute_whitening_filter(
     image_stack: Float[Array, "n_images y_dim x_dim"],
-    shape: tuple[int, int] | None = None,
-    interpolation_mode: str = "linear",
-    outputs_squared: bool = False,
+    shape: tuple[int, int] | None,
+    *,
+    interpolation_mode: str,
+    outputs_squared: bool,
 ) -> Float[Array, "{shape[0]} {shape[1]}"]:
     # Make coordinates
     frequency_grid = make_frequency_grid(image_stack.shape[1:])
@@ -247,16 +241,14 @@ def _compute_whitening_filter(
         in_axes=[0, None],
         out_axes=(0, None),
     )
-    radially_averaged_powerspectrum_stack, frequency_bins = compute_powerspectrum_stack(
+    binned_powerspectrum_stack, frequency_bins = compute_powerspectrum_stack(
         fourier_image_stack, radial_frequency_grid
     )
     # Take the mean over the stack
-    radially_averaged_powerspectrum = jnp.mean(
-        radially_averaged_powerspectrum_stack, axis=0
-    )
+    binned_powerspectrum = jnp.mean(binned_powerspectrum_stack, axis=0)
     # Put onto a grid
-    radially_averaged_powerspectrum_on_grid = radial_average_to_grid(
-        radially_averaged_powerspectrum,
+    binned_powerspectrum_on_grid = radial_average_to_grid(
+        binned_powerspectrum,
         frequency_bins,
         radial_frequency_grid,
         interpolation_mode=interpolation_mode,
@@ -264,27 +256,27 @@ def _compute_whitening_filter(
     # Resize to be the desired shape
     if shape is not None:
         new_shape = shape
-        radially_averaged_powerspectrum_on_grid = rfftn(
+        binned_powerspectrum_on_grid = rfftn(
             resize_with_crop_or_pad(
-                irfftn(radially_averaged_powerspectrum_on_grid, s=image_stack.shape[1:]),
+                irfftn(binned_powerspectrum_on_grid, s=image_stack.shape[1:]),
                 shape,
                 mode="edge",
             )
         ).real
         # ... resizing and going back to fourier space can introduce negative values
-        radially_averaged_powerspectrum_on_grid = jnp.where(
-            radially_averaged_powerspectrum_on_grid < 0,
+        binned_powerspectrum_on_grid = jnp.where(
+            binned_powerspectrum_on_grid < 0,
             0.0,
-            radially_averaged_powerspectrum_on_grid,
+            binned_powerspectrum_on_grid,
         )
     else:
         new_shape = image_stack.shape[1], image_stack.shape[2]
     # Compute inverse square root (or inverse square)
     inverse_fn = jax.lax.reciprocal if outputs_squared else jax.lax.rsqrt
     whitening_filter = jnp.where(
-        jnp.isclose(radially_averaged_powerspectrum_on_grid, 0.0),
+        jnp.isclose(binned_powerspectrum_on_grid, 0.0),
         0.0,
-        inverse_fn(radially_averaged_powerspectrum_on_grid),
+        inverse_fn(binned_powerspectrum_on_grid),
     )
     # Set zero mode to 0, defining the filter to zero out these modes
     whitening_filter = whitening_filter.at[0, 0].set(0.0)

--- a/cryojax/simulator/_pose.py
+++ b/cryojax/simulator/_pose.py
@@ -14,7 +14,7 @@ from equinox import AbstractVar, Module
 from jaxtyping import Array, Complex, Float
 
 from ..jax_util import FloatLike, NDArrayLike
-from ..ndimage import enforce_self_conjugate_rfftn_components
+from ..ndimage import enforce_rfftn_self_conjugates
 from ..rotations import SO3, convert_quaternion_to_euler_angles
 
 
@@ -89,8 +89,8 @@ class AbstractPose(Module, strict=True):
         The translated `fourier_image`, taking care to avoid image
         artifacts when applying the phase shifts.
         """
-        fourier_image = enforce_self_conjugate_rfftn_components(
-            fourier_image, shape, includes_zero_frequency=False, mode="zero"
+        fourier_image = enforce_rfftn_self_conjugates(
+            fourier_image, shape, includes_dc=False, mode="zero"
         )
         return fourier_image * translation_operator
 

--- a/cryojax/simulator/_solvent_2d.py
+++ b/cryojax/simulator/_solvent_2d.py
@@ -18,7 +18,7 @@ from ..ndimage import (
     PeakedFourierGaussian,
     ifftn,
     irfftn,
-    rescale_image,
+    rescale_fft,
 )
 from ._image_config import AbstractImageConfig
 
@@ -252,11 +252,10 @@ class GRFSolvent2D(AbstractRandomSolvent2D, strict=True):
         )
         mean = self.total_potential_per_molecule * molecules_per_angstrom_squared
         std = 1.0  # TODO: set standard deviation
-        fourier_in_plane_potential_of_solvent = rescale_image(
+        fourier_in_plane_potential_of_solvent = rescale_fft(
             solvent_grf,
             mean=mean,
             std=std,
-            input_is_real_space=False,
             input_is_rfft=outputs_rfft,
             shape_in_real_space=config.padded_shape,
         )

--- a/docs/api/ndimage.md
+++ b/docs/api/ndimage.md
@@ -53,7 +53,7 @@ This documentation is a collection of functions used to work with coordinate sys
                 - __call__
 
 
-::: cryojax.ndimage.ImageScaling
+::: cryojax.ndimage.ScaleImage
         options:
             members:
                 - __init__

--- a/docs/examples/simulate-image.ipynb
+++ b/docs/examples/simulate-image.ipynb
@@ -289,7 +289,7 @@
     "    pose,\n",
     "    transfer_theory,\n",
     "    normalizes_signal=True,\n",
-    "    transform=im.ImageScaling(scale=np.sqrt(snr)),\n",
+    "    transform=im.ScaleImage(scale=np.sqrt(snr)),\n",
     ")\n",
     "noise_model = cxs.GaussianWhiteNoiseModel(image_model, variance=1.0)\n",
     "# ... then, either simulate an image from this `noise_model``\n",

--- a/docs/examples/structure-refinement.ipynb
+++ b/docs/examples/structure-refinement.ipynb
@@ -144,7 +144,7 @@
     "        normalizes_signal=True,\n",
     "        signal_region=circular_mask.get() == 1.0,\n",
     "        signal_centering=\"bg\",\n",
-    "        transform=im.ImageScaling(scale=jnp.sqrt(SNR)),\n",
+    "        transform=im.ScaleImage(scale=jnp.sqrt(SNR)),\n",
     "    )\n",
     "    noise_model = cxs.GaussianWhiteNoiseModel(image_model, variance=1.0)\n",
     "    parameters = dict(\n",

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -5,8 +5,8 @@ import pytest
 from cryojax.io import read_array_from_mrc, read_atoms_from_pdb
 from cryojax.ndimage import (
     CircularCosineMask,
-    ImageScaling,
     LowpassFilter,
+    ScaleImage,
     crop_to_shape,
     pad_to_shape,
 )
@@ -194,7 +194,7 @@ def test_normalize_and_transform(std, signal_centering, voxel_info, basic_config
         voxel_volume,
         basic_config,
         pose=cxs.EulerAnglePose(),
-        transform=ImageScaling(scale=std),
+        transform=ScaleImage(scale=std),
         normalizes_signal=True,
         signal_centering="bg",
     )
@@ -210,7 +210,7 @@ def test_mask_zeros_edges(use_transform, voxel_info, basic_config):
         voxel_volume,
         basic_config,
         pose=cxs.EulerAnglePose(),
-        transform=(ImageScaling(scale=1.0) if use_transform else None),
+        transform=(ScaleImage(scale=1.0) if use_transform else None),
         normalizes_signal=True,
     )
     image = image_model.simulate(


### PR DESCRIPTION
Biggest user-facing change is probably `cryojax.ndimage.ImageScaling` to `cryojax.ndimage.ScaleImage`. The latter is better as we add more transformations.