### PR TITLE
More efficient approach to computing images en voxel grids in GaussianMixtureVolume: use `jnp.einsum` instead of `jnp.tranpose` followed by `jnp.sum`

### DIFF
--- a/cryojax/simulator/_image_config.py
+++ b/cryojax/simulator/_image_config.py
@@ -212,7 +212,9 @@ class AbstractImageConfig(eqx.Module, strict=True):
 
         if physical:
             pixel_size = error_if_not_positive(self.pixel_size)
-            coordinate_grid = _safe_multiply_by_constant(coordinate_grid, pixel_size)
+            coordinate_grid = _safe_multiply_by_constant(
+                coordinate_grid, pixel_size, is_fft_grid=False
+            )
 
         return coordinate_grid
 
@@ -264,7 +266,9 @@ class AbstractImageConfig(eqx.Module, strict=True):
 
         if physical:
             pixel_size = error_if_not_positive(self.pixel_size)
-            frequency_grid = _safe_multiply_by_constant(frequency_grid, 1 / pixel_size)
+            frequency_grid = _safe_multiply_by_constant(
+                frequency_grid, 1 / pixel_size, is_fft_grid=True
+            )
 
         return frequency_grid
 
@@ -716,7 +720,7 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
 
 
 def _safe_multiply_by_constant(
-    grid: Float[Array, "y_dim x_dim 2"], constant: Float[Array, ""]
+    grid: Float[Array, "y_dim x_dim 2"], constant: Float[Array, ""], is_fft_grid: bool
 ) -> Float[Array, "y_dim x_dim 2"]:
     """Multiplies a coordinate grid by a constant in a
     safe way for gradient computation.
@@ -726,6 +730,12 @@ def _safe_multiply_by_constant(
     term `sqrt(grid * constant)` that needs to be differentiated.
     This is undefined at locations where the grid is equal to zero.
     """
-    grid = grid.at[:, 1:, 0].multiply(constant)
-    grid = grid.at[1:, :, 1].multiply(constant)
+    if is_fft_grid:
+        grid = grid.at[:, 1:, 0].multiply(constant)
+        grid = grid.at[1:, :, 1].multiply(constant)
+
+    else:
+        s1, s2 = grid.shape[0], grid.shape[1]
+        grid = grid.at[:, s2 // 2, 0].multiply(constant)
+        grid = grid.at[s1 // 2, :, 1].multiply(constant)
     return grid

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -577,10 +577,15 @@ def _evaluate_multivariate_gaussian_2d(
 ) -> Float[Array, "dim_y dim_x"]:
     # Prepare matrices with dimensions of the number of positions and the number of grid
     # points. There are as many matrices as number of gaussians per position
-    gauss_x = jnp.transpose(gaussians_per_interval_per_position_x, (2, 1, 0))
-    gauss_y = jnp.transpose(gaussians_per_interval_per_position_y, (2, 0, 1))
-    # Compute matrix multiplication then sum over the number of gaussians per position
-    return jnp.sum(jnp.matmul(gauss_y, gauss_x), axis=0)
+    # gauss_x = jnp.transpose(gaussians_per_interval_per_position_x, (2, 1, 0))
+    # gauss_y = jnp.transpose(gaussians_per_interval_per_position_y, (2, 0, 1))
+    # # Compute matrix multiplication then sum over the number of gaussians per position
+    # return jnp.sum(jnp.matmul(gauss_y, gauss_x), axis=0)
+    return jnp.einsum(
+        "ikl, jkl -> ij",
+        gaussians_per_interval_per_position_y,
+        gaussians_per_interval_per_position_x,
+    )
 
 
 def _evaluate_gaussian_integrals_2d(
@@ -822,14 +827,12 @@ def _evaluate_multivariate_gaussian_3d(
 ) -> Float[Array, "dim_y dim_x"]:
     # Prepare matrices with dimensions of the number of positions and the number of grid
     # points. There are as many matrices as number of gaussians per position
-    gauss_x = jnp.transpose(gaussian_integrals_per_interval_per_position_x, (2, 1, 0))
-    gauss_yz = jnp.transpose(
+    return jnp.einsum(
+        "ikl, jkl -> ij",
         gaussian_integrals_per_interval_per_position_y
         * gaussian_integrals_per_position_z[None, :, :],
-        (2, 0, 1),
+        gaussian_integrals_per_interval_per_position_x,
     )
-    # Compute matrix multiplication then sum over the number of gaussians per position
-    return jnp.sum(jnp.matmul(gauss_yz, gauss_x), axis=0)
 
 
 def _batched_map_with_n_batches(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ docs = [
     "mkdocstrings==0.28.3",
     "mkdocstrings-python==1.16.8",
     "pymdown-extensions==10.14.3",
+    "pygments<2.20",
     "ruff"
 ]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ docs = [
     "mkdocs-material==9.6.7",
     "mkdocstrings==0.28.3",
     "mkdocstrings-python==1.16.8",
-    "pymdown-extensions==10.14.3",
-    "pygments<2.20",
+    "pymdown-extensions==10.21.2",
+    "pygments==2.20",
     "ruff"
 ]
 tests = [


### PR DESCRIPTION
Here is a better approach to compute images and voxel grids through a `GaussianMixtureVolume`. Before this, we would evaluate the Gaussians along the x-, y-, and z-axes (only for voxel grids), create copies via transpose operations, and, in some cases, create new axes. Now we simply use `jnp.einsum`, which should be more efficient and avoids creating spurious copies.

In addition, this PR fixes a bug where coordinate grids generated by `AbstractImageConfig` had incorrect scaling in some pixels when requesting a physical grid. Frequency grids were unaffected.


- Improved performance of evaluation of images and voxel grids using `GaussianMixtureVolume`.
- Bug fixed when computing physical coordinate grids with `AbstractImageConfig`.