### PR TITLE
Replace `BasicImageConfig` coordinate/frequency grid properties with `get_coordinate_grid`/`get_frequency_grid` 

### DIFF
--- a/cryojax/simulator/_image_config.py
+++ b/cryojax/simulator/_image_config.py
@@ -1,6 +1,7 @@
 """The image configuration and utility manager."""
 
 import math
+import warnings
 from functools import cached_property
 from typing import Any, TypedDict
 
@@ -15,6 +16,13 @@ from ..constants import (
 )
 from ..jax_util import FloatLike, error_if_not_positive
 from ..ndimage import make_coordinate_grid, make_frequency_grid
+
+
+_get_deprecation_msg = lambda self, prop, func: (
+    f"`{self.__class__.__name__}.{prop}` has been deprecated and will be "
+    "removed in cryoJAX 0.6.0. Instead, make "
+    f"the appropriate call to `{self.__class__.__name__}.{func}`."
+)
 
 
 class GridHelper(eqx.Module, strict=True):
@@ -69,144 +77,89 @@ class AbstractImageConfig(eqx.Module, strict=True):
         """The electron interaction constant at the given `voltage_in_kilovolts`."""
         return interaction_constant_from_kilovolts(self.voltage_in_kilovolts)
 
-    @cached_property
-    def coordinate_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
-        """A spatial coordinate system for the `shape`."""
-        if self.grid_helper is None:
-            return make_coordinate_grid(self.shape)
-        else:
-            return self.grid_helper.coordinate_grid
+    def get_coordinates(self, *, padding: bool = False, physical: bool = True):
+        """Return the image coordinate system. See
+        [`cryojax.ndimage.make_coordinate_grid`][] for more
+        information.
 
-    @cached_property
-    def coordinate_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
-        """Convenience property for `pixel_size * coordinate_grid_in_pixels`"""
-        return _safe_multiply_by_constant(self.coordinate_grid_in_pixels, self.pixel_size)
+        **Arguments:**
 
-    @cached_property
-    def frequency_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
-        """A spatial frequency coordinate system for the `shape`,
-        with hermitian symmetry.
+        - `padding`:
+            If `True`, return coordinates with shape
+            `image_config.padded_shape`. Otherwise, return with
+            shape `image_config.shape`.
+        - `physical`:
+            If `True`, return coordinates in units of angstroms.
+            Otherwise, return on the unit box.
+
+        **Returns:**
+
+        The coordinate grid.
         """
-        if self.grid_helper is None:
-            return make_frequency_grid(self.shape, outputs_rfftfreqs=True)
+        if padding:
+            if physical:
+                return self._padded_coordinate_grid_in_angstroms
+            else:
+                return self._padded_coordinate_grid_in_pixels
         else:
-            return self.grid_helper.frequency_grid
+            if physical:
+                return self._coordinate_grid_in_angstroms
+            else:
+                return self._coordinate_grid_in_pixels
 
-    @cached_property
-    def frequency_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
-        """Convenience property for `frequency_grid_in_pixels / pixel_size`"""
-        return _safe_multiply_by_constant(
-            self.frequency_grid_in_pixels, 1 / self.pixel_size
-        )
+    def get_frequencies(
+        self, *, padding: bool = False, physical: bool = True, full: bool = False
+    ):
+        """Return a grid of FFT frequencies. See
+        [`cryojax.ndimage.make_frequency_grid`] for more
+        information.
 
-    @cached_property
-    def full_frequency_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
-        """A spatial frequency coordinate system for the `shape`,
-        without hermitian symmetry.
+        **Arguments:**
+
+        - `padding`:
+            If `True`, return frequencies corresponding to shape
+            `image_config.padded_shape`. Otherwise, use
+            `image_config.shape`.
+        - `physical`:
+            If `True`, return frequencies in units of inverse
+            angstroms. Otherwise, return unitless where Nyquist
+            is equal to 0.5.
+        - `full`:
+            If `True`, return the full plane of frequencies
+            for usage with `jax.numpy.fft.fftn`.
+            Otherwise, return the half plane for usage with
+            `jax.numpy.fft.rfftn`.
+
+        **Returns:**
+
+        The frequency grid.
         """
-        if self.grid_helper is None or self.grid_helper.full_frequency_grid is None:
-            return make_frequency_grid(shape=self.shape, outputs_rfftfreqs=False)
+        if padding:
+            if physical:
+                if full:
+                    return self._padded_full_frequency_grid_in_angstroms
+                else:
+                    return self._padded_frequency_grid_in_angstroms
+            else:
+                if full:
+                    return self._padded_full_frequency_grid_in_pixels
+                else:
+                    return self._padded_frequency_grid_in_pixels
         else:
-            return self.grid_helper.full_frequency_grid
-
-    @cached_property
-    def full_frequency_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
-        """Convenience property for `full_frequency_grid_in_pixels / pixel_size`"""
-        return _safe_multiply_by_constant(
-            self.full_frequency_grid_in_pixels, 1 / self.pixel_size
-        )
+            if physical:
+                if full:
+                    return self._full_frequency_grid_in_angstroms
+                else:
+                    return self._frequency_grid_in_angstroms
+            else:
+                if full:
+                    return self._full_frequency_grid_in_pixels
+                else:
+                    return self._frequency_grid_in_pixels
 
     @property
     def padded_shape(self):
         return self.pad_options["shape"]
-
-    @cached_property
-    def padded_coordinate_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
-        """A spatial coordinate system for the `padded_shape`."""
-        grid_helper = (
-            self.grid_helper
-            if self.shape == self.padded_shape
-            else self.pad_options["grid_helper"]
-        )
-        if grid_helper is None:
-            return make_coordinate_grid(shape=self.padded_shape)
-        else:
-            return grid_helper.coordinate_grid
-
-    @cached_property
-    def padded_coordinate_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
-        """Convenience property for `pixel_size * padded_coordinate_grid_in_pixels`"""
-        return _safe_multiply_by_constant(
-            self.padded_coordinate_grid_in_pixels, self.pixel_size
-        )
-
-    @cached_property
-    def padded_frequency_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
-        """A spatial frequency coordinate system for the `padded_shape`,
-        with hermitian symmetry.
-        """
-        grid_helper = (
-            self.grid_helper
-            if self.shape == self.padded_shape
-            else self.pad_options["grid_helper"]
-        )
-        if grid_helper is None:
-            return make_frequency_grid(shape=self.padded_shape, outputs_rfftfreqs=True)
-        else:
-            return grid_helper.frequency_grid
-
-    @cached_property
-    def padded_frequency_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
-        """Convenience property for `padded_frequency_grid_in_pixels / pixel_size`"""
-        return _safe_multiply_by_constant(
-            self.padded_frequency_grid_in_pixels, 1 / self.pixel_size
-        )
-
-    @cached_property
-    def padded_full_frequency_grid_in_pixels(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
-        """A spatial frequency coordinate system for the `padded_shape`,
-        without hermitian symmetry.
-        """
-        grid_helper = (
-            self.grid_helper
-            if self.shape == self.padded_shape
-            else self.pad_options["grid_helper"]
-        )
-        if grid_helper is None or grid_helper.full_frequency_grid is None:
-            return make_frequency_grid(shape=self.padded_shape, outputs_rfftfreqs=False)
-        else:
-            return grid_helper.full_frequency_grid
-
-    @cached_property
-    def padded_full_frequency_grid_in_angstroms(
-        self,
-    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
-        """Convenience property for `padded_full_frequency_grid_in_pixels / pixel_size`"""
-        return _safe_multiply_by_constant(
-            self.padded_full_frequency_grid_in_pixels, 1 / self.pixel_size
-        )
 
     @property
     def n_pixels(self) -> int:
@@ -237,6 +190,289 @@ class AbstractImageConfig(eqx.Module, strict=True):
     def padded_n_pixels(self) -> int:
         """Convenience property for `math.prod(padded_shape)`"""
         return math.prod(self.padded_shape)
+
+    @cached_property
+    def _coordinate_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        """A spatial coordinate system for the `shape`."""
+        if self.grid_helper is None:
+            return make_coordinate_grid(self.shape)
+        else:
+            return self.grid_helper.coordinate_grid
+
+    @cached_property
+    def _coordinate_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        """Property for `pixel_size * coordinate_grid_in_pixels`"""
+        return _safe_multiply_by_constant(
+            self._coordinate_grid_in_pixels, self.pixel_size
+        )
+
+    @cached_property
+    def _frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
+        """A spatial frequency coordinate system for the `shape`,
+        with hermitian symmetry.
+        """
+        if self.grid_helper is None:
+            return make_frequency_grid(self.shape, outputs_rfftfreqs=True)
+        else:
+            return self.grid_helper.frequency_grid
+
+    @cached_property
+    def _frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
+        """Convenience property for `frequency_grid_in_pixels / pixel_size`"""
+        return _safe_multiply_by_constant(
+            self._frequency_grid_in_pixels, 1 / self.pixel_size
+        )
+
+    @cached_property
+    def _full_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        """A spatial frequency coordinate system for the `shape`,
+        without hermitian symmetry.
+        """
+        if self.grid_helper is None or self.grid_helper.full_frequency_grid is None:
+            return make_frequency_grid(shape=self.shape, outputs_rfftfreqs=False)
+        else:
+            return self.grid_helper.full_frequency_grid
+
+    @cached_property
+    def _full_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        """Property for `full_frequency_grid_in_pixels / pixel_size`"""
+        return _safe_multiply_by_constant(
+            self.full_frequency_grid_in_pixels, 1 / self.pixel_size
+        )
+
+    @cached_property
+    def _padded_coordinate_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        """A spatial coordinate system for the `padded_shape`."""
+        grid_helper = (
+            self.grid_helper
+            if self.shape == self.padded_shape
+            else self.pad_options["grid_helper"]
+        )
+        if grid_helper is None:
+            return make_coordinate_grid(shape=self.padded_shape)
+        else:
+            return grid_helper.coordinate_grid
+
+    @cached_property
+    def _padded_coordinate_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        """Property for `pixel_size * padded_coordinate_grid_in_pixels`"""
+        return _safe_multiply_by_constant(
+            self._padded_coordinate_grid_in_pixels, self.pixel_size
+        )
+
+    @cached_property
+    def _padded_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
+        """A spatial frequency coordinate system for the `padded_shape`,
+        with hermitian symmetry.
+        """
+        grid_helper = (
+            self.grid_helper
+            if self.shape == self.padded_shape
+            else self.pad_options["grid_helper"]
+        )
+        if grid_helper is None:
+            return make_frequency_grid(shape=self.padded_shape, outputs_rfftfreqs=True)
+        else:
+            return grid_helper.frequency_grid
+
+    @cached_property
+    def _padded_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
+        """Property for `padded_frequency_grid_in_pixels / pixel_size`"""
+        return _safe_multiply_by_constant(
+            self._padded_frequency_grid_in_pixels, 1 / self.pixel_size
+        )
+
+    @cached_property
+    def _padded_full_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        """A spatial frequency coordinate system for the `padded_shape`,
+        without hermitian symmetry.
+        """
+        grid_helper = (
+            self.grid_helper
+            if self.shape == self.padded_shape
+            else self.pad_options["grid_helper"]
+        )
+        if grid_helper is None or grid_helper.full_frequency_grid is None:
+            return make_frequency_grid(shape=self.padded_shape, outputs_rfftfreqs=False)
+        else:
+            return grid_helper.full_frequency_grid
+
+    @cached_property
+    def _padded_full_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        """Property for `padded_full_frequency_grid_in_pixels / pixel_size`"""
+        return _safe_multiply_by_constant(
+            self._padded_full_frequency_grid_in_pixels, 1 / self.pixel_size
+        )
+
+    @property
+    def coordinate_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(self, "coordinate_grid_in_pixels", "get_coordinates"),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._coordinate_grid_in_pixels
+
+    @property
+    def coordinate_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(self, "coordinate_grid_in_angstroms", "get_coordinates"),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._coordinate_grid_in_angstroms
+
+    @property
+    def frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(self, "frequency_grid_in_pixels", "g"),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._frequency_grid_in_pixels
+
+    @property
+    def frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim//2+1} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(self, "frequency_grid_in_angstroms", "get_frequencies"),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._frequency_grid_in_angstroms
+
+    @property
+    def full_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "full_frequency_grid_in_pixels", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._full_frequency_grid_in_pixels
+
+    @property
+    def full_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.y_dim} {self.x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "full_frequency_grid_in_angstroms", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._full_frequency_grid_in_angstroms
+
+    @property
+    def padded_coordinate_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "padded_coordinate_grid_in_pixels", "get_coordinates"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_coordinate_grid_in_pixels
+
+    @property
+    def padded_coordinate_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(self, "coordinate_grid_in_angstroms", "get_coordinates"),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_coordinate_grid_in_angstroms
+
+    @property
+    def padded_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "padded_frequency_grid_in_pixels", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_frequency_grid_in_pixels
+
+    @property
+    def padded_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim//2+1} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "padded_frequency_grid_in_angstroms", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_frequency_grid_in_angstroms
+
+    @property
+    def padded_full_frequency_grid_in_pixels(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "padded_full_frequency_grid_in_pixels", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_full_frequency_grid_in_pixels
+
+    @property
+    def padded_full_frequency_grid_in_angstroms(
+        self,
+    ) -> Float[Array, "{self.padded_y_dim} {self.padded_x_dim} 2"]:
+        warnings.warn(
+            _get_deprecation_msg(
+                self, "padded_full_frequency_grid_in_angstroms", "get_frequencies"
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return self._padded_full_frequency_grid_in_angstroms
 
 
 class BasicImageConfig(AbstractImageConfig, strict=True):

--- a/cryojax/simulator/_image_config.py
+++ b/cryojax/simulator/_image_config.py
@@ -77,7 +77,7 @@ class AbstractImageConfig(eqx.Module, strict=True):
         """The electron interaction constant at the given `voltage_in_kilovolts`."""
         return interaction_constant_from_kilovolts(self.voltage_in_kilovolts)
 
-    def get_coordinates(self, *, padding: bool = False, physical: bool = True):
+    def get_coordinate_grid(self, *, padding: bool = False, physical: bool = True):
         """Return the image coordinate system. See
         [`cryojax.ndimage.make_coordinate_grid`][] for more
         information.
@@ -107,7 +107,7 @@ class AbstractImageConfig(eqx.Module, strict=True):
             else:
                 return self._coordinate_grid_in_pixels
 
-    def get_frequencies(
+    def get_frequency_grid(
         self, *, padding: bool = False, physical: bool = True, full: bool = False
     ):
         """Return a grid of FFT frequencies. See

--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -190,7 +190,7 @@ class AbstractImageModel(eqx.Module, strict=True):
 
     def _phase_shift_translate(self, fourier_image: Array) -> Array:
         phase_shifts = self.pose.compute_translation_operator(
-            self.image_config.get_frequencies(physical=True, padding=True)
+            self.image_config.get_frequency_grid(physical=True, padding=True)
         )
         fourier_image = self.pose.translate_image(
             fourier_image,

--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -156,7 +156,10 @@ class AbstractImageModel(eqx.Module, strict=True):
         else:
             # ... otherwise, apply filter, crop, and mask, again trying to
             # minimize moving back and forth between real and fourier space
-            padded_rfft_shape = image_config.padded_frequency_grid_in_pixels.shape[0:2]
+            padded_rfft_shape = (
+                image_config.padded_shape[0],
+                image_config.padded_shape[1] // 2 + 1,
+            )
             if filter_c is not None:
                 # ... apply the filter
                 if filter is not None:
@@ -187,7 +190,7 @@ class AbstractImageModel(eqx.Module, strict=True):
 
     def _phase_shift_translate(self, fourier_image: Array) -> Array:
         phase_shifts = self.pose.compute_translation_operator(
-            self.image_config.padded_frequency_grid_in_angstroms
+            self.image_config.get_frequencies(physical=True, padding=True)
         )
         fourier_image = self.pose.translate_image(
             fourier_image,

--- a/cryojax/simulator/_multislice/multislice_integrator.py
+++ b/cryojax/simulator/_multislice/multislice_integrator.py
@@ -126,7 +126,7 @@ class FFTMultisliceIntegrator(
         transmission = jnp.exp(1.0j * object_per_slice)
         # Compute the fresnel propagator (TODO: check numerical factors)
         radial_frequency_grid = jnp.sum(
-            image_config.padded_full_frequency_grid_in_angstroms**2,
+            image_config.get_frequencies(padding=True, physical=True, full=True) ** 2,
             axis=-1,
         )
         fresnel_propagator = jnp.exp(

--- a/cryojax/simulator/_multislice/multislice_integrator.py
+++ b/cryojax/simulator/_multislice/multislice_integrator.py
@@ -126,7 +126,7 @@ class FFTMultisliceIntegrator(
         transmission = jnp.exp(1.0j * object_per_slice)
         # Compute the fresnel propagator (TODO: check numerical factors)
         radial_frequency_grid = jnp.sum(
-            image_config.get_frequencies(padding=True, physical=True, full=True) ** 2,
+            image_config.get_frequency_grid(padding=True, physical=True, full=True) ** 2,
             axis=-1,
         )
         fresnel_propagator = jnp.exp(

--- a/cryojax/simulator/_noise_model/gaussian_noise_model.py
+++ b/cryojax/simulator/_noise_model/gaussian_noise_model.py
@@ -189,7 +189,9 @@ class GaussianWhiteNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_model.image_config.padded_n_pixels
-        frequency_grid = self.image_model.image_config.padded_frequency_grid_in_angstroms
+        frequency_grid = self.image_model.image_config.get_frequencies(
+            padding=True, physical=True
+        )
         # Compute the zero mean variance and scale up to be independent of the number of
         # pixels
         std = jnp.sqrt(n_pixels * self.variance)
@@ -316,7 +318,9 @@ class GaussianColoredNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_model.image_config.padded_n_pixels
-        frequency_grid = self.image_model.image_config.padded_frequency_grid_in_angstroms
+        frequency_grid = self.image_model.image_config.get_frequencies(
+            padding=True, physical=True
+        )
         # Compute the zero mean variance and scale up to be independent of the number of
         # pixels
         std = jnp.sqrt(n_pixels * self.variance_fn(frequency_grid))
@@ -367,7 +371,9 @@ class GaussianColoredNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_config.n_pixels
-        frequency_grid = self.image_config.frequency_grid_in_angstroms
+        frequency_grid = self.image_model.image_config.get_frequencies(
+            padding=False, physical=True
+        )
         # Compute the variance and scale up to be independent of the number of pixels
         variance = n_pixels * self.variance_fn(frequency_grid)
         # Create simulated data

--- a/cryojax/simulator/_noise_model/gaussian_noise_model.py
+++ b/cryojax/simulator/_noise_model/gaussian_noise_model.py
@@ -189,7 +189,7 @@ class GaussianWhiteNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_model.image_config.padded_n_pixels
-        frequency_grid = self.image_model.image_config.get_frequencies(
+        frequency_grid = self.image_model.image_config.get_frequency_grid(
             padding=True, physical=True
         )
         # Compute the zero mean variance and scale up to be independent of the number of
@@ -318,7 +318,7 @@ class GaussianColoredNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_model.image_config.padded_n_pixels
-        frequency_grid = self.image_model.image_config.get_frequencies(
+        frequency_grid = self.image_model.image_config.get_frequency_grid(
             padding=True, physical=True
         )
         # Compute the zero mean variance and scale up to be independent of the number of
@@ -371,7 +371,7 @@ class GaussianColoredNoiseModel(AbstractGaussianNoiseModel, strict=True):
             A filter to apply to the final image.
         """
         n_pixels = self.image_config.n_pixels
-        frequency_grid = self.image_model.image_config.get_frequencies(
+        frequency_grid = self.image_model.image_config.get_frequency_grid(
             padding=False, physical=True
         )
         # Compute the variance and scale up to be independent of the number of pixels

--- a/cryojax/simulator/_solvent_2d.py
+++ b/cryojax/simulator/_solvent_2d.py
@@ -230,16 +230,16 @@ class GRFSolvent2D(AbstractRandomSolvent2D, strict=True):
         """
         n_pixels = config.padded_n_pixels
         if outputs_real_space:
-            frequency_grid_in_angstroms = config.get_frequencies(
+            frequency_grid_in_angstroms = config.get_frequency_grid(
                 padding=True, physical=True
             )
         else:
             if outputs_rfft:
-                frequency_grid_in_angstroms = config.get_frequencies(
+                frequency_grid_in_angstroms = config.get_frequency_grid(
                     padding=True, physical=True
                 )
             else:
-                frequency_grid_in_angstroms = config.get_frequencies(
+                frequency_grid_in_angstroms = config.get_frequency_grid(
                     padding=True, physical=True, full=True
                 )
         # Compute standard deviation, scaling up by the variance by the number

--- a/cryojax/simulator/_solvent_2d.py
+++ b/cryojax/simulator/_solvent_2d.py
@@ -230,13 +230,17 @@ class GRFSolvent2D(AbstractRandomSolvent2D, strict=True):
         """
         n_pixels = config.padded_n_pixels
         if outputs_real_space:
-            frequency_grid_in_angstroms = config.padded_frequency_grid_in_angstroms
+            frequency_grid_in_angstroms = config.get_frequencies(
+                padding=True, physical=True
+            )
         else:
             if outputs_rfft:
-                frequency_grid_in_angstroms = config.padded_frequency_grid_in_angstroms
+                frequency_grid_in_angstroms = config.get_frequencies(
+                    padding=True, physical=True
+                )
             else:
-                frequency_grid_in_angstroms = (
-                    config.padded_full_frequency_grid_in_angstroms
+                frequency_grid_in_angstroms = config.get_frequencies(
+                    padding=True, physical=True, full=True
                 )
         # Compute standard deviation, scaling up by the variance by the number
         # of pixels to make the realization independent pixel-independent in real-space.

--- a/cryojax/simulator/_transfer_theory/transfer_theory.py
+++ b/cryojax/simulator/_transfer_theory/transfer_theory.py
@@ -86,7 +86,7 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
             An optional defocus offset to apply to the CTF defocus at
             runtime.
         """
-        frequency_grid = image_config.padded_frequency_grid_in_angstroms
+        frequency_grid = image_config.get_frequencies(padding=True, physical=True)
         if not input_is_ewald_sphere:
             # Compute the CTF, including additional phase shifts
             ctf_array = self.ctf(

--- a/cryojax/simulator/_transfer_theory/transfer_theory.py
+++ b/cryojax/simulator/_transfer_theory/transfer_theory.py
@@ -86,7 +86,7 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
             An optional defocus offset to apply to the CTF defocus at
             runtime.
         """
-        frequency_grid = image_config.get_frequencies(padding=True, physical=True)
+        frequency_grid = image_config.get_frequency_grid(padding=True, physical=True)
         if not input_is_ewald_sphere:
             # Compute the CTF, including additional phase shifts
             ctf_array = self.ctf(

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -498,7 +498,7 @@ class FFTAtomProjection(
         else:
             shape_u, pixel_size_u = (u * shape[0], u * shape[1]), pixel_size / u
         if shape_u == image_config.padded_shape:
-            frequency_grid = image_config.get_frequencies(
+            frequency_grid = image_config.get_frequency_grid(
                 padding=True, physical=True, full=True
             )
         else:

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -498,7 +498,9 @@ class FFTAtomProjection(
         else:
             shape_u, pixel_size_u = (u * shape[0], u * shape[1]), pixel_size / u
         if shape_u == image_config.padded_shape:
-            frequency_grid = image_config.padded_full_frequency_grid_in_angstroms
+            frequency_grid = image_config.get_frequencies(
+                padding=True, physical=True, full=True
+            )
         else:
             frequency_grid = make_frequency_grid(
                 shape_u, pixel_size_u, outputs_rfftfreqs=False

--- a/docs/api/simulator/config.md
+++ b/docs/api/simulator/config.md
@@ -23,8 +23,8 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
                 - wavelength_in_angstroms
                 - lorentz_factor
                 - interaction_constant
-                - get_coordinates
-                - get_frequencies
+                - get_coordinate_grid
+                - get_frequency_grid
                 - n_pixels
                 - y_dim
                 - x_dim
@@ -46,8 +46,8 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
                 - wavelength_in_angstroms
                 - lorentz_factor
                 - interaction_constant
-                - get_coordinates
-                - get_frequencies
+                - get_coordinate_grid
+                - get_frequency_grid
                 - n_pixels
                 - y_dim
                 - x_dim

--- a/docs/api/simulator/config.md
+++ b/docs/api/simulator/config.md
@@ -5,28 +5,11 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
 ??? abstract "`cryojax.simulator.AbstractImageConfig`"
     ::: cryojax.simulator.AbstractImageConfig
             members:
-                - wavelength_in_angstroms
-                - lorentz_factor
-                - interaction_constant
-                - n_pixels
-                - y_dim
-                - x_dim
-                - coordinate_grid_in_pixels
-                - coordinate_grid_in_angstroms
-                - frequency_grid_in_pixels
-                - frequency_grid_in_angstroms
-                - full_frequency_grid_in_pixels
-                - full_frequency_grid_in_angstroms
-                - padded_n_pixels
-                - padded_y_dim
-                - padded_x_dim
-                - padded_coordinate_grid_in_pixels
-                - padded_coordinate_grid_in_angstroms
-                - padded_frequency_grid_in_pixels
-                - padded_frequency_grid_in_angstroms
-                - padded_full_frequency_grid_in_pixels
-                - padded_full_frequency_grid_in_angstroms
-
+                - shape
+                - pixel_size
+                - voltage_in_kilovolts
+                - grid_helper
+                - pad_options
 
 ---
 
@@ -34,6 +17,21 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
         options:
             members:
                 - __init__
+                - shape
+                - pixel_size
+                - voltage_in_kilovolts
+                - wavelength_in_angstroms
+                - lorentz_factor
+                - interaction_constant
+                - get_coordinates
+                - get_frequencies
+                - n_pixels
+                - y_dim
+                - x_dim
+                - padded_shape
+                - padded_n_pixels
+                - padded_y_dim
+                - padded_x_dim
 
 ---
 
@@ -41,6 +39,22 @@ The `AbstractImageConfig` is an object at the core of simulating images in `cryo
         options:
             members:
                 - __init__
+                - shape
+                - pixel_size
+                - voltage_in_kilovolts
+                - electron_dose
+                - wavelength_in_angstroms
+                - lorentz_factor
+                - interaction_constant
+                - get_coordinates
+                - get_frequencies
+                - n_pixels
+                - y_dim
+                - x_dim
+                - padded_shape
+                - padded_n_pixels
+                - padded_y_dim
+                - padded_x_dim
 
 ::: cryojax.simulator.GridHelper
         options:

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -22,63 +22,65 @@ def test_future_deprecated(sample_pdb_path):
     ic = cxs.BasicImageConfig((10, 10), 1.5, 300.0)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.coordinate_grid_in_angstroms is ic.get_coordinates()
+        assert ic.coordinate_grid_in_angstroms is ic.get_coordinate_grid()
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.coordinate_grid_in_pixels is ic.get_coordinates(physical=False)
+        assert ic.coordinate_grid_in_pixels is ic.get_coordinate_grid(physical=False)
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_coordinate_grid_in_pixels is ic.get_coordinates(
+        assert ic.padded_coordinate_grid_in_pixels is ic.get_coordinate_grid(
             padding=True, physical=False
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_coordinate_grid_in_angstroms is ic.get_coordinates(
+        assert ic.padded_coordinate_grid_in_angstroms is ic.get_coordinate_grid(
             padding=True,
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.frequency_grid_in_angstroms is ic.get_frequencies()
+        assert ic.frequency_grid_in_angstroms is ic.get_frequency_grid()
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.frequency_grid_in_pixels is ic.get_frequencies(physical=False)
+        assert ic.frequency_grid_in_pixels is ic.get_frequency_grid(physical=False)
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_frequency_grid_in_angstroms is ic.get_frequencies(padding=True)
+        assert ic.padded_frequency_grid_in_angstroms is ic.get_frequency_grid(
+            padding=True
+        )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_frequency_grid_in_pixels is ic.get_frequencies(
+        assert ic.padded_frequency_grid_in_pixels is ic.get_frequency_grid(
             padding=True, physical=False
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.full_frequency_grid_in_pixels is ic.get_frequencies(
+        assert ic.full_frequency_grid_in_pixels is ic.get_frequency_grid(
             physical=False, full=True
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.full_frequency_grid_in_angstroms is ic.get_frequencies(
+        assert ic.full_frequency_grid_in_angstroms is ic.get_frequency_grid(
             physical=True, full=True
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_full_frequency_grid_in_pixels is ic.get_frequencies(
+        assert ic.padded_full_frequency_grid_in_pixels is ic.get_frequency_grid(
             padding=True, physical=False, full=True
         )
         assert not should_be_removed(record)
 
     with pytest.warns(FutureWarning) as record:
-        assert ic.padded_full_frequency_grid_in_angstroms is ic.get_frequencies(
+        assert ic.padded_full_frequency_grid_in_angstroms is ic.get_frequency_grid(
             padding=True, physical=True, full=True
         )
         assert not should_be_removed(record)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -19,6 +19,70 @@ def test_future_deprecated(sample_pdb_path):
         removal_version = parse_version(match.group(1))
         return current_version >= removal_version
 
+    ic = cxs.BasicImageConfig((10, 10), 1.5, 300.0)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.coordinate_grid_in_angstroms is ic.get_coordinates()
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.coordinate_grid_in_pixels is ic.get_coordinates(physical=False)
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_coordinate_grid_in_pixels is ic.get_coordinates(
+            padding=True, physical=False
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_coordinate_grid_in_angstroms is ic.get_coordinates(
+            padding=True,
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.frequency_grid_in_angstroms is ic.get_frequencies()
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.frequency_grid_in_pixels is ic.get_frequencies(physical=False)
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_frequency_grid_in_angstroms is ic.get_frequencies(padding=True)
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_frequency_grid_in_pixels is ic.get_frequencies(
+            padding=True, physical=False
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.full_frequency_grid_in_pixels is ic.get_frequencies(
+            physical=False, full=True
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.full_frequency_grid_in_angstroms is ic.get_frequencies(
+            physical=True, full=True
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_full_frequency_grid_in_pixels is ic.get_frequencies(
+            padding=True, physical=False, full=True
+        )
+        assert not should_be_removed(record)
+
+    with pytest.warns(FutureWarning) as record:
+        assert ic.padded_full_frequency_grid_in_angstroms is ic.get_frequencies(
+            padding=True, physical=True, full=True
+        )
+        assert not should_be_removed(record)
+
     with pytest.warns(FutureWarning) as record:
         obj = cxs.AberratedAstigmaticCTF
         assert obj is cxs.AstigmaticCTF

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -70,10 +70,9 @@ def test_fourier_shape(model, request):
     model = request.getfixturevalue(model)
     image = model.simulate(outputs_real_space=False)
     padded_image = model.raw_simulate(outputs_real_space=False)
-    assert image.shape == model.image_config.frequency_grid_in_pixels.shape[0:2]
+    assert image.shape == model.image_config.get_frequencies(padding=False).shape[0:2]
     assert (
-        padded_image.shape
-        == model.image_config.padded_frequency_grid_in_pixels.shape[0:2]
+        padded_image.shape == model.image_config.get_frequencies(padding=True).shape[0:2]
     )
 
 
@@ -215,7 +214,7 @@ def test_mask_zeros_edges(use_transform, voxel_info, basic_config):
     )
     image = image_model.simulate(
         mask=CircularCosineMask(
-            basic_config.coordinate_grid_in_pixels, radius=10, rolloff_width=0
+            basic_config.get_coordinates(physical=False), radius=10, rolloff_width=0
         )
     )
     ny, nx = image.shape
@@ -235,14 +234,14 @@ def test_filter_padded_shape(voxel_info, basic_config):
     )
     _ = image_model.simulate(
         filter=LowpassFilter(
-            basic_config.padded_frequency_grid_in_pixels,
+            basic_config.get_frequencies(padding=True, physical=False),
             grid_spacing=basic_config.pixel_size,
         )
     )
     with pytest.raises(ValueError):
         _ = image_model.simulate(
             filter=LowpassFilter(
-                basic_config.frequency_grid_in_pixels,
+                basic_config.get_frequencies(physical=False),
                 grid_spacing=basic_config.pixel_size,
             )
         )

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -70,9 +70,10 @@ def test_fourier_shape(model, request):
     model = request.getfixturevalue(model)
     image = model.simulate(outputs_real_space=False)
     padded_image = model.raw_simulate(outputs_real_space=False)
-    assert image.shape == model.image_config.get_frequencies(padding=False).shape[0:2]
+    assert image.shape == model.image_config.get_frequency_grid(padding=False).shape[0:2]
     assert (
-        padded_image.shape == model.image_config.get_frequencies(padding=True).shape[0:2]
+        padded_image.shape
+        == model.image_config.get_frequency_grid(padding=True).shape[0:2]
     )
 
 
@@ -214,7 +215,7 @@ def test_mask_zeros_edges(use_transform, voxel_info, basic_config):
     )
     image = image_model.simulate(
         mask=CircularCosineMask(
-            basic_config.get_coordinates(physical=False), radius=10, rolloff_width=0
+            basic_config.get_coordinate_grid(physical=False), radius=10, rolloff_width=0
         )
     )
     ny, nx = image.shape
@@ -234,14 +235,14 @@ def test_filter_padded_shape(voxel_info, basic_config):
     )
     _ = image_model.simulate(
         filter=LowpassFilter(
-            basic_config.get_frequencies(padding=True, physical=False),
+            basic_config.get_frequency_grid(padding=True, physical=False),
             grid_spacing=basic_config.pixel_size,
         )
     )
     with pytest.raises(ValueError):
         _ = image_model.simulate(
             filter=LowpassFilter(
-                basic_config.get_frequencies(physical=False),
+                basic_config.get_frequency_grid(physical=False),
                 grid_spacing=basic_config.pixel_size,
             )
         )

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -384,7 +384,7 @@ def compute_projection_at_pose(
         rotated_volume, image_config, outputs_real_space=False
     )
     translation_operator = pose.compute_translation_operator(
-        image_config.get_frequencies(padding=True, physical=True)
+        image_config.get_frequency_grid(padding=True, physical=True)
     )
     return im.crop_to_shape(
         im.irfftn(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -384,7 +384,7 @@ def compute_projection_at_pose(
         rotated_volume, image_config, outputs_real_space=False
     )
     translation_operator = pose.compute_translation_operator(
-        image_config.padded_frequency_grid_in_angstroms
+        image_config.get_frequencies(padding=True, physical=True)
     )
     return im.crop_to_shape(
         im.irfftn(


### PR DESCRIPTION
The API for `BasicImageConfig` is too cumbersome with all of the properties to keep track of. This PR simplifies this behavior and deprecates the previous behavior for removal in the future version of cryoJAX.