### PR TITLE
Simpler approach to enforcing rotation convention agreement: remove `make_image_model(..., rotation_convention=...)` and enforce agreement at runtime

### DIFF
--- a/cryojax/jax_util/_errors.py
+++ b/cryojax/jax_util/_errors.py
@@ -2,12 +2,12 @@ from collections.abc import Callable
 from typing import TypeVar
 
 import equinox as eqx
-from jaxtyping import ArrayLike, Bool, PyTree
+from jaxtyping import ArrayLike, Bool
 
 from .._config import CRYOJAX_ENABLE_CHECKS
 
 
-T = TypeVar("T", bound="PyTree")
+T = TypeVar("T")
 
 
 def maybe_error_if(x: T, pred_fn: Callable[[T], Bool[ArrayLike, "..."]], msg: str) -> T:

--- a/cryojax/simulator/__init__.py
+++ b/cryojax/simulator/__init__.py
@@ -73,6 +73,7 @@ from ._volume import (
     IndependentAtomVolume as IndependentAtomVolume,
     LobatoScatteringFactor as LobatoScatteringFactor,
     PengScatteringFactor as PengScatteringFactor,
+    RealVoxelCloudVolume as RealVoxelCloudVolume,
     RealVoxelGridVolume as RealVoxelGridVolume,
     RealVoxelProjection as RealVoxelProjection,
 )

--- a/cryojax/simulator/_api_utils.py
+++ b/cryojax/simulator/_api_utils.py
@@ -2,7 +2,6 @@ import pathlib
 from collections.abc import Callable
 from typing import Any, Literal, overload
 
-import equinox as eqx
 import equinox.internal as eqxi
 import jax.numpy as jnp
 import mmdf
@@ -42,26 +41,12 @@ from ._volume import (
     FourierVoxelSplineVolume,
     GaussianMixtureVolume,
     IndependentAtomVolume,
+    RealVoxelCloudVolume,
     RealVoxelGridVolume,
 )
 
 
 identity_fn = eqxi.doc_repr(lambda x, _: x, "identity_fn")
-
-
-def _maybe_invert_rotation(
-    pose: AbstractPose,
-    volume: AbstractVolumeParametrization,
-    rotation_convention: Literal["object", "frame"],
-) -> AbstractPose:
-    jaxpr_fn = eqx.filter_make_jaxpr(lambda vol: vol.to_representation())
-    _, out_dynamic, out_static = jaxpr_fn(volume)
-    out_struct = eqx.combine(out_dynamic, out_static)
-    conventions = [rotation_convention, out_struct.rotation_convention]
-    if conventions[0] != conventions[1]:
-        pose = pose.to_inverse_rotation()
-
-    return pose
 
 
 @overload
@@ -79,7 +64,6 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["none"] = "none",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ProjectionImageModel: ...
 
 
@@ -98,7 +82,6 @@ def make_image_model(  # pyright: ignore[reportOverlappingOverload]
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["none"] = "none",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> LinearImageModel: ...
 
 
@@ -117,7 +100,6 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["contrast"] = "contrast",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ContrastImageModel: ...
 
 
@@ -136,7 +118,6 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["intensity"] = "intensity",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> IntensityImageModel: ...
 
 
@@ -155,7 +136,6 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["counts"] = "counts",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> ElectronCountsImageModel: ...
 
 
@@ -173,7 +153,6 @@ def make_image_model(
     signal_centering: Literal["bg", "mean"] = "mean",
     translate_mode: Literal["fft", "atom", "none"] = "fft",
     quantity_mode: Literal["contrast", "intensity", "counts", "none"] = "none",
-    rotation_convention: Literal["object", "frame"] = "object",
 ) -> AbstractImageModel:
     """Construct an [`cryojax.simulator.AbstractImageModel`][] for
     most common use-cases.
@@ -281,20 +260,6 @@ def make_image_model(
             Uses the [`cryojax.simulator.ElectronCountsImageModel`][]
             to simulate electron counts.
             If this is passed, a `detector` must also be passed.
-    - `rotation_convention`:
-        If `'object'`, the rotation given by `pose` is of the object.
-        If `'frame'`, the rotation given by `pose` is of the frame. These
-        are related by transpose.
-
-    !!! info
-        The `make_image_model` function enforces agreement between
-        rotation conventions of different volumes via the
-        `rotation_convention` argument. Lower level `cryojax` APIs
-        will not enforce this agreement, such as if the user instantiates
-        an [`cryojax.simulator.AbstractImageModel`][] directly.
-
-        In these cases, agreement can be acheived with a manual transpose
-        via `pose.to_inverse_rotation()`.
 
     **Returns:**
 
@@ -309,13 +274,6 @@ def make_image_model(
     [`cryojax.simulator.ElectronCountsImageModel`][] depending on
     the value of `quantity_mode`.
     """
-    # Invert pose if
-    if rotation_convention not in ["object", "frame"]:
-        raise ValueError(
-            f"Found `rotation_convention = {rotation_convention}`, but valid "
-            "values are 'object' and 'frame'."
-        )
-    pose = _maybe_invert_rotation(pose, volume, rotation_convention)
     options = dict(
         normalizes_signal=normalizes_signal,
         signal_centering=signal_centering,
@@ -581,14 +539,31 @@ def render_voxel_volume(
 ) -> RealVoxelGridVolume: ...
 
 
+@overload
+def render_voxel_volume(
+    atom_volume: AbstractAtomVolume,
+    render_fn: AbstractVolumeRenderFn,
+    *,
+    output_type: type[RealVoxelCloudVolume] = RealVoxelCloudVolume,
+) -> RealVoxelCloudVolume: ...
+
+
 def render_voxel_volume(
     atom_volume: AbstractAtomVolume,
     render_fn: AbstractVolumeRenderFn,
     *,
     output_type: type[
-        FourierVoxelGridVolume | FourierVoxelSplineVolume | RealVoxelGridVolume
+        FourierVoxelGridVolume
+        | FourierVoxelSplineVolume
+        | RealVoxelGridVolume
+        | RealVoxelCloudVolume
     ] = FourierVoxelGridVolume,
-) -> FourierVoxelGridVolume | FourierVoxelSplineVolume | RealVoxelGridVolume:
+) -> (
+    FourierVoxelGridVolume
+    | FourierVoxelSplineVolume
+    | RealVoxelGridVolume
+    | RealVoxelCloudVolume
+):
     """Render a voxel volume representation from an atomistic one.
 
     !!! example "Simulate an image with Fourier slice extraction"
@@ -624,7 +599,8 @@ def render_voxel_volume(
         Either [`cryojax.simulator.FourierVoxelGridVolume`][] /
         [`cryojax.simulator.FourierVoxelSplineVolume`][] for
         fourier-space representations, or
-        [`cryojax.simulator.RealVoxelGridVolume`][] for real-space.
+        [`cryojax.simulator.RealVoxelGridVolume`][] /
+        [`cryojax.simulator.RealVoxelCloudVolume`][] for real-space.
 
 
     **Returns:**
@@ -650,14 +626,20 @@ def render_voxel_volume(
         else:
             spline_coefficients = compute_spline_coefficients(fourier_voxel_grid)
             return FourierVoxelSplineVolume(spline_coefficients, frequency_slice)
-    elif output_type == RealVoxelGridVolume:
+    elif output_type == RealVoxelGridVolume or output_type == RealVoxelCloudVolume:
         coordinate_grid = make_coordinate_grid(render_fn.shape)
         real_voxel_grid = render_fn(atom_volume, outputs_real_space=True)
-        return RealVoxelGridVolume(real_voxel_grid, coordinate_grid)
+        if output_type == RealVoxelGridVolume:
+            return RealVoxelGridVolume(real_voxel_grid, coordinate_grid)
+        else:
+            return RealVoxelCloudVolume.from_real_voxel_grid(
+                real_voxel_grid, coordinate_grid_in_pixels=coordinate_grid
+            )
     else:
         raise ValueError(
-            "Only `output_type` equal to `FourierVoxelGridVolume`, "
-            "`FourierVoxelSplineVolume`, or `RealVoxelGridVolume` "
-            "are supported."
-            f"Got `output_type = {output_type}`."
+            f"Got `output_type = {output_type}`, but this is "
+            "not supported by `render_voxel_volume(..., output_type=...)`."
+            "Valid values for `output_type` are `FourierVoxelGridVolume`, "
+            "`FourierVoxelSplineVolume`, `RealVoxelGridVolume`, or "
+            "`RealVoxelCloudVolume`."
         )

--- a/cryojax/simulator/_volume/__init__.py
+++ b/cryojax/simulator/_volume/__init__.py
@@ -29,6 +29,7 @@ from .independent_atom_volume import (
     PengScatteringFactor as PengScatteringFactor,
 )
 from .real_voxels import (
+    RealVoxelCloudVolume as RealVoxelCloudVolume,
     RealVoxelGridVolume as RealVoxelGridVolume,
     RealVoxelProjection as RealVoxelProjection,
 )

--- a/cryojax/simulator/_volume/auto_select.py
+++ b/cryojax/simulator/_volume/auto_select.py
@@ -28,7 +28,7 @@ from .independent_atom_volume import (
     FFTAtomRenderFn,
     IndependentAtomVolume,
 )
-from .real_voxels import RealVoxelGridVolume, RealVoxelProjection
+from .real_voxels import RealVoxelCloudVolume, RealVoxelProjection
 
 
 class AutoVolumeProjection(
@@ -47,10 +47,13 @@ class AutoVolumeProjection(
         | [`cryojax.simulator.GaussianMixtureVolume`][] | [`cryojax.simulator.GaussianMixtureProjection`][] | atom |
         | [`cryojax.simulator.IndependentAtomVolume`][] | [`cryojax.simulator.FFTAtomProjection`][] | atom |
         | [`cryojax.simulator.FourierVoxelGridVolume`][] or [`cryojax.simulator.FourierVoxelSplineVolume`][] | [`cryojax.simulator.FourierSliceExtraction`][] | voxel |
-        | [`cryojax.simulator.RealVoxelGridVolume`][] | [`cryojax.simulator.RealVoxelProjection`][] | voxel |
+        | [`cryojax.simulator.RealVoxelCloudVolume`][] | [`cryojax.simulator.RealVoxelProjection`][] | voxel |
+
+        Note that [`cryojax.simulator.RealVoxelGridVolume`][] does not have an associated projection method. To
+        compute projections from real-space voxels, use [`cryojax.simulator.RealVoxelCloudVolume`][].
 
         To use advanced options for a given projection method,
-        see each respective class.
+        instantiate each respective class directly.
 
     !!! warning
         If using [`cryojax.simulator.FFTAtomRenderFn`][] or [`cryojax.simulator.RealVoxelProjection`][], [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
@@ -67,14 +70,15 @@ class AutoVolumeProjection(
             integrator = FourierSliceExtraction()
         elif isinstance(volume, GaussianMixtureVolume):
             integrator = GaussianMixtureProjection()
-        elif isinstance(volume, RealVoxelGridVolume):
+        elif isinstance(volume, RealVoxelCloudVolume):
             integrator = RealVoxelProjection()
         elif isinstance(volume, IndependentAtomVolume):
             integrator = FFTAtomProjection()
         else:
             raise ValueError(
                 "Could not use `AutoVolumeProjection` for volume of "
-                f"type {type(volume).__name__}. If using a custom volume, "
+                f"type {type(volume).__name__}. See the documentation for "
+                "supported types. If using a custom volume, "
                 "please directly pass an integrator."
             )
         return integrator

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Generic, Literal, TypeVar
+from typing import Generic, TypeVar
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -118,10 +118,10 @@ class AbstractVolumeRepresentation(AbstractVolumeParametrization, strict=True):
     classes for imaging.
     """
 
-    rotation_convention: eqx.AbstractClassVar[Literal["object", "frame"]]
+    is_frame_rotation: eqx.AbstractClassVar[bool]
 
     @abc.abstractmethod
-    def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
         """Rotate the coordinate system of the volume."""
         raise NotImplementedError
 
@@ -174,7 +174,7 @@ class AbstractVoxelVolume(AbstractVolumeRepresentation, strict=True):
     @property
     @abc.abstractmethod
     def shape(self) -> tuple[int, ...]:
-        """The shape of the voxel array."""
+        """The shape of the voxel grid."""
         raise NotImplementedError
 
     @classmethod

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -2,7 +2,7 @@
 Fourier voxel-based representations of a volume.
 """
 
-from typing import ClassVar, Literal, cast
+from typing import ClassVar, cast
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -41,12 +41,14 @@ class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
     frequency_slice_in_pixels: eqx.AbstractVar[Float[Array, "1 dim dim 3"]]
 
     @override
-    def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
         """Return a new volume with a rotated `frequency_slice_in_pixels`."""
         return eqx.tree_at(
             lambda d: d.frequency_slice_in_pixels,
             self,
-            pose.rotate_coordinates(self.frequency_slice_in_pixels, inverse=inverse),
+            pose.rotate_coordinates(
+                self.frequency_slice_in_pixels, inverse=self.is_frame_rotation
+            ),
         )
 
 
@@ -56,7 +58,7 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
     fourier_voxel_grid: Complex[Array, "dim dim dim"]
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
 
-    rotation_convention: ClassVar[Literal["frame"]] = "frame"
+    is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -146,7 +148,7 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
     spline_coefficients: Complex[Array, "coeff_dim coeff_dim coeff_dim"]
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
 
-    rotation_convention: ClassVar[Literal["frame"]] = "frame"
+    is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -317,8 +319,10 @@ class FourierSliceExtraction(
             )
         else:
             raise ValueError(
-                "Supported types for `volume_representation` are "
-                "`FourierVoxelGridVolume` and FourierVoxelSplineVolume`."
+                "Got unsupported type for `volume_representation` in "
+                "`FourierSliceExtraction.integrate`. Expected `FourierVoxelGridVolume` "
+                "or `FourierVoxelSplineVolume`, "
+                f"but got `{volume_representation.__class__.__name__}`."
             )
 
         # Resize the image to match the AbstractImageConfig.padded_shape
@@ -435,8 +439,10 @@ class EwaldSphereExtraction(
             )
         else:
             raise ValueError(
-                "Supported types for `volume_representation` are "
-                "`FourierVoxelGridVolume` and `FourierVoxelSplineVolume`."
+                "Got unsupported type for `volume_representation` in "
+                "`EwaldSphereExtraction.integrate`. Expected `FourierVoxelGridVolume` "
+                "or `FourierVoxelSplineVolume`, "
+                f"but got `{volume_representation.__class__.__name__}`."
             )
 
         # Resize the image to match the AbstractImageConfig.padded_shape

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -65,7 +65,7 @@ class GaussianMixtureVolume(AbstractAtomVolume, strict=True):
     amplitudes: Float[Array, "n_positions n_gaussians"]
     variances: Float[Array, " n_positions n_gaussians"]
 
-    rotation_convention: ClassVar[Literal["object"]] = "object"
+    is_frame_rotation: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -197,12 +197,12 @@ class GaussianMixtureVolume(AbstractAtomVolume, strict=True):
         return cls(atom_positions, amplitudes, b_factor_to_variance(b_factors))
 
     @override
-    def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
         """Return a new potential with rotated `positions`."""
         return eqx.tree_at(
             lambda d: d.positions,
             self,
-            pose.rotate_coordinates(self.positions, inverse=inverse),
+            pose.rotate_coordinates(self.positions, inverse=self.is_frame_rotation),
         )
 
     @override

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -148,7 +148,7 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
     positions: PyTree[Float[Array, "_ 3"]]
     scattering_factors: PyTree[AbstractFourierOperator]
 
-    rotation_convention: ClassVar[Literal["object"]] = "object"
+    is_frame_rotation: ClassVar[bool] = False
 
     def __init__(
         self,
@@ -177,9 +177,11 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         self.scattering_factors = scattering_factors
 
     @override
-    def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
         """Return a new potential with rotated `positions`."""
-        rotate_fn = lambda pos: pose.rotate_coordinates(pos, inverse=inverse)
+        rotate_fn = lambda pos: pose.rotate_coordinates(
+            pos, inverse=self.is_frame_rotation
+        )
         return eqx.tree_at(
             lambda x: x.positions,
             self,

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -109,7 +109,7 @@ class RealVoxelCloudVolume(AbstractRealVoxelVolume, strict=True):
     """A 3D cloud of voxels in real-space."""
 
     weights: Float[Array, " N"]
-    coordinate_list: Float[Array, "N 3"]
+    coordinate_list_in_pixels: Float[Array, "N 3"]
     box_dim: int
 
     is_frame_rotation: ClassVar[bool] = False
@@ -117,20 +117,33 @@ class RealVoxelCloudVolume(AbstractRealVoxelVolume, strict=True):
     def __init__(
         self,
         weights: Float[NDArrayLike, " N"],
-        coordinate_list: Float[NDArrayLike, "N 3"],
+        coordinate_list_in_pixels: Float[NDArrayLike, "N 3"],
         box_dim: int,
     ):
         """**Arguments:**
 
         - `weights`:
             The intensity of each voxel.
-        - `coordinate_list`:
-            The coordinate for each voxel.
+        - `coordinate_list_in_pixels`:
+            The coordinate for each voxel in pixel units, e.g.
+
+            ```python
+            import math
+            import cryojax.ndimage as im
+
+            box_dim = 128
+            shape = (box_dim, box_dim, box_dim)
+            coordinate_grid = im.make_coordinate_grid(shape)
+            n_voxels =
+            coordinate_list_in_pixels = coordinate_grid.reshape((math.prod(shape), 3))
+            ```
         - `box_dim`:
             The box dimension of the original unflattened voxel array.
-        """
+        """  # noqa: E501
         self.weights = jnp.asarray(weights, dtype=float)
-        self.coordinate_list = jnp.asarray(coordinate_list, dtype=float)
+        self.coordinate_list_in_pixels = jnp.asarray(
+            coordinate_list_in_pixels, dtype=float
+        )
         self.box_dim = box_dim
 
     @override
@@ -139,9 +152,11 @@ class RealVoxelCloudVolume(AbstractRealVoxelVolume, strict=True):
         `coordinate_grid_in_pixels`.
         """
         return eqx.tree_at(
-            lambda d: d.coordinate_list,
+            lambda d: d.coordinate_list_in_pixels,
             self,
-            pose.rotate_coordinates(self.coordinate_list, inverse=self.is_frame_rotation),
+            pose.rotate_coordinates(
+                self.coordinate_list_in_pixels, inverse=self.is_frame_rotation
+            ),
         )
 
     @property
@@ -183,9 +198,11 @@ class RealVoxelCloudVolume(AbstractRealVoxelVolume, strict=True):
         # Convert to cloud of voxels
         n_voxels = math.prod(voxel_volume.real_voxel_grid.shape)
         weights = voxel_volume.real_voxel_grid.ravel()
-        coordinate_list = voxel_volume.coordinate_grid_in_pixels.reshape((n_voxels, 3))
+        coordinate_list_in_pixels = voxel_volume.coordinate_grid_in_pixels.reshape(
+            (n_voxels, 3)
+        )
 
-        return cls(weights, coordinate_list, box_dim)
+        return cls(weights, coordinate_list_in_pixels, box_dim)
 
 
 class RealVoxelProjection(
@@ -254,7 +271,7 @@ class RealVoxelProjection(
             )
         fourier_projection = _project_with_nufft(
             volume_representation.weights,
-            volume_representation.coordinate_list,
+            volume_representation.coordinate_list_in_pixels,
             image_config.padded_shape,
             eps=self.eps,
             opts=self.opts,

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -3,7 +3,7 @@ Real voxel-based representations of a volume.
 """
 
 import math
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, cast
 from typing_extensions import Self, override
 
 import equinox as eqx
@@ -29,19 +29,6 @@ except ModuleNotFoundError as err:
 class AbstractRealVoxelVolume(AbstractVoxelVolume, strict=True):
     """Abstract interface for a voxel-based volume."""
 
-    coordinate_grid_in_pixels: eqx.AbstractVar[Float[Array, "dim dim dim 3"]]
-
-    @override
-    def rotate_to_pose(self, pose: AbstractPose, inverse: bool = False) -> Self:
-        """Return a new volume with a rotated
-        `coordinate_grid_in_pixels`.
-        """
-        return eqx.tree_at(
-            lambda d: d.coordinate_grid_in_pixels,
-            self,
-            pose.rotate_coordinates(self.coordinate_grid_in_pixels, inverse=inverse),
-        )
-
 
 class RealVoxelGridVolume(AbstractRealVoxelVolume, strict=True):
     """A 3D voxel grid in real-space."""
@@ -49,7 +36,7 @@ class RealVoxelGridVolume(AbstractRealVoxelVolume, strict=True):
     real_voxel_grid: Float[Array, "dim dim dim"]
     coordinate_grid_in_pixels: Float[Array, "dim dim dim 3"]
 
-    rotation_convention: ClassVar[Literal["frame"]] = "frame"
+    is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -58,12 +45,25 @@ class RealVoxelGridVolume(AbstractRealVoxelVolume, strict=True):
     ):
         """**Arguments:**
 
-        - `real_voxel_grid`: The voxel grid in fourier space.
+        - `real_voxel_grid`: The voxel grid in real space.
         - `coordinate_grid_in_pixels`: A coordinate grid.
         """
         self.real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         self.coordinate_grid_in_pixels = jnp.asarray(
             coordinate_grid_in_pixels, dtype=float
+        )
+
+    @override
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
+        """Return a new volume with a rotated
+        `coordinate_grid_in_pixels`.
+        """
+        return eqx.tree_at(
+            lambda d: d.coordinate_grid_in_pixels,
+            self,
+            pose.rotate_coordinates(
+                self.coordinate_grid_in_pixels, inverse=self.is_frame_rotation
+            ),
         )
 
     @property
@@ -105,8 +105,91 @@ class RealVoxelGridVolume(AbstractRealVoxelVolume, strict=True):
         return cls(real_voxel_grid, coordinate_grid_in_pixels)
 
 
+class RealVoxelCloudVolume(AbstractRealVoxelVolume, strict=True):
+    """A 3D cloud of voxels in real-space."""
+
+    weights: Float[Array, " N"]
+    coordinate_list: Float[Array, "N 3"]
+    box_dim: int
+
+    is_frame_rotation: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        weights: Float[NDArrayLike, " N"],
+        coordinate_list: Float[NDArrayLike, "N 3"],
+        box_dim: int,
+    ):
+        """**Arguments:**
+
+        - `weights`:
+            The intensity of each voxel.
+        - `coordinate_list`:
+            The coordinate for each voxel.
+        - `box_dim`:
+            The box dimension of the original unflattened voxel array.
+        """
+        self.weights = jnp.asarray(weights, dtype=float)
+        self.coordinate_list = jnp.asarray(coordinate_list, dtype=float)
+        self.box_dim = box_dim
+
+    @override
+    def rotate_to_pose(self, pose: AbstractPose) -> Self:
+        """Return a new volume with a rotated
+        `coordinate_grid_in_pixels`.
+        """
+        return eqx.tree_at(
+            lambda d: d.coordinate_list,
+            self,
+            pose.rotate_coordinates(self.coordinate_list, inverse=self.is_frame_rotation),
+        )
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        """The shape of the unflattened voxel grid."""
+        dim = self.box_dim
+        return (dim, dim, dim)
+
+    @classmethod
+    def from_real_voxel_grid(
+        cls,
+        real_voxel_grid: Float[NDArrayLike, "dim dim dim"],
+        *,
+        coordinate_grid_in_pixels: Float[Array, "dim dim dim 3"] | None = None,
+        crop_scale: float | None = None,
+    ) -> Self:
+        """Load a `RealVoxelCloudVolume` from a real-valued 3D voxel grid.
+
+        **Arguments:**
+
+        - `real_voxel_grid`: A voxel grid in real space.
+        - `crop_scale`: Scale factor at which to crop `real_voxel_grid`.
+                        Must be a value greater than `1`.
+        """
+        # Get voxel grid representation
+        voxel_volume = RealVoxelGridVolume.from_real_voxel_grid(
+            real_voxel_grid,
+            coordinate_grid_in_pixels=coordinate_grid_in_pixels,
+            crop_scale=crop_scale,
+        )
+        shape = voxel_volume.real_voxel_grid.shape
+        box_dim = shape[0]
+        if not all(box_dim == dim for dim in shape):
+            raise ValueError(
+                "`RealVoxelCloudVolume.from_real_voxel_grid` only supports "
+                "grids with cubic box dimensions, but passed a grid with "
+                f"shape {real_voxel_grid.shape}."
+            )
+        # Convert to cloud of voxels
+        n_voxels = math.prod(voxel_volume.real_voxel_grid.shape)
+        weights = voxel_volume.real_voxel_grid.ravel()
+        coordinate_list = voxel_volume.coordinate_grid_in_pixels.reshape((n_voxels, 3))
+
+        return cls(weights, coordinate_list, box_dim)
+
+
 class RealVoxelProjection(
-    AbstractVolumeIntegrator[RealVoxelGridVolume],
+    AbstractVolumeIntegrator[RealVoxelCloudVolume],
     strict=True,
 ):
     """Integrate points onto the exit plane using non-uniform FFTs."""
@@ -141,7 +224,7 @@ class RealVoxelProjection(
     @override
     def integrate(
         self,
-        volume_representation: RealVoxelGridVolume,
+        volume_representation: RealVoxelCloudVolume,
         image_config: AbstractImageConfig,
         outputs_real_space: bool = False,
     ) -> ProjectionArray:
@@ -163,10 +246,15 @@ class RealVoxelProjection(
         The volume projection in real or Fourier space, at the
         `image_config.padded_shape`.
         """
-        n_voxels = math.prod(volume_representation.shape)
+        if not isinstance(volume_representation, RealVoxelCloudVolume):
+            raise ValueError(
+                "Got unsupported type for `volume_representation` in "
+                "`RealVoxelProjection.integrate`. Expected `RealVoxelCloudVolume`, "
+                f"but got `{volume_representation.__class__.__name__}`."
+            )
         fourier_projection = _project_with_nufft(
-            volume_representation.real_voxel_grid.ravel(),
-            volume_representation.coordinate_grid_in_pixels.reshape((n_voxels, 3)),
+            volume_representation.weights,
+            volume_representation.coordinate_list,
             image_config.padded_shape,
             eps=self.eps,
             opts=self.opts,

--- a/docs/api/simulator/volume.md
+++ b/docs/api/simulator/volume.md
@@ -70,7 +70,6 @@ There are many different volume representations of biological structures for cry
                 - from_real_voxel_grid
                 - to_representation
                 - rotate_to_pose
-                - frequency_slice_in_pixels
                 - shape
 
 ---
@@ -82,11 +81,16 @@ There are many different volume representations of biological structures for cry
                 - from_real_voxel_grid
                 - to_representation
                 - rotate_to_pose
-                - frequency_slice_in_pixels
                 - shape
 
 
 #### Real-space
+
+!!! info "Real-space projections"
+    The [`cryojax.simulator.RealVoxelGridVolume`][] does not have an associated
+    method in cryoJAX for computing projections and therefore
+    cannot be used with with [`cryojax.simulator.make_image_model`][]. Instead,
+    use [`cryojax.simulator.RealVoxelCloudVolume`][].
 
 ::: cryojax.simulator.RealVoxelGridVolume
         options:
@@ -95,7 +99,17 @@ There are many different volume representations of biological structures for cry
                 - from_real_voxel_grid
                 - to_representation
                 - rotate_to_pose
-                - coordinate_grid_in_pixels
+                - shape
+
+---
+
+::: cryojax.simulator.RealVoxelCloudVolume
+        options:
+            members:
+                - __init__
+                - from_real_voxel_grid
+                - to_representation
+                - rotate_to_pose
                 - shape
 
 ## Volume rendering

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -1,7 +1,5 @@
-import cryojax.ndimage as im
 import cryojax.simulator as cxs
 import equinox as eqx
-import jax.numpy as jnp
 import numpy as np
 import pytest
 from cryojax.io import read_array_from_mrc, read_atoms_from_pdb
@@ -273,36 +271,6 @@ def test_bg_subtract(voxel_info):
     )
     image = compute_image(image_model)
     np.testing.assert_allclose(image[:, 0], 0.0, atol=5e-2)
-
-
-@pytest.mark.parametrize("rotation_convention", ("object", "frame", "asfsdkl"))
-def test_rotation_convention(rotation_convention):
-    pose = cxs.EulerAnglePose(phi_angle=45.0, theta_angle=80.0, psi_angle=-30.0)
-    volumes = [
-        cxs.RealVoxelGridVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
-        cxs.FourierVoxelGridVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
-        cxs.FourierVoxelSplineVolume.from_real_voxel_grid(jnp.zeros((10, 10, 10))),
-        cxs.GaussianMixtureVolume(jnp.zeros((10, 3)), 1.0, 1.0),
-        cxs.IndependentAtomVolume(jnp.zeros((10, 3)), im.FourierGaussian()),
-    ]
-    config = cxs.BasicImageConfig((10, 10), 1.0, 300.0)
-    make_wrapper = lambda _v: cxs.make_image_model(
-        _v, config, pose, rotation_convention=rotation_convention
-    )
-    for volume in volumes:
-        if rotation_convention in ["object", "frame"]:
-            image_model = make_wrapper(volume)
-            if volume.rotation_convention == rotation_convention:
-                quat1, quat2 = pose.rotation.wxyz, image_model.pose.rotation.wxyz
-            else:
-                quat1, quat2 = (
-                    pose.to_inverse_rotation().rotation.wxyz,
-                    image_model.pose.rotation.wxyz,
-                )
-            np.testing.assert_allclose(quat1, quat2)
-        else:
-            with pytest.raises(ValueError):
-                _ = make_wrapper(volume)
 
 
 @eqx.filter_jit

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -87,7 +87,7 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
                     amplitude=amplitude, b_factor=b_factor
                 ),
             ),
-            cxs.FFTAtomProjection(sampling_mode="point", eps=1e-16),
+            cxs.FFTAtomProjection(sampling_mode="point", eps=1e-10),
         )
         proj_by_gaussians = compute_projection(
             gaussian_volume, gaussian_integrator, image_config
@@ -121,7 +121,7 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
             ),
         )
         gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-        fft_integrator = cxs.FFTAtomProjection(eps=1e-16)
+        fft_integrator = cxs.FFTAtomProjection(eps=1e-10)
         padded_shape = (2 * shape[0], 2 * shape[1])
         image_config = cxs.BasicImageConfig(
             shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=padded_shape
@@ -168,7 +168,7 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsample_factor):
         # nufft (don't include anti-aliasing)
         gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
         fft_integrator = cxs.FFTAtomProjection(
-            sampling_mode="average", upsample_factor=upsample_factor, eps=1e-16
+            sampling_mode="average", upsample_factor=upsample_factor, eps=1e-10
         )
         proj_by_gaussians = compute_projection(
             gaussian_volume, gaussian_integrator, image_config
@@ -220,9 +220,9 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
         cxs.FourierSliceExtraction(),
     ]
     if jnufft is not None:
-        other_projection_methods.append(cxs.RealVoxelProjection(eps=1e-16))  # type: ignore
+        other_projection_methods.append(cxs.RealVoxelProjection(eps=1e-15))  # type: ignore
         other_volumes.append(
-            cxs.RealVoxelGridVolume.from_real_voxel_grid(real_voxel_grid)
+            cxs.RealVoxelCloudVolume.from_real_voxel_grid(real_voxel_grid)
         )
     else:
         warnings.warn(
@@ -234,10 +234,17 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     projection_by_gaussian_integration = compute_projection(
         base_volume, base_method, image_config
     )
+    # from matplotlib import pyplot as plt
+
     for volume, projection_method in zip(other_volumes, other_projection_methods):
         projection_by_other_method = compute_projection(
             volume, projection_method, image_config
         )
+        # fig, axes = plt.subplots(figsize=(12, 4), ncols=3)
+        # axes[0].imshow(projection_by_gaussian_integration)
+        # axes[1].imshow(projection_by_other_method)
+        # axes[2].imshow(projection_by_other_method - projection_by_gaussian_integration)
+        # plt.show()
         np.testing.assert_allclose(
             projection_by_gaussian_integration, projection_by_other_method, atol=1e-12
         )

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -173,6 +173,7 @@ def test_render_voxels(sample_pdb_path):
         cxs.FourierVoxelGridVolume,
         cxs.FourierVoxelSplineVolume,
         cxs.RealVoxelGridVolume,
+        cxs.RealVoxelCloudVolume,
     ]:
         assert (
             type(cxs.render_voxel_volume(atom_volume, render_fn, output_type=cls)) == cls
@@ -290,7 +291,7 @@ def test_render_options(pdb_info):
                 ),
             )
         )
-        render_fns.append(cxs.FFTAtomRenderFn(shape, voxel_size, eps=1e-16))
+        render_fns.append(cxs.FFTAtomRenderFn(shape, voxel_size, eps=1e-10))
     for volume, render_fn in zip(volumes, render_fns):
         real_voxel_grid = render_fn(volume, outputs_real_space=True)
         assert real_voxel_grid.shape == shape
@@ -330,7 +331,7 @@ def test_fft_atom_render(pdb_info, width, voxel_size, shape):
             ),
         )
         gaussian_render_fn = cxs.GaussianMixtureRenderFn(shape, voxel_size)
-        fft_render_fn = cxs.FFTAtomRenderFn(shape, voxel_size, eps=1e-16)
+        fft_render_fn = cxs.FFTAtomRenderFn(shape, voxel_size, eps=1e-10)
         voxels_by_gaussians = gaussian_render_fn(gaussian_volume)
         voxels_by_fft = fft_render_fn(atom_volume)
 


### PR DESCRIPTION
Here is simpler approach to making sure that rotation conventions agree across projection methods, which can differ by a transpose. This PR makes the following changes:

- The default rotation convention in cryoJAX (i.e. that rotations are w.r.t to the coordinates of the *object*, not the *frame*) is now always enforced across all of cryoJAX (even lower level APIs). This way, there is no ambiguity in the meaning of an `AbstractPose` object.
- As a result, `make_image_model(..., rotation_convention=...)` is removed.
- This wasn't simple to resolve because whether a given volume representation represents a frame or object rotation can depend. Now, we enforce that a given volume representation has to declare whether or not a transpose will happen at runtime (see the `AbstractVolumeRepresentation.is_frame_rotation`). This axed the ability to compute projections using the `RealVoxelGridVolume` class, so instead I've brought back the old `RealVoxelCloudVolume` (this is just a flattened grid). Relevant documentation and errors are added if the user tries to use a `RealVoxelGridVolume`.