### PR TITLE
Change `image_model.volume_parametrization` to `image_model.volume` for simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import cryojax.simulator as cxs
 # Instantiate a cryoJAX `image_model`
 image_model = cxs.make_image_model(
     # ... load atoms as gaussians mixture from tabulated electron scattering factors
-    volume_parametrization=cxs.load_tabulated_volume(
+    volume=cxs.load_tabulated_volume(
         "example.pdb", output_type=cxs.GaussianMixtureVolume
     ),
     # ... configure the image

--- a/cryojax/simulator/_api_utils.py
+++ b/cryojax/simulator/_api_utils.py
@@ -53,9 +53,9 @@ Args = TypeVar("Args")
 identity_fn = eqxi.doc_repr(lambda x, _: x, "identity_fn")
 
 
-def _use_inverse_pose(volume_parametrization: AbstractVolumeParametrization) -> bool:
+def _use_inverse_pose(volume: AbstractVolumeParametrization) -> bool:
     jaxpr_fn = eqx.filter_make_jaxpr(lambda vol: vol.to_representation())
-    _, out_dynamic, out_static = jaxpr_fn(volume_parametrization)
+    _, out_dynamic, out_static = jaxpr_fn(volume)
     out_struct = eqx.combine(out_dynamic, out_static)
     expects_frame_rotation = isinstance(
         out_struct, (FourierVoxelGridVolume, FourierVoxelSplineVolume)
@@ -65,7 +65,7 @@ def _use_inverse_pose(volume_parametrization: AbstractVolumeParametrization) -> 
 
 @overload
 def make_image_model(
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: None = None,
@@ -83,7 +83,7 @@ def make_image_model(
 
 @overload
 def make_image_model(  # pyright: ignore[reportOverlappingOverload]
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory,
@@ -101,7 +101,7 @@ def make_image_model(  # pyright: ignore[reportOverlappingOverload]
 
 @overload
 def make_image_model(
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory,
@@ -119,7 +119,7 @@ def make_image_model(
 
 @overload
 def make_image_model(
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory,
@@ -137,7 +137,7 @@ def make_image_model(
 
 @overload
 def make_image_model(
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory,
@@ -154,7 +154,7 @@ def make_image_model(
 
 
 def make_image_model(
-    volume_parametrization: AbstractVolumeParametrization,
+    volume: AbstractVolumeParametrization,
     image_config: AbstractImageConfig,
     pose: AbstractPose,
     transfer_theory: ContrastTransferTheory | None = None,
@@ -186,7 +186,7 @@ def make_image_model(
 
     **Arguments:**
 
-    - `volume_parametrization`:
+    - `volume`:
         The volume for imaging. To get started building volumes, see the
         [`cryojax.simulator.load_tabulated_volume`][] and
         [`cryojax.simulator.render_voxel_volume`][] utilities, or explore
@@ -245,7 +245,7 @@ def make_image_model(
             Apply phase shifts in the Fourier domain.
         - 'atom':
             Apply translation to atom positions before
-            projection. For this method, the `volume_parametrization`
+            projection. For this method, the `volume`
             argument must be or yield a [`cryojax.simulator.AbstractAtomVolume`][].
         - 'none':
             Do not apply the translation.
@@ -269,12 +269,12 @@ def make_image_model(
         rotation of the *object*, not of the frame. Some volume
         projection methods (e.g. [`cryojax.simulator.FourierSliceExtraction`][])
         instead image
-        a rotation of the frame, so if `volume_parametrization` is
+        a rotation of the frame, so if `volume` is
         such a representation, the pose is transposed under the hood.
 
         Rotations will still differ by a transpose if:
 
-        - The `volume_parametrization` is a custom subclass of
+        - The `volume` is a custom subclass of
         [`cryojax.simulator.AbstractVolumeRepresentation`][] that
         implements a frame rotation.
         - The user instantiates an [`cryojax.simulator.AbstractImageModel`][]
@@ -297,7 +297,7 @@ def make_image_model(
     the value of `quantity_mode`.
     """
     # Invert pose if volume expects frame rotation
-    if _use_inverse_pose(volume_parametrization):
+    if _use_inverse_pose(volume):
         pose = pose.to_inverse_rotation()
     options = dict(
         normalizes_signal=normalizes_signal,
@@ -309,7 +309,7 @@ def make_image_model(
     if transfer_theory is None:
         # Image model for projections
         image_model = ProjectionImageModel(
-            volume_parametrization,
+            volume,
             pose,
             image_config,
             volume_integrator,
@@ -320,7 +320,7 @@ def make_image_model(
         if quantity_mode is None:
             # Linear image model
             image_model = LinearImageModel(
-                volume_parametrization,
+                volume,
                 pose,
                 image_config,
                 transfer_theory,
@@ -344,7 +344,7 @@ def make_image_model(
                         "counts, an `AbstractDetector` must be passed."
                     )
                 image_model = ElectronCountsImageModel(
-                    volume_parametrization,
+                    volume,
                     pose,
                     image_config,
                     scattering_theory,
@@ -353,7 +353,7 @@ def make_image_model(
                 )
             elif quantity_mode == "contrast":
                 image_model = ContrastImageModel(
-                    volume_parametrization,
+                    volume,
                     pose,
                     image_config,
                     scattering_theory,
@@ -361,7 +361,7 @@ def make_image_model(
                 )
             elif quantity_mode == "intensity":
                 image_model = IntensityImageModel(
-                    volume_parametrization,
+                    volume,
                     pose,
                     image_config,
                     scattering_theory,
@@ -672,7 +672,7 @@ def make_linear_operator(
         operator, vector = cxs.make_linear_operator(
             simulate_fn=lambda x: x.simulate(),
             args=image_model,
-            where_vector=lambda x: x.volume_parametrization.fourier_voxel_grid,
+            where_vector=lambda x: x.volume.fourier_voxel_grid,
         )
         # Simulate an image
         image = operator.mv(vector)

--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -246,7 +246,7 @@ class AbstractImageModel(eqx.Module, strict=True):
 class LinearImageModel(AbstractImageModel, strict=True):
     """An simple image model in linear image formation theory."""
 
-    volume_parametrization: AbstractVolumeParametrization
+    volume: AbstractVolumeParametrization
     pose: AbstractPose
     volume_integrator: AbstractVolumeIntegrator
     transfer_theory: ContrastTransferTheory
@@ -260,7 +260,7 @@ class LinearImageModel(AbstractImageModel, strict=True):
 
     def __init__(
         self,
-        volume_parametrization: AbstractVolumeParametrization,
+        volume: AbstractVolumeParametrization,
         pose: AbstractPose,
         image_config: AbstractImageConfig,
         transfer_theory: ContrastTransferTheory,
@@ -274,7 +274,7 @@ class LinearImageModel(AbstractImageModel, strict=True):
     ):
         """**Arguments:**
 
-        - `volume_parametrization`:
+        - `volume`:
             The parametrization of an imaging volume.
         - `pose`:
             The pose of the volume.
@@ -318,7 +318,7 @@ class LinearImageModel(AbstractImageModel, strict=True):
                 Do not apply the translation.
         """
         # Simulator components
-        self.volume_parametrization = volume_parametrization
+        self.volume = volume
         self.pose = pose
         self.image_config = image_config
         self.volume_integrator = volume_integrator
@@ -342,12 +342,10 @@ class LinearImageModel(AbstractImageModel, strict=True):
     ) -> PaddedFourierImageArray:
         # Get the representation of the volume
         if rng_key is None:
-            volume_representation = self.volume_parametrization.to_representation()
+            volume_representation = self.volume.to_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.to_representation(
-                rng_key=this_key
-            )
+            volume_representation = self.volume.to_representation(rng_key=this_key)
         # Rotate it to the lab frame
         volume_representation = volume_representation.rotate_to_pose(self.pose)
         # Translate if using atom translations
@@ -378,7 +376,7 @@ class LinearImageModel(AbstractImageModel, strict=True):
 class ProjectionImageModel(AbstractImageModel, strict=True):
     """An simple image model for computing a projection."""
 
-    volume_parametrization: AbstractVolumeParametrization
+    volume: AbstractVolumeParametrization
     pose: AbstractPose
     volume_integrator: AbstractVolumeIntegrator
     image_config: AbstractImageConfig
@@ -391,7 +389,7 @@ class ProjectionImageModel(AbstractImageModel, strict=True):
 
     def __init__(
         self,
-        volume_parametrization: AbstractVolumeParametrization,
+        volume: AbstractVolumeParametrization,
         pose: AbstractPose,
         image_config: AbstractImageConfig,
         volume_integrator: AbstractVolumeIntegrator = AutoVolumeProjection(),
@@ -404,7 +402,7 @@ class ProjectionImageModel(AbstractImageModel, strict=True):
     ):
         """**Arguments:**
 
-        - `volume_parametrization`:
+        - `volume`:
             The parametrization of the imaging volume
         - `pose`:
             The pose of the volume.
@@ -447,7 +445,7 @@ class ProjectionImageModel(AbstractImageModel, strict=True):
                 Do not apply the translation.
         """
         # Simulator components
-        self.volume_parametrization = volume_parametrization
+        self.volume = volume
         self.pose = pose
         self.image_config = image_config
         self.volume_integrator = volume_integrator
@@ -470,12 +468,10 @@ class ProjectionImageModel(AbstractImageModel, strict=True):
     ) -> ImageArray | PaddedImageArray:
         # Get the representation of the volume
         if rng_key is None:
-            volume_representation = self.volume_parametrization.to_representation()
+            volume_representation = self.volume.to_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.to_representation(
-                rng_key=this_key
-            )
+            volume_representation = self.volume.to_representation(rng_key=this_key)
         # Rotate it to the lab frame
         volume_representation = volume_representation.rotate_to_pose(self.pose)
         # Translate if using atom translations
@@ -509,7 +505,7 @@ class ContrastImageModel(AbstractPhysicalImageModel, strict=True):
     scattering theory.
     """
 
-    volume_parametrization: AbstractVolumeParametrization
+    volume: AbstractVolumeParametrization
     pose: AbstractPose
     image_config: AbstractImageConfig
     scattering_theory: AbstractScatteringTheory
@@ -522,7 +518,7 @@ class ContrastImageModel(AbstractPhysicalImageModel, strict=True):
 
     def __init__(
         self,
-        volume_parametrization: AbstractVolumeParametrization,
+        volume: AbstractVolumeParametrization,
         pose: AbstractPose,
         image_config: AbstractImageConfig,
         scattering_theory: AbstractScatteringTheory,
@@ -533,7 +529,7 @@ class ContrastImageModel(AbstractPhysicalImageModel, strict=True):
         signal_centering: Literal["bg", "mean"] = "mean",
         translate_mode: Literal["fft", "atom", "none"] = "fft",
     ):
-        self.volume_parametrization = volume_parametrization
+        self.volume = volume
         self.pose = pose
         self.image_config = image_config
         self.scattering_theory = scattering_theory
@@ -556,12 +552,10 @@ class ContrastImageModel(AbstractPhysicalImageModel, strict=True):
         # Get the volume representation. Its data should be a scattering potential
         # to simulate in physical units
         if rng_key is None:
-            volume_representation = self.volume_parametrization.to_representation()
+            volume_representation = self.volume.to_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.to_representation(
-                rng_key=this_key
-            )
+            volume_representation = self.volume.to_representation(rng_key=this_key)
         # Rotate it to the lab frame
         volume_representation = volume_representation.rotate_to_pose(self.pose)
         # Translate if using atom translations
@@ -590,7 +584,7 @@ class IntensityImageModel(AbstractPhysicalImageModel, strict=True):
     words a squared wavefunction.
     """
 
-    volume_parametrization: AbstractVolumeParametrization
+    volume: AbstractVolumeParametrization
     pose: AbstractPose
     image_config: AbstractImageConfig
     scattering_theory: AbstractScatteringTheory
@@ -603,7 +597,7 @@ class IntensityImageModel(AbstractPhysicalImageModel, strict=True):
 
     def __init__(
         self,
-        volume_parametrization: AbstractVolumeParametrization,
+        volume: AbstractVolumeParametrization,
         pose: AbstractPose,
         image_config: AbstractImageConfig,
         scattering_theory: AbstractScatteringTheory,
@@ -614,7 +608,7 @@ class IntensityImageModel(AbstractPhysicalImageModel, strict=True):
         signal_centering: Literal["bg", "mean"] = "mean",
         translate_mode: Literal["fft", "atom", "none"] = "fft",
     ):
-        self.volume_parametrization = volume_parametrization
+        self.volume = volume
         self.pose = pose
         self.image_config = image_config
         self.scattering_theory = scattering_theory
@@ -637,12 +631,10 @@ class IntensityImageModel(AbstractPhysicalImageModel, strict=True):
         # Get the volume representation. Its data should be a scattering potential
         # to simulate in physical units
         if rng_key is None:
-            volume_representation = self.volume_parametrization.to_representation()
+            volume_representation = self.volume.to_representation()
         else:
             this_key, rng_key = jr.split(rng_key)
-            volume_representation = self.volume_parametrization.to_representation(
-                rng_key=this_key
-            )
+            volume_representation = self.volume.to_representation(rng_key=this_key)
         # Rotate it to the lab frame
         volume_representation = volume_representation.rotate_to_pose(self.pose)
         # Translate if using atom translations
@@ -670,7 +662,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
     model for the detector.
     """
 
-    volume_parametrization: AbstractVolumeParametrization
+    volume: AbstractVolumeParametrization
     pose: AbstractPose
     image_config: DoseImageConfig
     scattering_theory: AbstractScatteringTheory
@@ -684,7 +676,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
 
     def __init__(
         self,
-        volume_parametrization: AbstractVolumeParametrization,
+        volume: AbstractVolumeParametrization,
         pose: AbstractPose,
         image_config: DoseImageConfig,
         scattering_theory: AbstractScatteringTheory,
@@ -696,7 +688,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
         signal_centering: Literal["bg", "mean"] = "mean",
         translate_mode: Literal["fft", "atom", "none"] = "fft",
     ):
-        self.volume_parametrization = volume_parametrization
+        self.volume = volume
         self.pose = pose
         self.image_config = image_config
         self.scattering_theory = scattering_theory
@@ -720,7 +712,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
         if rng_key is None:
             # Get the volume representation. Its data should be a scattering potential
             # to simulate in physical units
-            volume_representation = self.volume_parametrization.to_representation()
+            volume_representation = self.volume.to_representation()
             # Rotate it to the lab frame
             volume_representation = volume_representation.rotate_to_pose(self.pose)
             # Translate if using atom translations
@@ -750,7 +742,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
             keys = jr.split(rng_key, 3)
             # Get the volume representation. Its data should be a scattering potential
             # to simulate in physical units
-            volume_representation = self.volume_parametrization.to_representation(keys[0])
+            volume_representation = self.volume.to_representation(keys[0])
             # Rotate it to the lab frame
             volume_representation = volume_representation.rotate_to_pose(self.pose)
             # Translate if using atom translations
@@ -781,7 +773,7 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
 
 _init_doc = """**Arguments:**
 
-- `volume_parametrization`:
+- `volume`:
     The parametrization of the imaging volume.
 - `pose`:
     The pose of the volume.

--- a/docs/examples/simulate-relion-dataset.ipynb
+++ b/docs/examples/simulate-relion-dataset.ipynb
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -309,7 +309,7 @@
     "        conformation_rng_key, conformational_space, weights=(0.5, 0.5)\n",
     "    )\n",
     "    image_model = cxs.make_image_model(\n",
-    "        volume_parametrization=volume,\n",
+    "        volume=volume,\n",
     "        pose=pose,\n",
     "        image_config=image_config,\n",
     "        transfer_theory=transfer_theory,\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ import cryojax.simulator as cxs
 # Instantiate a cryoJAX `image_model`
 image_model = cxs.make_image_model(
     # ... load atoms as gaussians mixture from tabulated electron scattering factors
-    volume_parametrization=cxs.load_tabulated_volume(
+    volume=cxs.load_tabulated_volume(
         "example.pdb", output_type=cxs.GaussianMixtureVolume
     ),
     # ... configure the image

--- a/tests/test_linear_operator.py
+++ b/tests/test_linear_operator.py
@@ -42,7 +42,7 @@ def test_simulate_equality(image_model):
     linear_operator, vector = cxe.make_linear_operator(
         simulate_fn=lambda x: x.simulate(),
         args=image_model,
-        where_vector=lambda x: x.volume_parametrization.fourier_voxel_grid,
+        where_vector=lambda x: x.volume.fourier_voxel_grid,
     )
     image_cxs = image_model.simulate()
     image_lx = linear_operator.mv(vector)
@@ -50,7 +50,7 @@ def test_simulate_equality(image_model):
 
 
 def test_linear_transpose(image_model):
-    where_vector = lambda x: x.volume_parametrization.fourier_voxel_grid
+    where_vector = lambda x: x.volume.fourier_voxel_grid
     linear_operator, _ = cxe.make_linear_operator(
         simulate_fn=lambda x: x.simulate(),
         args=image_model,
@@ -69,7 +69,7 @@ def test_bad_linear_transpose(sample_pdb_path, image_config):
         image_config,
         pose=cxs.EulerAnglePose(),
     )
-    where_vector = lambda x: x.volume_parametrization.positions
+    where_vector = lambda x: x.volume.positions
     linear_operator, _ = cxe.make_linear_operator(
         simulate_fn=lambda x: x.simulate(),
         args=image_model,


### PR DESCRIPTION
While more ambiguous, this is an important user-facing API and I think using the full base class name here is too verbose and slightly hurts usability/clarity.