### PR TITLE
Drop support for python 3.10

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(github.base_ref == 'main' && '["ubuntu-latest","macos-latest"]' || '["ubuntu-latest"]') }}
-        python-version: ${{ fromJSON(github.base_ref == 'main' && '["3.10", "3.14"]' || '["3.11"]') }}
+        python-version: ${{ fromJSON(github.base_ref == 'main' && '["3.11", "3.14"]' || '["3.11"]') }}
 
     steps:
       - name: Checkout repository

--- a/cryojax/dataset/_particle_data/relion.py
+++ b/cryojax/dataset/_particle_data/relion.py
@@ -6,8 +6,8 @@ import re
 import warnings
 from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Literal, TypedDict, cast
-from typing_extensions import Self, override
+from typing import Any, Literal, Self, TypedDict, cast
+from typing_extensions import override
 
 import equinox as eqx
 import jax

--- a/cryojax/rotations/_lie_group.py
+++ b/cryojax/rotations/_lie_group.py
@@ -4,8 +4,8 @@ Abstraction of rotations represented by matrix lie groups.
 
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import ClassVar
-from typing_extensions import Self, override
+from typing import ClassVar, Self
+from typing_extensions import override
 
 import equinox as eqx
 import jax

--- a/cryojax/rotations/_rotation.py
+++ b/cryojax/rotations/_rotation.py
@@ -3,8 +3,7 @@ Abstraction of a rotation.
 """
 
 from abc import abstractmethod
-from typing import overload
-from typing_extensions import Self
+from typing import Self, overload
 
 from equinox import AbstractClassVar, Module
 from jaxtyping import Array, PRNGKeyArray

--- a/cryojax/simulator/_pose.py
+++ b/cryojax/simulator/_pose.py
@@ -5,7 +5,8 @@ Representations of rigid body rotations and translations of 3D coordinate system
 from abc import abstractmethod
 from collections.abc import Sequence
 from functools import cached_property
-from typing_extensions import Self, override
+from typing import Self
+from typing_extensions import override
 
 import equinox as eqx
 import jax

--- a/cryojax/simulator/_volume/base_volume.py
+++ b/cryojax/simulator/_volume/base_volume.py
@@ -1,6 +1,6 @@
 import abc
-from typing import Generic, TypeVar
-from typing_extensions import Self, override
+from typing import Generic, Self, TypeVar
+from typing_extensions import override
 
 import equinox as eqx
 from jaxtyping import Array, Complex, Float, Inexact, PRNGKeyArray

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -2,8 +2,8 @@
 Fourier voxel-based representations of a volume.
 """
 
-from typing import ClassVar, cast
-from typing_extensions import Self, override
+from typing import ClassVar, Self, cast
+from typing_extensions import override
 
 import equinox as eqx
 import jax.numpy as jnp

--- a/cryojax/simulator/_volume/gaussian_volume.py
+++ b/cryojax/simulator/_volume/gaussian_volume.py
@@ -1,7 +1,7 @@
 import warnings
 from collections.abc import Callable
-from typing import Any, ClassVar, Literal, TypedDict
-from typing_extensions import Self, override
+from typing import Any, ClassVar, Literal, Self, TypedDict
+from typing_extensions import override
 
 import equinox as eqx
 import jax

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, ClassVar, Literal, TypeVar
-from typing_extensions import Self, override
+from typing import Any, ClassVar, Literal, Self, TypeVar
+from typing_extensions import override
 
 import equinox as eqx
 import jax

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -3,8 +3,8 @@ Real voxel-based representations of a volume.
 """
 
 import math
-from typing import Any, ClassVar, cast
-from typing_extensions import Self, override
+from typing import Any, ClassVar, Self, cast
+from typing_extensions import override
 
 import equinox as eqx
 import jax.numpy as jnp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cryojax"
 description = "Cryo-EM image simulation and analysis powered by JAX"
 authors = [{ name = "Michael O'Brien", email = "michaelobrien@g.harvard.edu" }]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 keywords = ["jax", "equinox", "cryo-EM", "electron-microscopy"]
 classifiers = [


### PR DESCRIPTION
Newer versions of JAX have dropped this and dependencies are slowly starting to. Will not be officially supported anymore later this year.