### PR TITLE
Simplifications and upgrades in `cryojax.dataset`: `RelionParticleStackDataset` -> `RelionParticleDataset` and remove typed dicts `ParticleStackInfo` and `ParticleParameterInfo`

### DIFF
--- a/cryojax/dataset/__init__.py
+++ b/cryojax/dataset/__init__.py
@@ -1,11 +1,50 @@
+import warnings as _warnings
+from typing import Any as _Any
+
 from ._dataset import AbstractDataset as AbstractDataset
 from ._particle_data import (
+    AbstractParticleDataset as AbstractParticleDataset,
     AbstractParticleParameterFile as AbstractParticleParameterFile,
-    AbstractParticleStackDataset as AbstractParticleStackDataset,
     AbstractParticleStarFile as AbstractParticleStarFile,
-    ParticleParameterInfo as ParticleParameterInfo,
-    ParticleStackInfo as ParticleStackInfo,
+    RelionParticleDataset as RelionParticleDataset,
     RelionParticleParameterFile as RelionParticleParameterFile,
-    RelionParticleStackDataset as RelionParticleStackDataset,
     simulate_particle_stack as simulate_particle_stack,
 )
+
+
+def __getattr__(name: str) -> _Any:
+    # Future deprecations
+    if name == "RelionParticleStackDataset":
+        _warnings.warn(
+            "The 'RelionParticleStackDataset' alias is deprecated and will be removed in "
+            "cryoJAX 0.6.0. Use 'RelionParticleDataset' instead.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        return RelionParticleDataset
+
+    if name == "ParticleParameterInfo":
+        _warnings.warn(
+            "The 'ParticleParameterInfo' TypedDict is deprecated and will be removed in "
+            "cryoJAX 0.6.0.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        from ._particle_data.relion import (
+            RelionParticleParameterInfo as RelionParticleParameterInfo,
+        )
+
+        return RelionParticleParameterInfo
+
+    if name == "ParticleStackInfo":
+        _warnings.warn(
+            "The 'ParticleStackInfo' TypedDict is deprecated and will be removed in "
+            "cryoJAX 0.6.0.",
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        from ._particle_data.relion import (
+            RelionParticleStackInfo as RelionParticleStackInfo,
+        )
+
+        return RelionParticleStackInfo

--- a/cryojax/dataset/_particle_data/__init__.py
+++ b/cryojax/dataset/_particle_data/__init__.py
@@ -1,12 +1,10 @@
 from .base_particle_dataset import (
+    AbstractParticleDataset as AbstractParticleDataset,
     AbstractParticleParameterFile as AbstractParticleParameterFile,
-    AbstractParticleStackDataset as AbstractParticleStackDataset,
 )
 from .particle_simulation import simulate_particle_stack as simulate_particle_stack
 from .relion import (
     AbstractParticleStarFile as AbstractParticleStarFile,
-    ParticleParameterInfo as ParticleParameterInfo,
-    ParticleStackInfo as ParticleStackInfo,
+    RelionParticleDataset as RelionParticleDataset,
     RelionParticleParameterFile as RelionParticleParameterFile,
-    RelionParticleStackDataset as RelionParticleStackDataset,
 )

--- a/cryojax/dataset/_particle_data/base_particle_dataset.py
+++ b/cryojax/dataset/_particle_data/base_particle_dataset.py
@@ -41,7 +41,7 @@ class AbstractParticleParameterFile(AbstractDataset[T1], Generic[T1, T2]):
         raise NotImplementedError
 
 
-class AbstractParticleStackDataset(AbstractDataset[T1], Generic[T1, T2]):
+class AbstractParticleDataset(AbstractDataset[T1], Generic[T1, T2]):
     @property
     @abc.abstractmethod
     def parameter_file(self) -> AbstractParticleParameterFile:

--- a/cryojax/dataset/_particle_data/particle_simulation.py
+++ b/cryojax/dataset/_particle_data/particle_simulation.py
@@ -7,11 +7,7 @@ import numpy as np
 from jaxtyping import Array, Float, Int, PyTree
 
 from ...jax_util import NDArrayLike, filter_bscan
-from .base_particle_dataset import (
-    AbstractParticleParameterFile,
-    AbstractParticleStackDataset,
-)
-from .relion import ParticleParameterInfo
+from .base_particle_dataset import AbstractParticleDataset, AbstractParticleParameterFile
 
 
 PerParticleT = TypeVar("PerParticleT")
@@ -20,8 +16,8 @@ T = TypeVar("T")
 
 
 def simulate_particle_stack(
-    dataset: AbstractParticleStackDataset,
-    compute_image_fn: Callable[
+    dataset: AbstractParticleDataset,
+    simulate_fn: Callable[
         [PyTree, ConstantT, PerParticleT],
         Float[Array, "_ _"],
     ],
@@ -32,52 +28,52 @@ def simulate_particle_stack(
     **kwargs: Any,
 ):
     """Write a stack of images from parameters contained in an
-    `AbstractParticleStackDataset`.
+    `AbstractParticleDataset`.
 
     !!! note
-        This function works generally for a `compute_image_fn`
+        This function works generally for a `simulate_fn`
         of the form
 
         ```python
-        image = compute_image_fn(
-            parameters, constant_args, per_particle_args
+        image = simulate_fn(
+            parameter_info, constant_args, per_particle_args
         )
         ```
 
-        where `parameters` is the pytree read from the
-        `AbstractParticleStackDataset.parameter_file`,
+        where `parameter_info` is the pytree read from the
+        `AbstractParticleDataset.parameter_file`,
         `constant_args` is a parameter that does not change
         between images, and `per_particle_args` is a pytree whose
         leaves have a batch dimension equal to the number of particles
         to be simulated.
 
     *Example 1*: Basic usage such as instantiating an
-    `AbstractParticleStackDataset` and writing a
-    `compute_image_fn`
+    `AbstractParticleDataset` and writing a
+    `simulate_fn`
 
     ```python
     import cryojax.simulator as cxs
     import jax
-    from cryojax.data import RelionParticleStackDataset
+    from cryojax.data import RelionParticleDataset
     from jaxtyping import PyTree
 
-    # Load a `RelionParticleStackDataset` object. This loads
+    # Load a `RelionParticleDataset` object. This loads
     # parameters and writes images
-    dataset = RelionParticleStackDataset(..., mode='w')
+    dataset = RelionParticleDataset(..., mode='w')
 
-    # Write your `compute_image_fn` function, building an
+    # Write your `simulate_fn` function, building an
     # `AbstractImageModel` (see tutorials for details)
 
-    def compute_image_fn(
-        parameters: RelionParticleParameters,
+    def simulate_fn(
+        parameter_info: PyTree, # loaded from `dataset.parameter_file`
         constant_args: PyTree,
         _,
     ) -> jax.Array:
         # `constant_args` do not change between images. For
         # example, include the method of taking projections
-        integrator, ... = constant_args
+        ... = constant_args
         # Using the pose, CTF, and image config from the
-        # `parameters`, build image simulation model
+        # `parameter_info`, build image simulation model
         image_model = cxs.make_image_model(...)
         # ... and compute
         return image_model.simulate()
@@ -85,26 +81,26 @@ def simulate_particle_stack(
     # Simulate images and write to disk
     simulate_particle_stack(
         dataset,
-        compute_image_fn,
-        constant_args=(integrator, ...)
+        simulate_fn,
+        constant_args=(...)
         per_particle_args=None, # default
         batch_size=10,
     )
     ```
 
     *Example 2*: More-advanced usage, writing a
-    `compute_image_fn` that simulates images with noise.
+    `simulate_fn` that simulates images with noise.
     Uses `per_particle_args` as well as `constant_args`.
 
     ```python
     import cryojax.simulator as cxs
     import jax
-    from cryojax.data import RelionParticleStackDataset
+    from cryojax.data import RelionParticleDataset
     from jaxtyping import Array, PyTree, Shaped
 
-    # Load a `RelionParticleStackDataset` object. This loads
+    # Load a `RelionParticleDataset` object. This loads
     # parameters and writes images
-    dataset = RelionParticleStackDataset(..., mode='w')
+    dataset = RelionParticleDataset(..., mode='w')
 
     # Instantiate per-particle arguments. First, the RNG keys used
     # to generate the noise
@@ -116,12 +112,12 @@ def simulate_particle_stack(
     key, subkey = jax.random.split(key)
     scaling_params = jax.random.uniform(subkey, shape=(n_images,))
 
-    # Now write your `compute_image_fn` function, building a
-    # `cryojax.simulator.UncorrelationGaussianNoiseModel` to
+    # Now write your `simulate_fn` function, building a
+    # `cryojax.simulator.GaussianWhiteNoiseModel` to
     # simulate images with white noise (see tutorials for details)
 
-    def compute_image_fn(
-        particle_parameters: RelionParticleParameters,
+    def simulate_fn(
+        parameter_info: PyTree,
         constant_args: PyTree,
         per_particle_args: PyTree[Shaped[Array, "_ ..."]],
     ) -> jax.Array:
@@ -130,13 +126,13 @@ def simulate_particle_stack(
 
         # Combine two previously split PyTrees
         image_model = cxs.make_image_model(...)
-        distribution = cxs.UncorrelatedGaussianNoiseModel(image_model, ...)
+        distribution = cxs.GaussianWhiteNoiseModel(image_model, ...)
 
         return scale * distribution.sample(key)
 
     simulate_particle_stack(
         dataset,
-        compute_image_fn,
+        simulate_fn,
         constant_args=(...)
         per_particle_args=(keys_noise, scaling_params)
         batch_size=10,
@@ -146,16 +142,16 @@ def simulate_particle_stack(
     **Arguments:**
 
     - `dataset`:
-        The `AbstractParticleStackDataset` dataset. Note that this must be
+        The `AbstractParticleDataset` dataset. Note that this must be
         passed in *writing mode*, i.e. `mode = 'w'`.
-    - `compute_image_fn`:
+    - `simulate_fn`:
         A callable that computes the image stack from the parameters contained
         in the STAR file.
     - `constant_args`:
-        The constant arguments to pass to the `compute_image_fn` function.
+        The constant arguments to pass to the `simulate_fn` function.
         These must be the same for all images.
     - `per_particle_args`:
-        Arguments to pass to the `compute_image_fn` function.
+        Arguments to pass to the `simulate_fn` function.
         This is a pytree with leaves having a batch size with equal dimension
         to the number of images.
     - `batch_size`:
@@ -168,7 +164,7 @@ def simulate_particle_stack(
         set this as the number of particles in the dataset.
     - `kwargs`:
         Keyword arguments passed to
-        `AbstractParticleStackDataset.parameter_dataset.save`.
+        `AbstractParticleDataset.parameter_file.save`.
     """
     if dataset.mode == "r":
         raise ValueError(
@@ -179,8 +175,8 @@ def simulate_particle_stack(
     n_particles = len(dataset)
     images_per_file = n_particles if images_per_file is None else images_per_file
     # Get function that simulates batch of images
-    compute_image_stack_fn = _configure_simulation_fn(
-        compute_image_fn,
+    simulate_batch_fn = _configure_simulation_fn(
+        simulate_fn,
         batch_size,
         images_per_file,
     )
@@ -194,28 +190,26 @@ def simulate_particle_stack(
         dataset_index = np.arange(
             file_index * images_per_file, (file_index + 1) * images_per_file, dtype=int
         )
-        images, parameters = _simulate_images(
+        images, parameter_info = _simulate_images(
             dataset_index,
             parameter_file,
-            compute_image_stack_fn,
+            simulate_batch_fn,
             constant_args,
             per_particle_args,
         )
-        dataset.write_images(dataset_index, images, parameters)
+        dataset.write_images(dataset_index, images, parameter_info)
     # ... handle remainder
     if remainder > 0:
-        compute_image_stack_fn = _configure_simulation_fn(
-            compute_image_fn, batch_size, remainder
-        )
+        simulate_batch_fn = _configure_simulation_fn(simulate_fn, batch_size, remainder)
         index_array = np.arange(n_particles - remainder, n_particles, dtype=int)
-        images, parameters = _simulate_images(
+        images, parameter_info = _simulate_images(
             index_array,
             parameter_file,
-            compute_image_stack_fn,
+            simulate_batch_fn,
             constant_args,
             per_particle_args,
         )
-        dataset.write_images(index_array, images, parameters)
+        dataset.write_images(index_array, images, parameter_info)
     # Finally, save metadata file
     parameter_file.save(**kwargs)
 
@@ -223,22 +217,22 @@ def simulate_particle_stack(
 def _simulate_images(
     index: Int[np.ndarray, " _"],
     parameter_file: AbstractParticleParameterFile,
-    compute_image_stack_fn: Callable[
+    simulate_batch_fn: Callable[
         [PyTree, ConstantT, PerParticleT],
         Float[NDArrayLike, "_ _ _"],
     ],
     constant_args: ConstantT,
     per_particle_args: PerParticleT,
-) -> tuple[Float[NDArrayLike, "_ _ _"], ParticleParameterInfo]:
-    parameters = parameter_file[index]
+) -> tuple[Float[NDArrayLike, "_ _ _"], PyTree]:
+    parameter_info = parameter_file[index]
     args = (constant_args, _index_pytree(index, per_particle_args))
-    image_stack = compute_image_stack_fn(parameters, *args)
+    image_stack = simulate_batch_fn(parameter_info, *args)
 
-    return image_stack, parameters
+    return image_stack, parameter_info
 
 
 def _configure_simulation_fn(
-    compute_image_fn: Callable[
+    simulate_fn: Callable[
         [PyTree, ConstantT, PerParticleT],
         Float[Array, "_ _"],
     ],
@@ -250,14 +244,20 @@ def _configure_simulation_fn(
 ]:
     if batch_size is None:
 
-        def compute_image_stack_fn(parameters, constant_args, per_particle_args):  # type: ignore
-            shape = parameters["image_config"].shape
+        def simulate_batch_fn(parameter_info, constant_args, per_particle_args):  # type: ignore
+            parameter_info_at_0, per_particle_args_at_0 = (
+                _index_pytree(0, parameter_info),
+                _index_pytree(0, per_particle_args),
+            )
+            shape = _determine_output_shape(
+                simulate_fn, parameter_info_at_0, constant_args, per_particle_args_at_0
+            )
             image_stack = np.empty((images_per_file, *shape))
             for i in range(images_per_file):
-                parameters_at_i = _index_pytree(i, parameters)
+                parameter_info_at_i = _index_pytree(i, parameter_info)
                 per_particle_args_at_i = _index_pytree(i, per_particle_args)
-                image = compute_image_fn(
-                    parameters_at_i, constant_args, per_particle_args_at_i
+                image = simulate_fn(
+                    parameter_info_at_i, constant_args, per_particle_args_at_i
                 )
                 image_stack[i] = np.asarray(image)
             return image_stack
@@ -265,23 +265,23 @@ def _configure_simulation_fn(
     else:
         batch_size = min(images_per_file, batch_size)
         compute_vmap = eqx.filter_vmap(
-            compute_image_fn, in_axes=(eqx.if_array(0), None, eqx.if_array(0))
+            simulate_fn, in_axes=(eqx.if_array(0), None, eqx.if_array(0))
         )
         if batch_size == images_per_file:
-            compute_image_stack_fn = eqx.filter_jit(compute_vmap)
+            simulate_batch_fn = eqx.filter_jit(compute_vmap)
         else:
 
             @eqx.filter_jit
-            def compute_image_stack_fn(parameters, constant_args, per_particle_args):
+            def simulate_batch_fn(parameter_info, constant_args, per_particle_args):
                 # Compute with `jax.lax.scan` via `cryojax.jax_util.filter_bscan`
                 init = constant_args
-                xs = (parameters, per_particle_args)
+                xs = (parameter_info, per_particle_args)
 
                 def f_scan(carry, xs):
                     _constant_args = carry
-                    _parameters, _per_particle_args = xs
+                    _parameter_info, _per_particle_args = xs
                     image_stack = compute_vmap(
-                        _parameters, _constant_args, _per_particle_args
+                        _parameter_info, _constant_args, _per_particle_args
                     )
                     return carry, image_stack
 
@@ -289,7 +289,7 @@ def _configure_simulation_fn(
 
                 return image_stack
 
-    return compute_image_stack_fn  # type: ignore
+    return simulate_batch_fn  # type: ignore
 
 
 def _index_pytree(
@@ -298,3 +298,10 @@ def _index_pytree(
     dynamic, static = eqx.partition(pytree, eqx.is_array)
     dynamic_at_index = jax.tree.map(lambda x: x[index], dynamic)
     return eqx.combine(dynamic_at_index, static)
+
+
+def _determine_output_shape(_fn, *_args):
+    jaxpr_fn = eqx.filter_make_jaxpr(_fn)
+    _, out_dynamic, out_static = jaxpr_fn(*_args)
+    out_struct = eqx.combine(out_dynamic, out_static)
+    return out_struct.shape

--- a/cryojax/dataset/_particle_data/relion.py
+++ b/cryojax/dataset/_particle_data/relion.py
@@ -26,10 +26,7 @@ from ...simulator import (
     ContrastTransferTheory,
     EulerAnglePose,
 )
-from .._particle_data import (
-    AbstractParticleParameterFile,
-    AbstractParticleStackDataset,
-)
+from .base_particle_dataset import AbstractParticleDataset, AbstractParticleParameterFile
 
 
 # RELION column entries
@@ -80,7 +77,7 @@ RELION_SUPPORTED_PARTICLE_ENTRIES = [
 ]
 
 
-class ParticleParameterInfo(TypedDict):
+class RelionParticleParameterInfo(TypedDict):
     """Parameters for a particle stack from RELION."""
 
     image_config: BasicImageConfig
@@ -90,15 +87,15 @@ class ParticleParameterInfo(TypedDict):
     metadata: pd.DataFrame | None
 
 
-class ParticleStackInfo(TypedDict):
+class RelionParticleStackInfo(TypedDict):
     """Particle stack info from RELION."""
 
-    parameters: ParticleParameterInfo | None
+    parameters: RelionParticleParameterInfo | None
     images: Float[np.ndarray, "... y_dim x_dim"]
 
 
-ParticleParameterLike = dict[str, Any] | ParticleParameterInfo
-ParticleStackLike = dict[str, Any] | ParticleStackInfo
+ParticleParameterLike = dict[str, Any] | RelionParticleParameterInfo
+ParticleStackLike = dict[str, Any] | RelionParticleStackInfo
 
 
 class StarfileData(TypedDict):
@@ -116,7 +113,7 @@ class MrcfileSettings(TypedDict):
 
 
 class AbstractParticleStarFile(
-    AbstractParticleParameterFile[ParticleParameterInfo, ParticleParameterLike]
+    AbstractParticleParameterFile[RelionParticleParameterInfo, ParticleParameterLike]
 ):
     @property
     @override
@@ -246,9 +243,9 @@ class RelionParticleParameterFile(AbstractParticleStarFile):
             filter by class using
             `selection_filter["rlnClassNumber"] = lambda x: x == 0`.
         - `loads_metadata`:
-            If `True`, the resulting `ParticleParameterInfo` dict loads
+            If `True`, the resulting `RelionParticleParameterInfo` dict loads
             the raw metadata from the STAR file that is not otherwise included
-            in the `ParticleParameterInfo` as a `pandas.DataFrame`.
+            in the `RelionParticleParameterInfo` as a `pandas.DataFrame`.
             If this is set to `True`, note that dictionaries cannot pass through
             JIT boundaries without removing the metadata.
         - `broadcasts_image_config`:
@@ -293,7 +290,7 @@ class RelionParticleParameterFile(AbstractParticleStarFile):
     @override
     def __getitem__(
         self, index: int | slice | Int[np.ndarray, ""] | Int[np.ndarray, " _"]
-    ) -> ParticleParameterInfo:
+    ) -> RelionParticleParameterInfo:
         # Validate index
         n_rows = self.starfile_data["particles"].shape[0]
         _validate_dataset_index(type(self), index, n_rows)
@@ -328,7 +325,7 @@ class RelionParticleParameterFile(AbstractParticleStarFile):
         else:
             metadata = None
 
-        return ParticleParameterInfo(
+        return RelionParticleParameterInfo(
             image_config=image_config,
             pose=pose,
             transfer_theory=transfer_theory,
@@ -538,8 +535,8 @@ class RelionParticleParameterFile(AbstractParticleStarFile):
         self._rotation_convention = _validate_rotation_convention(value)
 
 
-class RelionParticleStackDataset(
-    AbstractParticleStackDataset[ParticleStackInfo, ParticleStackLike]
+class RelionParticleDataset(
+    AbstractParticleDataset[RelionParticleStackInfo, ParticleStackLike]
 ):
     """A dataset that wraps a RELION particle stack in
     [STAR](https://relion.readthedocs.io/en/latest/Reference/Conventions.html) format.
@@ -635,7 +632,7 @@ class RelionParticleStackDataset(
                 )
             if not project_exists:
                 raise FileNotFoundError(
-                    "`RelionParticleStackDataset` opened in "
+                    "`RelionParticleDataset` opened in "
                     "'mode = `r`', but the RELION project directory "
                     "`path_to_relion_project` does not exist. "
                     "To write images in a STAR file in a new RELION project, "
@@ -645,7 +642,7 @@ class RelionParticleStackDataset(
     @override
     def __getitem__(
         self, index: int | slice | Int[np.ndarray, ""] | Int[np.ndarray, " N"]
-    ) -> ParticleStackInfo:
+    ) -> RelionParticleStackInfo:
         if self.loads_parameters:
             # Load images and parameters. First, read parameters
             # and metadata from the STAR file
@@ -670,7 +667,7 @@ class RelionParticleStackDataset(
             if parameters["pose"].offset_x_in_angstroms.ndim == 0:
                 images = np.squeeze(images)
 
-            return ParticleStackInfo(parameters=parameters, images=images)
+            return RelionParticleStackInfo(parameters=parameters, images=images)
         else:
             # Otherwise, do not read parameters to more efficiently read images. First,
             # validate the dataset index.
@@ -699,7 +696,7 @@ class RelionParticleStackDataset(
             ):
                 images = np.squeeze(images)
 
-            return ParticleStackInfo(parameters=None, images=images)
+            return RelionParticleStackInfo(parameters=None, images=images)
 
     @override
     def __len__(self) -> int:
@@ -832,7 +829,7 @@ class RelionParticleStackDataset(
                 "file. Most likely, the filename the writer "
                 f"chose ({str(path_to_filename)}) already "
                 "exists. Try changing the "
-                "`RelionParticleStackDataset.mrcfile_settings`. "
+                "`RelionParticleDataset.mrcfile_settings`. "
                 f"The error message was:\n{err}"
             )
 
@@ -1333,7 +1330,7 @@ def _validate_rln_image_name_exists(particle_data, index):
     if "rlnImageName" not in particle_data.columns:
         raise OSError(
             "Tried to read STAR file for "
-            f"`RelionParticleStackDataset` index = {index}, "
+            f"`RelionParticleDataset` index = {index}, "
             "but no entry found for 'rlnImageName'."
         )
 

--- a/docs/examples/read-dataset.ipynb
+++ b/docs/examples/read-dataset.ipynb
@@ -48,23 +48,23 @@
    "outputs": [],
    "source": [
     "# CryoJAX imports\n",
-    "from cryojax.dataset import RelionParticleParameterFile, RelionParticleStackDataset"
+    "from cryojax.dataset import RelionParticleDataset, RelionParticleParameterFile"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we will read in the RELION particle stack using the `cryojax` particle stack loader `RelionParticleStackDataset`.\n",
+    "First, we will read in the RELION particle stack using the `cryojax` particle stack loader `RelionParticleDataset`.\n",
     "\n",
-    "!!! info \"What is a `RelionParticleStackDataset`?\"\n",
+    "!!! info \"What is a `RelionParticleDataset`?\"\n",
     "\n",
-    "    CryoJAX implements an abstraction an a dataset in RELION, called a `RelionParticleStackDataset`. This object takes in a\n",
+    "    CryoJAX implements an abstraction an a dataset in RELION, called a `RelionParticleDataset`. This object takes in a\n",
     "    RELION STAR file for a particle stack. Upon accessing an image in the particle stack, a dictionary with keys 'parameters' and 'images' is returned.\n",
     "    The parameters are also a dictionary with cryoJAX objects instantiated from the\n",
     "    information in the STAR file, such as the contrast transfer function (the `AstigmaticCTF` class) and the pose (the `EulerAnglePose` class).\n",
     "\n",
-    "    More generally, a `RelionParticleStackDataset` is an `AbstractDataset`.\n",
+    "    More generally, a `RelionParticleDataset` is an `AbstractDataset`.\n",
     "    This abstract interface are part of the `cryojax` public API!"
    ]
   },
@@ -86,7 +86,7 @@
       "      pixel_size=f32[](numpy),\n",
       "      voltage_in_kilovolts=f32[](numpy),\n",
       "      grid_helper=None,\n",
-      "      pad_options={'grid_helper': None, 'mode': 'constant', 'shape': (100, 100)}\n",
+      "      pad_options={'grid_helper': None, 'shape': (100, 100)}\n",
       "    ),\n",
       "    'pose':\n",
       "    EulerAnglePose(\n",
@@ -122,7 +122,7 @@
     "    broadcasts_image_config=True,  # If `True`, this is useful for vmapping\n",
     "    loads_envelope=False,  # If `False`, assumes b_factor is 0 and CTF amplitude is 1\n",
     ")\n",
-    "dataset = RelionParticleStackDataset(\n",
+    "dataset = RelionParticleDataset(\n",
     "    parameter_file,\n",
     "    path_to_relion_project=\"./\",\n",
     ")\n",
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upon inspecting the zeroth element of the `RelionParticleStackDataset`, we see that a `ParticleStackInfo` dict is returned. We can access a particular image by accessing the 'images' key. Let's normalize this image, plot it, and make sure the mean and standard deviation are zero and one, respectively."
+    "Upon inspecting the zeroth element of the `RelionParticleDataset`, we see that a dict is returned with keys 'parameters' and 'images'. Let's grab the image, normalize it, plot it, and make sure the mean and standard deviation are zero and one, respectively."
    ]
   },
   {
@@ -148,6 +148,14 @@
      "output_type": "stream",
      "text": [
       "Image mean: 3.814697e-09 Image standard deviation: 1.0000001\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/37/7n3d9k7903zc8cy1_374smt00000gn/T/ipykernel_90302/2205053247.py:2: FutureWarning: 'normalize_image' is deprecated and has been renamed to 'standardize_image'. The old name will be deprecated in cryoJAX 0.6.0.\n",
+      "  from cryojax.ndimage import normalize_image\n"
      ]
     },
     {
@@ -215,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -283,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -345,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -356,7 +364,7 @@
        " None]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/docs/examples/simulate-relion-dataset.ipynb
+++ b/docs/examples/simulate-relion-dataset.ipynb
@@ -231,7 +231,7 @@
     "Now, define a function that simulates images given the `DiscreteConformationSampler`. Ultimately this will be passed to the `cryojax.dataset.simulate_particle_stack` utility. For reasons we will see, the following function signature is required.\n",
     "\n",
     "```python\n",
-    "def compute_image(particle_parameters, constant_args, per_particle_args):\n",
+    "def simulate_fn(particle_parameters, constant_args, per_particle_args):\n",
     "    \"\"\"Compute a single image from the given particle parameters.\n",
     "\n",
     "    **Arguments:**\n",
@@ -259,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -289,7 +289,7 @@
     "import jax.random as jr\n",
     "\n",
     "\n",
-    "def compute_image(particle_parameters, conformational_space, rng_key):\n",
+    "def simulate_fn(particle_parameters, conformational_space, rng_key):\n",
     "    # Generate RNG keys for each part of the process\n",
     "    conformation_rng_key, noise_rng_key, snr_rng_key = jr.split(rng_key, 3)\n",
     "    # Build image model, including normalization within a circular mask\n",
@@ -331,7 +331,7 @@
     "# Simulate a test image\n",
     "fig, ax = plt.figure(figsize=(3, 3)), plt.gca()\n",
     "test_parameters = parameter_file[0]\n",
-    "image = compute_image(test_parameters, conformational_space, rng_key=jax.random.key(1234))\n",
+    "image = simulate_fn(test_parameters, conformational_space, rng_key=jax.random.key(1234))\n",
     "plot_image(image, fig, ax, label=\"Simulated Image\")"
    ]
   },
@@ -345,7 +345,7 @@
     "    This function takes in two key arguments: a STAR file and a function\n",
     "    that simulates images. We just defined the latter, but we also need\n",
     "    build off of the `RelionParticleParameterFile` we defined and build what\n",
-    "    is called a `RelionParticleStackDataset`. This specifies how to write\n",
+    "    is called a `RelionParticleDataset`. This specifies how to write\n",
     "    the MRC files."
    ]
   },
@@ -357,17 +357,17 @@
    "source": [
     "import pathlib\n",
     "\n",
-    "from cryojax.dataset import RelionParticleStackDataset\n",
+    "from cryojax.dataset import RelionParticleDataset\n",
     "\n",
     "\n",
-    "# Instantiate MRC I/O via the `RelionParticleStackDataset`\n",
+    "# Instantiate MRC I/O via the `RelionParticleDataset`\n",
     "path_to_relion_project = \"./outputs/\"\n",
     "mrcfile_output_folder = \"images/\"\n",
     "path_to_mrcfiles = pathlib.Path(path_to_relion_project, mrcfile_output_folder)\n",
     "if not path_to_mrcfiles.exists():\n",
     "    path_to_mrcfiles.mkdir(parents=True, exist_ok=False)\n",
     "\n",
-    "dataset = RelionParticleStackDataset(\n",
+    "dataset = RelionParticleDataset(\n",
     "    parameter_file,\n",
     "    path_to_relion_project=path_to_relion_project,\n",
     "    mode=\"w\",\n",
@@ -397,7 +397,7 @@
     "rng_keys = jax.random.split(jax.random.key(seed=1234), num=len(dataset))\n",
     "simulate_particle_stack(\n",
     "    dataset,\n",
-    "    compute_image_fn=compute_image,\n",
+    "    simulate_fn,\n",
     "    constant_args=conformational_space,\n",
     "    per_particle_args=rng_keys,\n",
     "    batch_size=10,  # how many images to simulate in parallel\n",
@@ -410,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, as we saw in the [load cryo-EM images](https://michael-0brien.github.io/cryojax/examples/read-dataset/) tutorial, we can load images and parameters using the `RelionParticleStackDataset`."
+    "Finally, as we saw in the [load cryo-EM images](https://michael-0brien.github.io/cryojax/examples/read-dataset/) tutorial, we can load images and parameters using the `RelionParticleDataset`."
    ]
   },
   {

--- a/tests/test_relion_dataset.py
+++ b/tests/test_relion_dataset.py
@@ -18,8 +18,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from cryojax.dataset import (
+    RelionParticleDataset,
     RelionParticleParameterFile,
-    RelionParticleStackDataset,
     simulate_particle_stack,
 )
 from cryojax.dataset._particle_data.relion import (
@@ -95,7 +95,7 @@ def relion_parameters():
 class TestErrorRaisingForLoading:
     def test_load_with_badparticle_name(self, parameter_file, sample_relion_project_path):
         parameter_file.starfile_data["particles"].loc[0, "rlnImageName"] = 0.0
-        dataset = RelionParticleStackDataset(
+        dataset = RelionParticleDataset(
             path_to_relion_project=sample_relion_project_path,
             parameter_file=parameter_file,
         )
@@ -106,7 +106,7 @@ class TestErrorRaisingForLoading:
             self, parameter_file, sample_relion_project_path
         ):
             parameter_file.starfile_data["particles"].loc[0, "rlnImageName"] = "0000.mrcs"
-            dataset = RelionParticleStackDataset(
+            dataset = RelionParticleDataset(
                 path_to_relion_project=sample_relion_project_path,
                 parameter_file=parameter_file,
             )
@@ -115,7 +115,7 @@ class TestErrorRaisingForLoading:
 
     def test_load_with_bad_shape(self, parameter_file, sample_relion_project_path):
         parameter_file.starfile_data["optics"].loc[0, "rlnImageSize"] = 1
-        dataset = RelionParticleStackDataset(
+        dataset = RelionParticleDataset(
             path_to_relion_project=sample_relion_project_path,
             parameter_file=parameter_file,
         )
@@ -123,7 +123,7 @@ class TestErrorRaisingForLoading:
             dataset[0]
 
     def test_with_bad_indices(self, parameter_file, sample_relion_project_path):
-        dataset = RelionParticleStackDataset(
+        dataset = RelionParticleDataset(
             path_to_relion_project=sample_relion_project_path,
             parameter_file=parameter_file,
         )
@@ -475,7 +475,7 @@ def test_load_starfile_vs_mrcs_shape(sample_starfile_path, sample_relion_project
         loads_metadata=False,
         broadcasts_image_config=False,
     )
-    dataset = RelionParticleStackDataset(
+    dataset = RelionParticleDataset(
         parameter_file, sample_relion_project_path, loads_parameters=True
     )
 
@@ -504,7 +504,7 @@ def test_load_starfile_vs_mrcs_shape(sample_starfile_path, sample_relion_project
 def test_no_load_parameters(sample_starfile_path, sample_relion_project_path):
     """Test loading a starfile with mrcs."""
     parameter_file = RelionParticleParameterFile(path_to_starfile=sample_starfile_path)
-    dataset = RelionParticleStackDataset(
+    dataset = RelionParticleDataset(
         parameter_file, sample_relion_project_path, loads_parameters=True
     )
 
@@ -833,7 +833,7 @@ def test_write_image(
         "tests/outputs/starfile_writing/test_particle_parameters.star"
     )
 
-    dataset = RelionParticleStackDataset(
+    dataset = RelionParticleDataset(
         parameter_file,
         path_to_relion_project=sample_relion_project_path,
         mode="w",
@@ -1028,7 +1028,7 @@ def test_write_simulated_image_stack_from_starfile_jit(sample_starfile_path):
     )
 
     # Create a simulated image stack
-    new_stack = RelionParticleStackDataset(
+    new_stack = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",
@@ -1037,7 +1037,7 @@ def test_write_simulated_image_stack_from_starfile_jit(sample_starfile_path):
 
     simulate_particle_stack(
         new_stack,
-        compute_image_fn=_mock_compute_image,
+        simulate_fn=_mock_compute_image,
         constant_args=(1.0, 2.0),
         per_particle_args=true_images,
         is_jittable=True,
@@ -1047,7 +1047,7 @@ def test_write_simulated_image_stack_from_starfile_jit(sample_starfile_path):
     # try to overwrite
     simulate_particle_stack(
         new_stack,
-        compute_image_fn=_mock_compute_image,
+        simulate_fn=_mock_compute_image,
         constant_args=(1.0, 2.0),
         per_particle_args=true_images,
         is_jittable=True,
@@ -1058,7 +1058,7 @@ def test_write_simulated_image_stack_from_starfile_jit(sample_starfile_path):
     with pytest.raises(FileExistsError):
         simulate_particle_stack(
             new_stack,
-            compute_image_fn=_mock_compute_image,
+            simulate_fn=_mock_compute_image,
             constant_args=(1.0, 2.0),
             per_particle_args=true_images,
             is_jittable=True,
@@ -1066,7 +1066,7 @@ def test_write_simulated_image_stack_from_starfile_jit(sample_starfile_path):
         )
 
     # load the simulated image stack
-    particle_dataset = RelionParticleStackDataset(
+    particle_dataset = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="r",
@@ -1089,7 +1089,7 @@ def test_write_simulated_image_stack_from_starfile_nojit(sample_starfile_path):
         # Mock the image computation
         c1, c2 = constant_args
         image = per_particle_args
-        return image / np.linalg.norm(image)
+        return image / jnp.linalg.norm(image)
 
     """Test writing a simulated image stack from a starfile."""
     parameter_file = RelionParticleParameterFile(
@@ -1109,7 +1109,7 @@ def test_write_simulated_image_stack_from_starfile_nojit(sample_starfile_path):
     )
 
     # Create a simulated image stack
-    new_stack = RelionParticleStackDataset(
+    new_stack = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",
@@ -1118,13 +1118,13 @@ def test_write_simulated_image_stack_from_starfile_nojit(sample_starfile_path):
 
     simulate_particle_stack(
         new_stack,
-        compute_image_fn=_mock_compute_image,
+        simulate_fn=_mock_compute_image,
         constant_args=(1.0, 2.0),
         per_particle_args=true_images,
         overwrite=True,
     )
 
-    particle_dataset = RelionParticleStackDataset(
+    particle_dataset = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="r",
@@ -1147,7 +1147,7 @@ def test_write_single_image(sample_starfile_path):
         c1, c2 = constant_args
         p1, p2 = per_particle_args
         image = jnp.ones(particle_parameters["image_config"].shape, dtype=jnp.float32)
-        return image / np.linalg.norm(image)
+        return image / jnp.linalg.norm(image)
 
     selection_filter = {
         "rlnImageName": lambda x: np.where(x == "0000001@000000.mrcs", True, False)
@@ -1165,7 +1165,7 @@ def test_write_single_image(sample_starfile_path):
     )
 
     # Create a simulated image stack
-    new_stack = RelionParticleStackDataset(
+    new_stack = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",
@@ -1175,14 +1175,14 @@ def test_write_single_image(sample_starfile_path):
     n_images = 1
     simulate_particle_stack(
         new_stack,
-        compute_image_fn=_mock_compute_image,
+        simulate_fn=_mock_compute_image,
         constant_args=(1.0, 2.0),
         per_particle_args=(3.0 * jnp.ones(n_images), 4.0 * jnp.ones(n_images)),
         overwrite=True,
         images_per_file=1,
     )
 
-    particle_dataset = RelionParticleStackDataset(
+    particle_dataset = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="r",
@@ -1239,7 +1239,7 @@ def test_load_multiple_mrcs():
         jax.random.key(0), shape=(n_images, *shape), dtype=jnp.float32
     )
 
-    new_dataset = RelionParticleStackDataset(
+    new_dataset = RelionParticleDataset(
         parameters_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",
@@ -1249,7 +1249,7 @@ def test_load_multiple_mrcs():
     # Create a simulated image stack
     simulate_particle_stack(
         new_dataset,
-        compute_image_fn=_mock_compute_image,
+        simulate_fn=_mock_compute_image,
         constant_args=(1.0, 2.0),
         per_particle_args=true_images,
         overwrite=True,
@@ -1258,7 +1258,7 @@ def test_load_multiple_mrcs():
     )
 
     n_tests = 10
-    for i in range(n_tests):
+    for _ in range(n_tests):
         indices = np.random.choice(len(parameters_file), size=3, replace=False)
 
         images = new_dataset[indices]["images"]
@@ -1334,7 +1334,7 @@ def test_raise_errors_stack_dataset(sample_starfile_path, sample_relion_project_
     }
 
     with pytest.raises(IOError):
-        particle_dataset = RelionParticleStackDataset(
+        particle_dataset = RelionParticleDataset(
             parameter_file,
             path_to_relion_project=sample_relion_project_path,
             mode="r",
@@ -1345,7 +1345,7 @@ def test_raise_errors_stack_dataset(sample_starfile_path, sample_relion_project_
     parameter_file.path_to_starfile = (
         "tests/outputs/starfile_writing/test_particle_parameters.star"
     )
-    particle_dataset = RelionParticleStackDataset(
+    particle_dataset = RelionParticleDataset(
         parameter_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",
@@ -1418,7 +1418,7 @@ def test_append_relion_stack_dataset():
         loads_envelope=True,
     )
 
-    new_stack = RelionParticleStackDataset(
+    new_stack = RelionParticleDataset(
         new_parameters_file,
         path_to_relion_project="tests/outputs/starfile_writing/",
         mode="w",


### PR DESCRIPTION
This PR makes changes to assist with PR #524. The changed features are kept for deprecation.

This also makes upgrades to `simulate_particle_stack`, allowing the simulation function passed to it to accept arbitrary pytrees as input. 