### PR TITLE
Simplify `AbstractDetector` interface, including removal of `AbstractDQE` for now

### DIFF
--- a/cryojax/simulator/__init__.py
+++ b/cryojax/simulator/__init__.py
@@ -9,9 +9,7 @@ from ._api_utils import (
 )
 from ._detector import (
     AbstractDetector as AbstractDetector,
-    AbstractDQE as AbstractDQE,
     GaussianDetector as GaussianDetector,
-    NullDQE as NullDQE,
     PoissonDetector as PoissonDetector,
 )
 from ._image_config import (

--- a/cryojax/simulator/_detector.py
+++ b/cryojax/simulator/_detector.py
@@ -5,7 +5,6 @@ Abstraction of electron detectors in a cryo-EM image.
 from abc import abstractmethod
 from typing_extensions import override
 
-import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
@@ -16,63 +15,39 @@ from ..ndimage import irfftn, rfftn
 from ._image_config import DoseImageConfig
 
 
-class AbstractDQE(eqx.Module, strict=True):
-    r"""Base class for a detector DQE."""
-
-    @abstractmethod
-    def __call__(self, image_config: DoseImageConfig) -> Float[Array, "_ _"]:
-        raise NotImplementedError
-
-
-class NullDQE(AbstractDQE, strict=True):
-    r"""A DQE that is perfect across all spatial frequencies."""
-
-    @override
-    def __call__(
-        self, image_config: DoseImageConfig
-    ) -> Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]:
-        """**Arguments:**
-
-        - `image_config`: The image config.
-        """
-        return jnp.full(
-            (image_config.padded_y_dim, image_config.padded_x_dim // 2 + 1), 1.0
-        )
-
-
 class AbstractDetector(Module, strict=True):
     """Base class for an electron detector."""
 
-    dqe: AbstractDQE
-
-    def __init__(self, dqe: AbstractDQE = NullDQE()):
-        self.dqe = dqe
-
-    @abstractmethod
-    def sample_readout_from_expected_events(
-        self, key: PRNGKeyArray, expected_electron_events: Float[Array, "y_dim x_dim"]
-    ) -> Float[Array, "y_dim x_dim"]:
-        """Sample a realization from the detector noise model."""
-        raise NotImplementedError
-
-    def compute_expected_electron_events(
+    def compute_expected_counts(
         self,
         fourier_intensity: Complex[
             Array,
             "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
         ],
         image_config: DoseImageConfig,
-    ) -> Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]:
-        """Compute the expected electron events from the detector."""
-        fourier_expected_electron_events = (
-            self._compute_expected_events_or_detector_readout(
-                fourier_intensity, image_config, key=None
-            )
-        )
+        *,
+        outputs_real_space: bool = True,
+    ) -> (
+        Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]
+        | Float[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim}"]
+    ):
+        """Compute the expected electron counts from the detector."""
+        # The total number of electrons over the entire image
+        n_pixels = np.prod(image_config.padded_shape)
+        electrons_per_image = n_pixels * image_config.electrons_per_pixel
+        # Normalize the squared wavefunction to a set of probabilities
+        fourier_intensity /= fourier_intensity[0, 0]
+        # Compute the noiseless signal by applying the DQE to the squared wavefunction
+        # fourier_intensity = fourier_intensity * jnp.sqrt(self.dqe(image_config))
+        # Apply the integrated dose rate
+        fourier_expected_counts = electrons_per_image * fourier_intensity
+        if outputs_real_space:
+            return irfftn(fourier_expected_counts, s=image_config.padded_shape)
+        else:
+            return fourier_expected_counts
 
-        return fourier_expected_electron_events
-
-    def compute_detector_readout(
+    @abstractmethod
+    def sample_counts(
         self,
         key: PRNGKeyArray,
         fourier_intensity: Complex[
@@ -80,45 +55,11 @@ class AbstractDetector(Module, strict=True):
             "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
         ],
         image_config: DoseImageConfig,
+        *,
+        outputs_real_space: bool = True,
     ) -> Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]:
-        """Measure the readout from the detector."""
-        fourier_detector_readout = self._compute_expected_events_or_detector_readout(
-            fourier_intensity, image_config, key
-        )
-
-        return fourier_detector_readout
-
-    def _compute_expected_events_or_detector_readout(
-        self,
-        fourier_intensity: Complex[
-            Array,
-            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
-        ],
-        image_config: DoseImageConfig,
-        key: PRNGKeyArray | None = None,
-    ) -> Complex[Array, "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}"]:
-        """Pass the image through the detector model."""
-        # The total number of electrons over the entire image
-        n_pixels = np.prod(image_config.padded_shape)
-        electrons_per_image = n_pixels * image_config.electrons_per_pixel
-        # Normalize the squared wavefunction to a set of probabilities
-        fourier_intensity /= fourier_intensity[0, 0]
-        # Compute the noiseless signal by applying the DQE to the squared wavefunction
-        fourier_signal = fourier_intensity * jnp.sqrt(self.dqe(image_config))
-        # Apply the integrated dose rate
-        fourier_expected_electron_events = electrons_per_image * fourier_signal
-        if key is None:
-            # If there is no key given, return
-            return fourier_expected_electron_events
-        else:
-            # ... otherwise, go to real space, sample, go back to fourier,
-            # and return.
-            expected_electron_events = irfftn(
-                fourier_expected_electron_events, s=image_config.padded_shape
-            )
-            return rfftn(
-                self.sample_readout_from_expected_events(key, expected_electron_events)
-            )
+        """Measure the electron counts from the detector."""
+        raise NotImplementedError
 
 
 class GaussianDetector(AbstractDetector, strict=True):
@@ -127,19 +68,43 @@ class GaussianDetector(AbstractDetector, strict=True):
     """
 
     @override
-    def sample_readout_from_expected_events(
-        self, key: PRNGKeyArray, expected_electron_events: Float[Array, "y_dim x_dim"]
+    def sample_counts(
+        self,
+        key: PRNGKeyArray,
+        fourier_intensity: Complex[
+            Array,
+            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
+        ],
+        image_config: DoseImageConfig,
+        *,
+        outputs_real_space: bool = True,
     ) -> Float[Array, "y_dim x_dim"]:
-        return expected_electron_events + jnp.sqrt(expected_electron_events) * jr.normal(
-            key, expected_electron_events.shape
+        expected_electron_counts = self.compute_expected_counts(
+            fourier_intensity, image_config, outputs_real_space=True
         )
+        electron_counts = expected_electron_counts + jnp.sqrt(
+            expected_electron_counts
+        ) * jr.normal(key, expected_electron_counts.shape)
+        return electron_counts if outputs_real_space else rfftn(electron_counts)
 
 
 class PoissonDetector(AbstractDetector, strict=True):
     """A detector with a poisson noise model."""
 
     @override
-    def sample_readout_from_expected_events(
-        self, key: PRNGKeyArray, expected_electron_events: Float[Array, "y_dim x_dim"]
+    def sample_counts(
+        self,
+        key: PRNGKeyArray,
+        fourier_intensity: Complex[
+            Array,
+            "{image_config.padded_y_dim} {image_config.padded_x_dim//2+1}",
+        ],
+        image_config: DoseImageConfig,
+        *,
+        outputs_real_space: bool = True,
     ) -> Float[Array, "y_dim x_dim"]:
-        return jr.poisson(key, expected_electron_events).astype(float)
+        expected_electron_counts = self.compute_expected_counts(
+            fourier_intensity, image_config, outputs_real_space=True
+        )
+        electron_counts = jr.poisson(key, expected_electron_counts).astype(float)
+        return electron_counts if outputs_real_space else rfftn(electron_counts)

--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -729,17 +729,11 @@ class ElectronCountsImageModel(AbstractPhysicalImageModel, strict=True):
             )
             if self.translate_mode == "fft":
                 fourier_intensity = self._phase_shift_translate(fourier_intensity)
-            # ... now measure the expected electron events at the detector
-            fourier_expected_electron_events = (
-                self.detector.compute_expected_electron_events(
-                    fourier_intensity, self.image_config
-                )
-            )
-
-            return (
-                irfftn(fourier_expected_electron_events, s=self.image_config.padded_shape)
-                if outputs_real_space
-                else fourier_expected_electron_events
+            # ... now measure the expected electron events at the detector and return
+            return self.detector.compute_expected_counts(
+                fourier_intensity,
+                self.image_config,
+                outputs_real_space=outputs_real_space,
             )
         else:
             keys = jr.split(rng_key, 3)

--- a/docs/api/simulator/detector.md
+++ b/docs/api/simulator/detector.md
@@ -4,10 +4,5 @@
     ::: cryojax.simulator.AbstractDetector
         options:
             members:
-                - sample_readout_from_expected_events
-
-??? abstract "`cryojax.simulator.AbstractDQE`"
-    ::: cryojax.simulator.AbstractDQE
-        options:
-            members:
-                - __call__
+                - compute_expected_counts
+                - sample_counts

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -19,16 +19,15 @@ def test_constant_wavefunction_gives_constant_expected_events():
     vacuum_squared_wavefunction = jnp.ones(image_config.shape, dtype=float)
     fourier_vacuum_squared_wavefunction = rfftn(vacuum_squared_wavefunction)
     # Create detector models
-    dqe = cs.NullDQE()
-    poisson_detector = cs.PoissonDetector(dqe)
+    poisson_detector = cs.PoissonDetector()
     # Compute expected events
-    fourier_expected_electron_events = poisson_detector.compute_expected_electron_events(
+    expected_electron_events = poisson_detector.compute_expected_counts(
         fourier_vacuum_squared_wavefunction,
         image_config,
     )
     # Make sure it is equal to the electron per pixel
     np.testing.assert_allclose(
-        irfftn(fourier_expected_electron_events, s=image_config.padded_shape),
+        expected_electron_events,
         jnp.full(image_config.padded_shape, electrons_per_pixel),
         # rtol=1e-2,
     )
@@ -50,29 +49,24 @@ def test_gaussian_limit():
     fourier_vacuum_squared_wavefunction = rfftn(vacuum_squared_wavefunction)
     # Create detector models
     key = jax.random.key(1234)
-    dqe = cs.NullDQE()
-    gaussian_detector = cs.GaussianDetector(dqe)
-    poisson_detector = cs.PoissonDetector(dqe)
+    gaussian_detector = cs.GaussianDetector()
+    poisson_detector = cs.PoissonDetector()
     # Compute detector readout
-    fourier_gaussian_detector_readout = gaussian_detector.compute_detector_readout(
-        key,
-        fourier_vacuum_squared_wavefunction,
-        image_config,
+    gaussian_detector_readout_fft = gaussian_detector.sample_counts(
+        key, fourier_vacuum_squared_wavefunction, image_config, outputs_real_space=False
     )
-    fourier_poisson_detector_readout = poisson_detector.compute_detector_readout(
-        key,
-        fourier_vacuum_squared_wavefunction,
-        image_config,
+    poisson_detector_readout_fft = poisson_detector.sample_counts(
+        key, fourier_vacuum_squared_wavefunction, image_config, outputs_real_space=False
     )
     # Compare to see if the autocorrelation has converged
     np.testing.assert_allclose(
         irfftn(
-            jnp.abs(fourier_gaussian_detector_readout) ** 2
+            jnp.abs(gaussian_detector_readout_fft) ** 2
             / (n_pixels * electrons_per_pixel**2),
             s=image_config.padded_shape,
         ),
         irfftn(
-            jnp.abs(fourier_poisson_detector_readout) ** 2
+            jnp.abs(poisson_detector_readout_fft) ** 2
             / (n_pixels * electrons_per_pixel**2),
             s=image_config.padded_shape,
         ),

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -55,7 +55,7 @@ def image_model(volume, basic_config):
 
 @pytest.fixture
 def detector_image_model(volume, dose_config):
-    detector = cxs.PoissonDetector(cxs.NullDQE())
+    detector = cxs.PoissonDetector()
     scattering_theory = cxs.WeakPhaseScatteringTheory(
         volume_integrator=cxs.FourierSliceExtraction(),
         transfer_theory=cxs.ContrastTransferTheory(cxs.AstigmaticCTF()),


### PR DESCRIPTION
Simplify interface to make it read better and more flexible. Also let's remove the DQE until we understand this better and it is helpful to someone.