### PR TITLE
Explicitly determine rotation convention: `make_image_model(..., rotation_convention=...)`

### DIFF
--- a/cryojax/simulator/_api_utils.py
+++ b/cryojax/simulator/_api_utils.py
@@ -49,14 +49,19 @@ from ._volume import (
 identity_fn = eqxi.doc_repr(lambda x, _: x, "identity_fn")
 
 
-def _use_inverse_pose(volume: AbstractVolumeParametrization) -> bool:
+def _maybe_invert_rotation(
+    pose: AbstractPose,
+    volume: AbstractVolumeParametrization,
+    rotation_convention: Literal["object", "frame"],
+) -> AbstractPose:
     jaxpr_fn = eqx.filter_make_jaxpr(lambda vol: vol.to_representation())
     _, out_dynamic, out_static = jaxpr_fn(volume)
     out_struct = eqx.combine(out_dynamic, out_static)
-    expects_frame_rotation = isinstance(
-        out_struct, (FourierVoxelGridVolume, FourierVoxelSplineVolume)
-    )
-    return expects_frame_rotation
+    conventions = [rotation_convention, out_struct.rotation_convention]
+    if conventions[0] != conventions[1]:
+        pose = pose.to_inverse_rotation()
+
+    return pose
 
 
 @overload
@@ -74,6 +79,7 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: None = None,
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ProjectionImageModel: ...
 
 
@@ -92,6 +98,7 @@ def make_image_model(  # pyright: ignore[reportOverlappingOverload]
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: None = None,
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> LinearImageModel: ...
 
 
@@ -110,6 +117,7 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["contrast"] = "contrast",
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ContrastImageModel: ...
 
 
@@ -128,6 +136,7 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["intensity"] = "intensity",
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> IntensityImageModel: ...
 
 
@@ -146,6 +155,7 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["counts"] = "counts",
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ElectronCountsImageModel: ...
 
 
@@ -163,6 +173,7 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["contrast", "intensity", "counts"] | None = None,
+    rotation_convention: Literal["object", "frame"] = "object",
 ) -> AbstractImageModel:
     """Construct an [`cryojax.simulator.AbstractImageModel`][] for
     most common use-cases.
@@ -259,29 +270,24 @@ def make_image_model(
             Uses the [`cryojax.simulator.ElectronCountsImageModel`][]
             to simulate electron counts.
             If this is passed, a `detector` must also be passed.
+    - `rotation_convention`:
+        If `'object'`, the rotation given by `pose` is of the object.
+        If `'frame'`, the rotation given by `pose` is of the frame. These
+        are related by transpose.
 
-    !!! warning
-        The `pose` given to `make_image_model` always represents a
-        rotation of the *object*, not of the frame. Some volume
-        projection methods (e.g. [`cryojax.simulator.FourierSliceExtraction`][])
-        instead image
-        a rotation of the frame, so if `volume` is
-        such a representation, the pose is transposed under the hood.
+    !!! info
+        The `make_image_model` function enforces agreement between
+        rotation conventions of different volumes via the
+        `rotation_convention` argument. Lower level `cryojax` APIs
+        will not enforce this agreement, such as if the user instantiates
+        an [`cryojax.simulator.AbstractImageModel`][] directly.
 
-        Rotations will still differ by a transpose if:
-
-        - The `volume` is a custom subclass of
-        [`cryojax.simulator.AbstractVolumeRepresentation`][] that
-        implements a frame rotation.
-        - The user instantiates an [`cryojax.simulator.AbstractImageModel`][]
-        directly, rather than through `make_image_model`.
-
-        In these cases, it is necessary to manually transpose the pose by
-        calling `pose.to_inverse_rotation()`.
+        In these cases, agreement can be acheived with a manual transpose
+        via `pose.to_inverse_rotation()`.
 
     **Returns:**
 
-    A [`cryojax.simulator.AbstractImageModel`][] with type
+    An [`cryojax.simulator.AbstractImageModel`][]. This has type:
 
     - [`cryojax.simulator.ProjectionImageModel`][] if no `transfer_theory`
     is specified.
@@ -292,9 +298,13 @@ def make_image_model(
     [`cryojax.simulator.ElectronCountsImageModel`][] depending on
     the value of `quantity_mode`.
     """
-    # Invert pose if volume expects frame rotation
-    if _use_inverse_pose(volume):
-        pose = pose.to_inverse_rotation()
+    # Invert pose if
+    if rotation_convention not in ["object", "frame"]:
+        raise ValueError(
+            f"Found `rotation_convention = {rotation_convention}`, but valid "
+            "values are 'object' and 'frame'."
+        )
+    pose = _maybe_invert_rotation(pose, volume, rotation_convention)
     options = dict(
         normalizes_signal=normalizes_signal,
         signal_centering=signal_centering,
@@ -365,9 +375,8 @@ def make_image_model(
                 )
             else:
                 raise ValueError(
-                    f"`quantity_mode = {quantity_mode}` not supported. Supported "
-                    "modes for simulating "
-                    "physical quantities are 'contrast', 'intensity', and 'counts'."
+                    f"Found `quantity_mode = {quantity_mode}`, but valid "
+                    "values are 'contrast', 'intensity', and 'counts'."
                 )
 
     return image_model

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypeVar
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -117,6 +117,8 @@ class AbstractVolumeRepresentation(AbstractVolumeParametrization, strict=True):
     passed to [`cryojax.simulator.AbstractVolumeIntegrator`][]
     classes for imaging.
     """
+
+    rotation_convention: eqx.AbstractClassVar[Literal["object", "frame"]]
 
     @abc.abstractmethod
     def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -2,7 +2,7 @@
 Fourier voxel-based representations of a volume.
 """
 
-from typing import ClassVar, cast
+from typing import ClassVar, Literal, cast
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -55,6 +55,8 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
 
     fourier_voxel_grid: Complex[Array, "dim dim dim"]
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
+
+    rotation_convention: ClassVar[Literal["frame"]] = "frame"
 
     def __init__(
         self,
@@ -143,6 +145,8 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
 
     spline_coefficients: Complex[Array, "coeff_dim coeff_dim coeff_dim"]
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
+
+    rotation_convention: ClassVar[Literal["frame"]] = "frame"
 
     def __init__(
         self,

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -65,6 +65,8 @@ class GaussianMixtureVolume(AbstractAtomVolume, strict=True):
     amplitudes: Float[Array, "n_positions n_gaussians"]
     variances: Float[Array, " n_positions n_gaussians"]
 
+    rotation_convention: ClassVar[Literal["object"]] = "object"
+
     def __init__(
         self,
         positions: Float[NDArrayLike, "n_positions 3"],

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -147,6 +147,8 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
     positions: PyTree[Float[Array, "_ 3"]]
     scattering_factors: PyTree[AbstractFourierOperator]
 
+    rotation_convention: ClassVar[Literal["object"]] = "object"
+
     def __init__(
         self,
         positions: PyTree[Float[NDArrayLike, "_ 3"], "T"],

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -3,7 +3,7 @@ Real voxel-based representations of a volume.
 """
 
 import math
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Literal, cast
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -48,6 +48,8 @@ class RealVoxelGridVolume(AbstractRealVoxelVolume, strict=True):
 
     real_voxel_grid: Float[Array, "dim dim dim"]
     coordinate_grid_in_pixels: Float[Array, "dim dim dim 3"]
+
+    rotation_convention: ClassVar[Literal["frame"]] = "frame"
 
     def __init__(
         self,

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -1,5 +1,7 @@
+import cryojax.ndimage as im
 import cryojax.simulator as cxs
 import equinox as eqx
+import jax.numpy as jnp
 import numpy as np
 import pytest
 from cryojax.io import read_array_from_mrc, read_atoms_from_pdb
@@ -196,7 +198,7 @@ def test_normalize_and_transform(std, signal_centering, voxel_info, basic_config
         pose=cxs.EulerAnglePose(),
         image_transform=ScaleImage(scale=std),
         normalizes_signal=True,
-        signal_centering="bg",
+        signal_centering=signal_centering,
     )
     image = compute_image(image_model)
     np.testing.assert_approx_equal(np.std(image), std)
@@ -271,6 +273,40 @@ def test_bg_subtract(voxel_info):
     )
     image = compute_image(image_model)
     np.testing.assert_allclose(image[:, 0], 0.0, atol=5e-2)
+
+
+@pytest.mark.parametrize("rotation_convention", ("object", "frame", "asfsdkl"))
+def test_rotation_convention(rotation_convention):
+    pose = cxs.EulerAnglePose(phi_angle=45.0, theta_angle=80.0, psi_angle=-30.0)
+    volumes = [
+        cxs.RealVoxelGridVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
+        cxs.FourierVoxelGridVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
+        cxs.FourierVoxelSplineVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
+        cxs.GaussianMixtureVolume(jnp.zeros((10, 3)), 1.0, 1.0),
+        cxs.IndependentAtomVolume(jnp.zeros((10, 3)), im.FourierGaussian()),
+    ]
+    config = cxs.BasicImageConfig((10, 10), 1.0, 300.0)
+    make_wrapper = lambda _v: cxs.make_image_model(
+        _v, config, pose, rotation_convention=rotation_convention
+    )
+    for volume in volumes:
+        if rotation_convention in ["object", "frame"]:
+            image_model = make_wrapper(volume)
+            from matplotlib import pyplot as plt
+
+            plt.imshow(image_model.simulate())
+            plt.show()
+            if volume.rotation_convention == rotation_convention:
+                quat1, quat2 = pose.rotation.wxyz, image_model.pose.rotation.wxyz
+            else:
+                quat1, quat2 = (
+                    pose.to_inverse_rotation().rotation.wxyz,
+                    image_model.pose.rotation.wxyz,
+                )
+            np.testing.assert_allclose(quat1, quat2)
+        else:
+            with pytest.raises(ValueError):
+                _ = make_wrapper(volume)
 
 
 @eqx.filter_jit

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -292,10 +292,6 @@ def test_rotation_convention(rotation_convention):
     for volume in volumes:
         if rotation_convention in ["object", "frame"]:
             image_model = make_wrapper(volume)
-            from matplotlib import pyplot as plt
-
-            plt.imshow(image_model.simulate())
-            plt.show()
             if volume.rotation_convention == rotation_convention:
                 quat1, quat2 = pose.rotation.wxyz, image_model.pose.rotation.wxyz
             else:


### PR DESCRIPTION
The previous way we enforced projection equivalence between methods was implicit and difficult for users to debug and reason about. This makes things explicit, with the tradeoff now that `AbstractVolumeIntegrators` *must* implement the convention stated by `AbstractVolumeRepresentation.rotation_convention` (there are edge cases where this can be broken). This is worth it.

This is a non-breaking change.