### PR TITLE
Adopt `nufftax` for `IndependentAtom*` rendering/projections, including new real-space method

### DIFF
--- a/cryojax/ndimage/__init__.py
+++ b/cryojax/ndimage/__init__.py
@@ -35,6 +35,7 @@ from ._fourier_statistics import (
 from ._fourier_utils import (
     convert_fftn_to_rfftn as convert_fftn_to_rfftn,
     enforce_rfftn_self_conjugates as enforce_rfftn_self_conjugates,
+    query_efficient_grid_size as query_efficient_grid_size,
 )
 from ._map_coordinates import (
     compute_spline_coefficients as compute_spline_coefficients,

--- a/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
+++ b/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
@@ -68,6 +68,7 @@ def make_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """Create a fourier-space cartesian coordinate system on a grid.
     The zero-frequency component is in the corner.
@@ -93,6 +94,7 @@ def make_frequency_grid(
         grid_spacing=grid_spacing,
         outputs_real_space=False,
         outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
     return frequency_grid
 
@@ -101,6 +103,7 @@ def make_radial_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, " *shape"]:
     """Create a fourier-space radial coordinate system on a grid.
     The zero-frequency component is in the corner.
@@ -127,7 +130,10 @@ def make_radial_frequency_grid(
     """
     # Make a cartesian grid
     frequency_grid = make_frequency_grid(
-        shape=shape, grid_spacing=grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs
+        shape=shape,
+        grid_spacing=grid_spacing,
+        outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
 
     # Now compute the magnitude of the frequency vector
@@ -140,6 +146,7 @@ def make_frequency_slice(
     shape: tuple[int, int],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = False,
+    fftshifted: bool = True,
 ) -> Float[Array, "1 {shape[0]} {shape[1]} 3"]:
     """Create a fourier-space cartesian coordinate system on a grid, where
     zero-frequency component is in the *center* of the grid.
@@ -180,12 +187,8 @@ def make_frequency_slice(
     zero-frequency component is in the *center* of the grid.
     """  # noqa: E501
     frequency_slice = make_frequency_grid(
-        shape, grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs
+        shape, grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs, fftshifted=fftshifted
     )
-    if outputs_rfftfreqs:
-        frequency_slice = jnp.fft.fftshift(frequency_slice, axes=(0,))
-    else:
-        frequency_slice = jnp.fft.fftshift(frequency_slice, axes=(0, 1))
     frequency_slice = jnp.expand_dims(
         jnp.pad(
             frequency_slice,
@@ -201,6 +204,7 @@ def make_frequency_slice(
 def make_1d_coordinate_grid(
     size: int,
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """
     Create a 1D real-space cartesian coordinate array.
@@ -218,7 +222,7 @@ def make_1d_coordinate_grid(
     A 1D cartesian coordinate array in real space.
     """
     coordinate_array = _make_coordinates_or_frequencies_1d(
-        size, grid_spacing=grid_spacing, outputs_real_space=True
+        size, grid_spacing=grid_spacing, outputs_real_space=True, fftshifted=fftshifted
     )
     return coordinate_array
 
@@ -227,6 +231,7 @@ def make_1d_frequency_grid(
     size: int,
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """Create a 1D fourier-space cartesian coordinate array.
     If `outputs_rfftfreqs = False`, the zero-frequency component is in the beginning.
@@ -252,6 +257,7 @@ def make_1d_frequency_grid(
         grid_spacing=grid_spacing,
         outputs_real_space=False,
         outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
     return frequency_array
 
@@ -261,13 +267,14 @@ def _make_coordinates_or_frequencies(
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_real_space: bool = False,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     ndim = len(shape)
     coords1D = []
     for idx in range(ndim):
         if outputs_real_space:
             c1D = _make_coordinates_or_frequencies_1d(
-                shape[idx], grid_spacing, outputs_real_space
+                shape[idx], grid_spacing, outputs_real_space, fftshifted=fftshifted
             )
         else:
             if not outputs_rfftfreqs:
@@ -275,7 +282,11 @@ def _make_coordinates_or_frequencies(
             else:
                 rfftfreq = False if idx < ndim - 1 else True
             c1D = _make_coordinates_or_frequencies_1d(
-                shape[idx], grid_spacing, outputs_real_space, rfftfreq
+                shape[idx],
+                grid_spacing,
+                outputs_real_space,
+                rfftfreq,
+                fftshifted=fftshifted,
             )
         coords1D.append(c1D)
     if ndim == 2:
@@ -303,15 +314,22 @@ def _make_coordinates_or_frequencies_1d(
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""],
     outputs_real_space: bool = False,
     outputs_rfftfreqs: bool | None = None,
+    fftshifted: bool = False,
 ) -> Float[Array, " size"]:
     """One-dimensional coordinates in real or fourier space"""
     if outputs_real_space:
-        make_1d = lambda size, dx: jnp.fft.fftshift(jnp.fft.fftfreq(size, 1 / dx)) * size
+        make_1d = lambda size, dx: dx * (jnp.arange(size, dtype=float) - size / 2)
     else:
         if outputs_rfftfreqs is None:
             raise ValueError("Internal error in `cryojax.coordinates`.")
         else:
-            fn = jnp.fft.rfftfreq if outputs_rfftfreqs else jnp.fft.fftfreq
+            if outputs_rfftfreqs:
+                fn = jnp.fft.rfftfreq
+            else:
+                if fftshifted:
+                    fn = lambda *x: jnp.fft.fftshift(jnp.fft.fftfreq(*x))
+                else:
+                    fn = jnp.fft.fftfreq
             make_1d = lambda size, dx: fn(size, dx)
 
     return make_1d(size, grid_spacing)

--- a/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
+++ b/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
@@ -318,7 +318,7 @@ def _make_coordinates_or_frequencies_1d(
 ) -> Float[Array, " size"]:
     """One-dimensional coordinates in real or fourier space"""
     if outputs_real_space:
-        make_1d = lambda size, dx: dx * (jnp.arange(size, dtype=float) - size / 2)
+        make_1d = lambda size, dx: jnp.fft.fftshift(jnp.fft.fftfreq(size, 1 / dx) * size)
     else:
         if outputs_rfftfreqs is None:
             raise ValueError("Internal error in `cryojax.coordinates`.")

--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -237,14 +237,14 @@ def _fft_ds_real_signal_to_shape(
     outputs_rfft: bool = True,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
     # Forward Hartley Transform
-    hartley_array = jnp.fft.fftshift(fftn(image_or_volume))
+    hartley_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(image_or_volume)))
     hartley_array = hartley_array.real - hartley_array.imag
 
     # Crop to the desired shape
     ds_array = crop_to_shape(hartley_array, downsampled_shape)
 
     # Inverse Hartley Transform
-    ds_array = jnp.fft.fftshift(fftn(ds_array))
+    ds_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(ds_array)))
     ds_array /= ds_array.size
     ds_array = ds_array.real - ds_array.imag
 

--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -180,6 +180,7 @@ def fourier_crop_to_shape(
     image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
     shape: tuple[int, int] | tuple[int, int, int],
     outputs_real_space: bool = True,
+    outputs_rfft: bool = True,
     preserve_mean: bool = False,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
     """Downsample an array to a specified shape using fourier cropping.
@@ -199,6 +200,9 @@ def fourier_crop_to_shape(
         If `False`, the `image_or_volume` is returned in fourier space
         with the zero-frequency component in the corner. For real signals,
         hermitian symmetry is assumed.
+    - `outputs_rfft`:
+        Returns the result `fftn` instead of `rfftn` if equal to `False`.
+        Only applies to real signals, and ignored if `outputs_real_space` is `False`.
     - `preserve_mean`:
         Preserve the mean of the volume after downsampling, rather
         than the sum.
@@ -214,16 +218,23 @@ def fourier_crop_to_shape(
         )
     else:
         signal = _fft_ds_real_signal_to_shape(
-            image_or_volume, shape, outputs_real_space=outputs_real_space
+            image_or_volume,
+            shape,
+            outputs_real_space=outputs_real_space,
+            outputs_rfft=outputs_rfft,
         )
     n_pixels, n_pixels_ds = math.prod(image_or_volume.shape), math.prod(shape)
-    return (n_pixels_ds / n_pixels) * signal if preserve_mean else signal
+    if outputs_real_space:
+        return signal
+    else:
+        return (n_pixels_ds / n_pixels) * signal if preserve_mean else signal
 
 
 def _fft_ds_real_signal_to_shape(
     image_or_volume: Float[NDArrayLike, "_ _"] | Float[NDArrayLike, "_ _ _"],
     downsampled_shape: tuple[int, int] | tuple[int, int, int],
     outputs_real_space: bool = True,
+    outputs_rfft: bool = True,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
     # Forward Hartley Transform
     hartley_array = jnp.fft.fftshift(fftn(image_or_volume))
@@ -240,7 +251,7 @@ def _fft_ds_real_signal_to_shape(
     if outputs_real_space:
         return ds_array
     else:
-        return rfftn(ds_array)
+        return rfftn(ds_array) if outputs_rfft else fftn(ds_array)
 
 
 def _fft_ds_complex_signal_to_shape(

--- a/cryojax/ndimage/_edges.py
+++ b/cryojax/ndimage/_edges.py
@@ -15,10 +15,9 @@ def crop_to_shape(
     image_or_volume: (
         Inexact[NDArrayLike, "y_dim x_dim"] | Inexact[NDArrayLike, "z_dim y_dim x_dim"]
     ),
-    shape: tuple[int, int] | tuple[int, int, int],
+    shape: tuple[int, ...],
     center: (
-        tuple[int, int]
-        | tuple[int, int, int]
+        tuple[int, ...]
         | tuple[Int[NDArrayLike, ""], Int[NDArrayLike, ""]]
         | tuple[Int[NDArrayLike, ""], Int[NDArrayLike, ""], Int[NDArrayLike, ""]]
         | None
@@ -98,7 +97,7 @@ def pad_to_shape(
     image_or_volume: (
         Inexact[NDArrayLike, "y_dim x_dim"] | Inexact[NDArrayLike, "z_dim y_dim x_dim"]
     ),
-    shape: tuple[int, int] | tuple[int, int, int],
+    shape: tuple[int, ...],
     **kwargs: Any,
 ) -> (
     Inexact[Array, " {shape[0]} {shape[1]}"]
@@ -135,7 +134,7 @@ def pad_to_shape(
 
 
 def resize_with_crop_or_pad(
-    image: Inexact[NDArrayLike, "y_dim x_dim"], shape: tuple[int, int], **kwargs
+    image: Inexact[NDArrayLike, "y_dim x_dim"], shape: tuple[int, ...], **kwargs
 ) -> Inexact[Array, " {shape[0]} {shape[1]}"]:
     """Resize an image to a new shape using padding and cropping."""
     if image.ndim != 2 or len(shape) != 2:

--- a/cryojax/ndimage/_fft.py
+++ b/cryojax/ndimage/_fft.py
@@ -26,7 +26,7 @@ def ifftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.ifftn(ft, s=s, axes=axes), axes=axes)
+    ift = jnp.fft.ifftn(ft, s=s, axes=axes)
 
     return ift
 
@@ -49,7 +49,7 @@ def fftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.fftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
+    ft = jnp.fft.fftn(ift, s=s, axes=axes)
 
     return ft
 
@@ -72,7 +72,7 @@ def irfftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.irfftn(ft, s=s, axes=axes), axes=axes)
+    ift = jnp.fft.irfftn(ft, s=s, axes=axes)
 
     return ift
 
@@ -94,6 +94,6 @@ def rfftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.rfftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
+    ft = jnp.fft.rfftn(ift, axes=axes, s=s)
 
     return ft

--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -179,7 +179,7 @@ def enforce_rfftn_self_conjugates(
 
 
 def query_efficient_grid_size(
-    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = True
+    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = False
 ) -> tuple[int, ...]:
     """Select an efficient grid size for FFT"""
 

--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -1,3 +1,4 @@
+import math
 from typing import Literal
 
 from jaxtyping import Array, Complex
@@ -175,3 +176,69 @@ def enforce_rfftn_self_conjugates(
             f"Passed an array with `ndim = {rfftn_array.ndim}`."
         )
     return rfftn_array
+
+
+def query_efficient_grid_size(
+    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = True
+) -> tuple[int, ...]:
+    """Select an efficient grid size for FFT"""
+
+    if match_parity:
+        is_same_parity = lambda n1, n2: (n1 % 2) == (n2 % 2)
+    else:
+        is_same_parity = lambda *_: True
+
+    padded_shape = tuple(int(math.ceil(pad_scale * s)) for s in shape)
+
+    def next_smooth_int(n: int, nf: int) -> int:
+        # Check if n is already smooth
+        def is_smooth(x):
+            for p in [2, 3, 5]:
+                while x % p == 0:
+                    x //= p
+            return x == 1
+
+        # Find next smooth number
+        candidate = nf
+        while not (is_smooth(candidate) and is_same_parity(n, candidate)):
+            candidate += 1
+        return candidate
+
+    return tuple(next_smooth_int(n, nf) for n, nf in zip(shape, padded_shape))
+
+
+# def _make_fftshift_phase(
+#     shape: tuple[int, ...],
+#     axes: tuple[int, ...] | None = None,
+# ) -> Array:
+#     """Build the `(-1)^(k1+k2+...)` sign pattern for the full (non-real) FFT.
+
+#     Multiplying `jnp.fft.fftn(x)` by this pattern gives the same result as
+#     `jnp.fft.fftn(jnp.fft.ifftshift(x))`, so the output has DC at corner
+#     (modeord=0 convention). Then `jnp.fft.fftshift` moves DC back to center
+#     if needed for storage.
+
+#     Only exact for even-sized dimensions.
+
+#     **Arguments:**
+
+#     - `shape`: shape of the FFT output array (same as input when s=None).
+#     - `axes`: axes to include; defaults to all axes.
+
+#     **Returns:**
+
+#     Broadcastable ±1 array with the same number of dimensions as `shape`.
+#     """
+#     ndim = len(shape)
+#     if axes is None:
+#         axes = tuple(range(ndim))
+#     else:
+#         axes = tuple(ax % ndim for ax in axes)
+#     phase = jnp.ones(())
+#     for ax in axes:
+#         n = shape[ax]
+#         p = jnp.where(jnp.arange(n) % 2 == 0, 1.0, -1.0)
+#         reshape = [1] * ndim
+#         reshape[ax] = n
+#         phase = phase * p.reshape(reshape)
+#     return phase

--- a/cryojax/ndimage/_operators/_fourier_operator.py
+++ b/cryojax/ndimage/_operators/_fourier_operator.py
@@ -43,16 +43,8 @@ class AbstractFourierOperator(eqx.Module, strict=True):
     @abstractmethod
     def __call__(
         self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
+        frequencies: Float[Array, "..."],
+    ) -> Inexact[Array, "..."]:
         raise NotImplementedError
 
     def __add__(self, other) -> "AbstractFourierOperator":
@@ -97,17 +89,9 @@ class _SumFourierOperator(AbstractFourierOperator, strict=True):
     @override
     def __call__(
         self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(frequency_grid) + self.operator2(frequency_grid)
+        frequencies: Float[Array, "..."],
+    ) -> Inexact[Array, "..."]:
+        return self.operator1(frequencies) + self.operator2(frequencies)
 
     def __repr__(self):
         return f"{repr(self.operator1)} + {repr(self.operator2)}"
@@ -122,19 +106,8 @@ class _DiffFourierOperator(AbstractFourierOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(frequency_grid) - self.operator2(frequency_grid)
+    def __call__(self, frequencies: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.operator1(frequencies) - self.operator2(frequencies)
 
     def __repr__(self):
         return f"{repr(self.operator1)} - {repr(self.operator2)}"
@@ -149,19 +122,8 @@ class _ProductFourierOperator(AbstractFourierOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(frequency_grid) * self.operator2(frequency_grid)
+    def __call__(self, frequencies: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.operator1(frequencies) * self.operator2(frequencies)
 
     def __repr__(self):
         return f"{repr(self.operator1)} * {repr(self.operator2)}"
@@ -170,53 +132,29 @@ class _ProductFourierOperator(AbstractFourierOperator, strict=True):
 class CustomFourierOperator(AbstractFourierOperator, strict=True):
     """An operator that calls a custom function."""
 
-    fn: Callable[
-        ...,
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"],
-    ]
+    fn: Callable[..., Inexact[Array, "..."]]
     args: Any
     kwargs: Any
 
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     def __init__(
-        self,
-        fn: Callable[
-            ...,
-            Inexact[Array, " x_dim"]
-            | Inexact[Array, "y_dim x_dim"]
-            | Inexact[Array, "z_dim y_dim x_dim"],
-        ],
-        *args: Any,
-        **kwargs: Any,
+        self, fn: Callable[..., Inexact[Array, "..."]], *args: Any, **kwargs: Any
     ):
         self.fn = fn
         self.args = args
         self.kwargs = kwargs
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.fn(frequency_grid, *self.args, **self.kwargs)
+    def __call__(self, frequencies: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.fn(frequencies, *self.args, **self.kwargs)
 
 
 CustomFourierOperator.__init__.__doc__ = """**Arguments:**
 
 - `fn`:
     The `Callable` wrapped into a `AbstractFourierOperator`.
-    Has signature `out = fn(frequency_grid, *args, **kwargs)`
+    Has signature `out = fn(frequencies, *args, **kwargs)`
 - `args`:
     Passed to `fn`.
 - `kwargs`:
@@ -239,29 +177,18 @@ class FourierDC(AbstractFourierOperator, strict=True):
         self.value = jnp.asarray(value)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Float[Array, " x_dim"]
-        | Float[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
-        if frequency_grid.ndim == 1:
-            return jnp.zeros(frequency_grid.shape).at[0].set(self.value)
-        elif frequency_grid.ndim - 1 == 2:
-            return jnp.zeros(frequency_grid.shape[0:-1]).at[0, 0].set(self.value)
-        elif frequency_grid.ndim - 1 == 3:
-            return jnp.zeros(frequency_grid.shape[0:-1]).at[0, 0, 0].set(self.value)
+    def __call__(self, frequencies: Float[Array, "..."]) -> Float[Array, "..."]:
+        frequencies, ndim, flag = _standardize_frequencies(frequencies)
+        if ndim == 1 and not flag:
+            return jnp.zeros(frequencies.shape).at[0].set(self.value)
+        elif ndim == 2:
+            return jnp.zeros(frequencies.shape[0:-1]).at[0, 0].set(self.value)
+        elif ndim == 3:
+            return jnp.zeros(frequencies.shape[0:-1]).at[0, 0, 0].set(self.value)
         else:
             raise ValueError(
-                "Unrecognized format for `frequency_grid` passed to `FourierDC` "
-                f"Was shape {frequency_grid.shape}, but only shapes `(N,)` "
-                "`(N1, N2, 2)`, and `(N1, N2, N3, 3)` are supported."
+                "Could not parse the spatial dimension of `frequencies` passed to "
+                f"`FourierDC`. Got `frequencies` with shape {frequencies.shape}."
             )
 
 
@@ -272,7 +199,7 @@ class FourierConstant(AbstractFourierOperator, strict=True):
 
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
-    def __init__(self, value: float | Float[Array, "..."]):
+    def __init__(self, value: FloatLike):
         """**Arguments:**
 
         - `value`: The value of the constant
@@ -280,15 +207,8 @@ class FourierConstant(AbstractFourierOperator, strict=True):
         self.value = jnp.asarray(value)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> Float[Array, "..."]:
-        del frequency_grid
+    def __call__(self, frequencies: Float[Array, "..."]) -> Float[Array, "..."]:
+        del frequencies
         return self.value
 
 
@@ -333,10 +253,15 @@ class FourierExp2D(AbstractFourierOperator, strict=True):
         self.length_scale = jnp.asarray(length_scale, dtype=float)
 
     @override
-    def __call__(
-        self, frequency_grid: Float[Array, "y_dim x_dim 2"]
-    ) -> Float[Array, "y_dim x_dim"]:
-        k_sqr = jnp.sum(frequency_grid**2, axis=-1)
+    def __call__(self, frequencies: Float[Array, "... 2"]) -> Float[Array, "..."]:
+        frequencies, ndim, _ = _standardize_frequencies(frequencies)
+        if ndim != 2:
+            raise ValueError(
+                "`cryojax.ndimage.FourierExp2D` only supports "
+                "`spatial_dim = 2`, but passed a frequency "
+                "array with `spatial_dim = 1`."
+            )
+        k_sqr = jnp.sum(frequencies**2, axis=-1)
         scaling = (
             1.0
             / (k_sqr + jnp.divide(1, (error_if_not_positive(self.length_scale)) ** 2))
@@ -377,28 +302,13 @@ class FourierGaussian(AbstractFourierOperator, strict=True):
         self.b_factor = jnp.asarray(b_factor, dtype=float)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Float[Array, " x_dim"]
-        | Float[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
-        k_sqr = (
-            frequency_grid**2
-            if frequency_grid.ndim == 1
-            else jnp.sum(frequency_grid**2, axis=-1)
-        )
+    def __call__(self, frequencies: Float[Array, "..."]) -> Float[Array, "..."]:
+        frequencies, _, flag = _standardize_frequencies(frequencies)
+        q_squared = jnp.sum(frequencies**2, axis=-1)
         gaussian = self.amplitude * jnp.exp(
-            -0.25 * error_if_not_positive(self.b_factor) * k_sqr
+            -0.25 * error_if_not_positive(self.b_factor) * q_squared
         )
-
-        return gaussian
+        return _standardize_output(gaussian, flag=flag)
 
 
 class PeakedFourierGaussian(AbstractFourierOperator, strict=True):
@@ -434,29 +344,15 @@ class PeakedFourierGaussian(AbstractFourierOperator, strict=True):
         self.radial_peak = jnp.asarray(radial_peak, dtype=float)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Float[Array, " x_dim"]
-        | Float[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
-        k = (
-            jnp.linalg.norm(frequency_grid)
-            if frequency_grid.ndim == 1
-            else jnp.linalg.norm(frequency_grid, axis=-1)
-        )
+    def __call__(self, frequencies: Float[Array, "..."]) -> Float[Array, "..."]:
+        frequencies, _, flag = _standardize_frequencies(frequencies)
+        k = jnp.linalg.norm(frequencies, axis=-1)
         gaussian = self.amplitude * jnp.exp(
             -0.25
             * error_if_not_positive(self.b_factor)
             * (k - error_if_negative(self.radial_peak)) ** 2
         )
-        return gaussian
+        return _standardize_output(gaussian, flag=flag)
 
 
 class FourierSinc(AbstractFourierOperator, strict=True):
@@ -491,24 +387,14 @@ class FourierSinc(AbstractFourierOperator, strict=True):
         self.box_width = jnp.asarray(box_width, dtype=float)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Float[Array, " x_dim"]
-        | Float[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
-        if frequency_grid.ndim == 1:
-            frequency_grid = frequency_grid[:, None]
-        ndim = frequency_grid.ndim - 1
-        return functools.reduce(
-            operator.mul,
-            [jnp.sinc(frequency_grid[..., i] * self.box_width) for i in range(ndim)],
+    def __call__(self, frequencies: Float[Array, "..."]) -> Float[Array, "..."]:
+        frequencies, ndim, flag = _standardize_frequencies(frequencies)
+        return _standardize_output(
+            functools.reduce(
+                operator.mul,
+                [jnp.sinc(frequencies[..., i] * self.box_width) for i in range(ndim)],
+            ),
+            flag=flag,
         )
 
 
@@ -527,31 +413,35 @@ class FourierPhaseShifts(AbstractFourierOperator):
 
         - `shift`:
             The shift to apply in the Fourier domain. The units of this should
-            be the inverse of the units of the `frequency_grid` passed at runtime.
+            be the inverse of the units of the `frequencies` passed at runtime.
         """
         self.shift = jnp.asarray(jnp.atleast_1d(shift), dtype=float)
 
     @override
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Complex[Array, " x_dim"]
-        | Complex[Array, "y_dim x_dim"]
-        | Complex[Array, "z_dim y_dim x_dim"]
-    ):
-        if frequency_grid.ndim == 1:
-            frequency_grid = frequency_grid[:, None]
-        ndim = frequency_grid.ndim - 1
+    def __call__(self, frequencies: Float[Array, "..."]) -> Complex[Array, "..."]:
+        frequencies, ndim, flag = _standardize_frequencies(frequencies)
         if ndim != self.shift.size:
             raise ValueError(
-                "The `frequency_grid` passed to `FourierPhaseShift` had "
+                "The `frequencies` passed to `FourierPhaseShift` had "
                 "dimensionality that does not seem to match `FourierPhaseShift.shift`. "
                 f"Got that the dimensionality of the grid was `{ndim}`, but the "
                 f"shift was an array of size {self.shift.size}"
             )
-        return jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid, self.shift)))
+        return _standardize_output(
+            jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(frequencies, self.shift))), flag=flag
+        )
+
+
+def _standardize_frequencies(q: Array):
+    flag = False
+    if q.ndim == 0:
+        flag = True
+        q = q[None, None]
+    elif q.ndim == 1:
+        q = q[:, None]
+    ndim = q.shape[-1]
+    return q, ndim, flag
+
+
+def _standardize_output(out: Array, *, flag: bool):
+    return out[0] if flag else out

--- a/cryojax/ndimage/_operators/_real_operator.py
+++ b/cryojax/ndimage/_operators/_real_operator.py
@@ -34,16 +34,8 @@ class AbstractRealOperator(eqx.Module, strict=True):
     @abstractmethod
     def __call__(  # pyright: ignore
         self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
+        coordinates: Float[Array, "..."],
+    ) -> Inexact[Array, "..."]:
         raise NotImplementedError
 
     def __add__(self, other) -> "AbstractRealOperator":
@@ -86,19 +78,8 @@ class _SumRealOperator(AbstractRealOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     @override
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(coordinate_grid) * self.operator2(coordinate_grid)
+    def __call__(self, coordinates: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.operator1(coordinates) * self.operator2(coordinates)
 
     def __repr__(self):
         return f"{repr(self.operator1)} + {repr(self.operator2)}"
@@ -113,19 +94,8 @@ class _DiffRealOperator(AbstractRealOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     @override
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(coordinate_grid) * self.operator2(coordinate_grid)
+    def __call__(self, coordinates: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.operator1(coordinates) * self.operator2(coordinates)
 
     def __repr__(self):
         return f"{repr(self.operator1)} - {repr(self.operator2)}"
@@ -140,19 +110,8 @@ class _ProductRealOperator(AbstractRealOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1, 2, 3]
 
     @override
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Inexact[Array, " x_dim"]
-        | Inexact[Array, "y_dim x_dim"]
-        | Inexact[Array, "z_dim y_dim x_dim"]
-    ):
-        return self.operator1(coordinate_grid) * self.operator2(coordinate_grid)
+    def __call__(self, coordinates: Float[Array, "..."]) -> Inexact[Array, "..."]:
+        return self.operator1(coordinates) * self.operator2(coordinates)
 
     def __repr__(self):
         return f"{repr(self.operator1)} * {repr(self.operator2)}"
@@ -198,28 +157,18 @@ class RealGaussian(AbstractRealOperator, strict=True):
             self.offset = None
 
     @override
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> (
-        Float[Array, " x_dim"]
-        | Float[Array, "y_dim x_dim"]
-        | Float[Array, "z_dim y_dim x_dim"]
-    ):
-        if coordinate_grid.ndim == 1:
-            coordinate_grid = coordinate_grid[:, None]
-        ndim = coordinate_grid.ndim - 1
+    def __call__(self, coordinates: Float[Array, "..."]) -> Float[Array, "..."]:
+        coordinates, ndim, flag = _standardize_coordinates(coordinates)
         offset = jnp.zeros((ndim,), dtype=float) if self.offset is None else self.offset
-        r_squared = jnp.sum((coordinate_grid - offset) ** 2, axis=-1)
+        if offset is None:
+            r_squared = jnp.sum(coordinates**2, axis=-1)
+        else:
+            r_squared = jnp.sum((coordinates - offset) ** 2, axis=-1)
         scaling = (
             self.amplitude
             / jnp.sqrt(2 * jnp.pi * error_if_not_positive(self.variance)) ** ndim
         ) * jnp.exp(-0.5 * r_squared / self.variance)
-        return scaling
+        return _standardize_output(scaling, flag=flag)
 
 
 class RealConstant(AbstractRealOperator, strict=True):
@@ -237,13 +186,21 @@ class RealConstant(AbstractRealOperator, strict=True):
         self.value = jnp.asarray(value)
 
     @override
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ) -> Float[Array, ""]:
-        del coordinate_grid
+    def __call__(self, coordinates: Float[Array, "..."]) -> Float[Array, ""]:
+        del coordinates
         return self.value
+
+
+def _standardize_coordinates(x: Array):
+    flag = False
+    if x.ndim == 0:
+        flag = True
+        x = x[None, None]
+    elif x.ndim == 1:
+        x = x[:, None]
+    ndim = x.shape[-1]
+    return x, ndim, flag
+
+
+def _standardize_output(out: Array, *, flag: bool):
+    return out[0] if flag else out

--- a/cryojax/ndimage/_operators/_real_operator.py
+++ b/cryojax/ndimage/_operators/_real_operator.py
@@ -79,7 +79,7 @@ class _SumRealOperator(AbstractRealOperator, strict=True):
 
     @override
     def __call__(self, coordinates: Float[Array, "..."]) -> Inexact[Array, "..."]:
-        return self.operator1(coordinates) * self.operator2(coordinates)
+        return self.operator1(coordinates) + self.operator2(coordinates)
 
     def __repr__(self):
         return f"{repr(self.operator1)} + {repr(self.operator2)}"
@@ -95,7 +95,7 @@ class _DiffRealOperator(AbstractRealOperator, strict=True):
 
     @override
     def __call__(self, coordinates: Float[Array, "..."]) -> Inexact[Array, "..."]:
-        return self.operator1(coordinates) * self.operator2(coordinates)
+        return self.operator1(coordinates) - self.operator2(coordinates)
 
     def __repr__(self):
         return f"{repr(self.operator1)} - {repr(self.operator2)}"

--- a/cryojax/simulator/_image_config.py
+++ b/cryojax/simulator/_image_config.py
@@ -3,7 +3,7 @@
 import math
 import warnings
 from functools import cached_property
-from typing import Literal
+from typing import Literal, cast
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -18,7 +18,11 @@ from ..constants import (
     wavelength_from_kilovolts,
 )
 from ..jax_util import FloatLike
-from ..ndimage import make_coordinate_grid, make_frequency_grid
+from ..ndimage import (
+    make_coordinate_grid,
+    make_frequency_grid,
+    query_efficient_grid_size,
+)
 
 
 _get_deprecation_msg = lambda self, prop, func: (
@@ -548,6 +552,7 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
         voltage_in_kilovolts: FloatLike,
         *,
         padded_shape: tuple[int, int] | None = None,
+        pad_scale: float = 1.0,
         precompute_mode: Literal[
             "none", "rfft", "fft", "all", "compile_time_eval"
         ] = "none",
@@ -564,6 +569,12 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
         - `padded_shape`:
             The shape of the image after padding. By default, equal
             to `shape`.
+        - `pad_scale`:
+            A scale factor used to determine the `padded_shape`.
+            Used only if `padded_shape` is not directly provided.
+            Unless `pad_scale = 1.0`, it is only an approximation
+            of the resulting `padded_shape`. By default, a good
+            array size for FFT efficiency is chosen.
         - `precompute_mode`:
             How to pre-compute coordinate and frequency grids stored in
             the `image_config`. Options are
@@ -598,7 +609,7 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
             )
             padded_shape = pad_options["shape"]
         self.shape = shape
-        self.padded_shape = shape if padded_shape is None else padded_shape
+        self.padded_shape = _set_padded_shape(type(self), shape, padded_shape, pad_scale)
         # Finally, grid precompute
         if precompute_mode == "rfft":
             self.precomputed_grids = PrecomputedGrids(
@@ -641,6 +652,7 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
         electron_dose: FloatLike,
         *,
         padded_shape: tuple[int, int] | None = None,
+        pad_scale: float = 1.0,
         precompute_mode: Literal[
             "none", "rfft", "fft", "all", "compile_time_eval"
         ] = "none",
@@ -660,6 +672,12 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
         - `padded_shape`:
             The shape of the image after padding. By default, equal
             to `shape`.
+        - `pad_scale`:
+            A scale factor used to determine the `padded_shape`.
+            Used only if `padded_shape` is not directly provided.
+            Unless `pad_scale = 1.0`, it is only an approximation
+            of the resulting `padded_shape`. By default, a good
+            array size for FFT efficiency is chosen.
         - `precompute_mode`:
             How to pre-compute coordinate and frequency grids stored in
             the `image_config`. Options are
@@ -695,7 +713,7 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
             )
             padded_shape = pad_options["shape"]
         self.shape = shape
-        self.padded_shape = shape if padded_shape is None else padded_shape
+        self.padded_shape = _set_padded_shape(type(self), shape, padded_shape, pad_scale)
         # Finally, grid precompute
         if precompute_mode == "rfft":
             self.precomputed_grids = PrecomputedGrids(
@@ -739,3 +757,22 @@ def _safe_multiply_by_constant(
         grid = grid.at[:, s2 // 2, 0].multiply(constant)
         grid = grid.at[s1 // 2, :, 1].multiply(constant)
     return grid
+
+
+def _set_padded_shape(
+    cls, shape: tuple[int, int], padded_shape: tuple[int, int] | None, pad_scale: float
+):
+    if padded_shape is not None:
+        return padded_shape
+    elif pad_scale == 1.0:
+        return shape
+    elif pad_scale > 1.0:
+        return cast(
+            tuple[int, int],
+            query_efficient_grid_size(shape, pad_scale=pad_scale),
+        )
+    else:
+        raise ValueError(
+            f"Invalid value for `{cls.__name__}(..., pad_scale=...)`. "
+            f"This must be greater than `1.0`, but got value `{pad_scale}`."
+        )

--- a/cryojax/simulator/_image_model.py
+++ b/cryojax/simulator/_image_model.py
@@ -190,7 +190,8 @@ class AbstractImageModel(eqx.Module, strict=True):
 
     def _phase_shift_translate(self, fourier_image: Array) -> Array:
         phase_shifts = self.pose.compute_translation_operator(
-            self.image_config.get_frequency_grid(physical=True, padding=True)
+            self.image_config.padded_shape,
+            self.image_config.pixel_size,
         )
         fourier_image = self.pose.translate_image(
             fourier_image,

--- a/cryojax/simulator/_pose.py
+++ b/cryojax/simulator/_pose.py
@@ -119,10 +119,11 @@ class AbstractPose(Module, strict=True):
         grid of in-plane phase shifts $\\exp{(- 2 \\pi i (t_x q_x + t_y q_y))}$.
         """
         tx, ty = self.offset_in_angstroms[0], self.offset_in_angstroms[1]
-        q_x = make_1d_frequency_grid(shape[1], pixel_size, outputs_rfftfreqs=True)
-        q_y = make_1d_frequency_grid(shape[0], pixel_size, outputs_rfftfreqs=False)
-        phase_x = FourierPhaseShifts(tx)(q_x)
-        phase_y = FourierPhaseShifts(ty)(q_y)
+        q_x, q_y = (
+            make_1d_frequency_grid(shape[1], pixel_size, outputs_rfftfreqs=True),
+            make_1d_frequency_grid(shape[0], pixel_size, outputs_rfftfreqs=False),
+        )
+        phase_x, phase_y = (FourierPhaseShifts(tx)(q_x), FourierPhaseShifts(ty)(q_y))
         return phase_y[:, None] * phase_x[None, :]
 
     @cached_property

--- a/cryojax/simulator/_pose.py
+++ b/cryojax/simulator/_pose.py
@@ -15,7 +15,11 @@ from equinox import AbstractVar, Module
 from jaxtyping import Array, Complex, Float
 
 from ..jax_util import FloatLike, NDArrayLike
-from ..ndimage import FourierPhaseShifts, enforce_rfftn_self_conjugates
+from ..ndimage import (
+    FourierPhaseShifts,
+    enforce_rfftn_self_conjugates,
+    make_1d_frequency_grid,
+)
 from ..rotations import SO3, convert_quaternion_to_euler_angles
 
 
@@ -96,24 +100,30 @@ class AbstractPose(Module, strict=True):
         return fourier_image * translation_operator
 
     def compute_translation_operator(
-        self, frequency_grid_in_angstroms: Float[Array, "y_dim x_dim 2"]
-    ) -> Complex[Array, "y_dim x_dim"]:
-        """Compute the phase shifts from the in-plane translation,
-        given a frequency grid coordinate system.
+        self,
+        shape: tuple[int, int],
+        pixel_size: Float[Array, ""],
+    ) -> Complex[Array, "y_dim x_dim//2+1"]:
+        """Compute the phase shifts from the in-plane translation.
 
         **Arguments:**
 
-        - `frequency_grid_in_angstroms`:
-            A grid of in-plane frequency coordinates $(q_x, q_y)$
+        - `shape`:
+            The real-space image shape $(N_y, N_x)$.
+        - `pixel_size`:
+            The pixel size in Angstroms.
 
         **Returns:**
 
         From the vector $(t_x, t_y)$ (given by `self.offset_in_angstroms`), returns the
         grid of in-plane phase shifts $\\exp{(- 2 \\pi i (t_x q_x + t_y q_y))}$.
         """
-        xy = self.offset_in_angstroms[0:2]
-        compute_fn = FourierPhaseShifts(xy)
-        return compute_fn(frequency_grid_in_angstroms)
+        tx, ty = self.offset_in_angstroms[0], self.offset_in_angstroms[1]
+        q_x = make_1d_frequency_grid(shape[1], pixel_size, outputs_rfftfreqs=True)
+        q_y = make_1d_frequency_grid(shape[0], pixel_size, outputs_rfftfreqs=False)
+        phase_x = FourierPhaseShifts(tx)(q_x)
+        phase_y = FourierPhaseShifts(ty)(q_y)
+        return phase_y[:, None] * phase_x[None, :]
 
     @cached_property
     def offset_x_in_angstroms(self) -> Float[Array, "..."]:

--- a/cryojax/simulator/_transfer_theory/transfer_theory.py
+++ b/cryojax/simulator/_transfer_theory/transfer_theory.py
@@ -51,6 +51,17 @@ class ContrastTransferTheory(AbstractTransferTheory, strict=True):
         self.amplitude_contrast_ratio = jnp.asarray(amplitude_contrast_ratio, dtype=float)
         self.phase_shift = jnp.asarray(phase_shift, dtype=float)
 
+    def __check_init__(self):
+        if self.envelope is not None:
+            if 2 not in self.envelope.spatial_dims:
+                raise ValueError(
+                    "`ContrastTransferTheory.envelope` of type "
+                    f"`{self.envelope.__class__.__name__}` must support "
+                    "`spatial_dim = 2`, but found that "
+                    f"`{self.envelope.__class__.__name__}.spatial_dims = "
+                    f"{self.envelope.spatial_dims}`."
+                )
+
     def propagate_object(
         self,
         object_spectrum: (

--- a/cryojax/simulator/_volume/__init__.py
+++ b/cryojax/simulator/_volume/__init__.py
@@ -27,7 +27,6 @@ from .independent_atom_volume import (
     IndependentAtomVolume as IndependentAtomVolume,
     LobatoScatteringFactor as LobatoScatteringFactor,
     PengScatteringFactor as PengScatteringFactor,
-    PengScatteringPotential as PengScatteringPotential,
 )
 from .real_voxels import (
     RealVoxelCloudVolume as RealVoxelCloudVolume,

--- a/cryojax/simulator/_volume/common.py
+++ b/cryojax/simulator/_volume/common.py
@@ -1,0 +1,21 @@
+"""Shared helpers for volume rendering backends."""
+
+from jaxtyping import Array, Float
+
+from ...ndimage import make_1d_frequency_grid
+
+
+def make_frequencies_1d(
+    shape_u: tuple[int, ...],
+    pixel_size_u: Float[Array, ""],
+    modeord: int = 0,
+):
+    return tuple(
+        make_1d_frequency_grid(
+            s,
+            pixel_size_u,
+            outputs_rfftfreqs=False,
+            fftshifted=(True if modeord == 0 else False),
+        )
+        for s in shape_u[::-1]
+    )

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -22,6 +22,7 @@ from ...ndimage import (
     map_coordinates,
     map_coordinates_spline,
     pad_to_shape,
+    query_efficient_grid_size,
     resize_with_crop_or_pad,
     rfftn,
 )
@@ -110,17 +111,27 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         # Cast to jax array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Pad template
-        if pad_scale < 1.0:
+        if isinstance(pad_scale, float) and pad_scale < 1.0:
             raise ValueError("`pad_scale` must be greater than 1.0")
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
-        padded_shape = cast(
-            tuple[int, int, int],
-            tuple([int(s * pad_scale) for s in real_voxel_grid.shape]),
-        )
-        padded_real_voxel_grid = pad_to_shape(
-            real_voxel_grid, padded_shape, mode=pad_mode
-        )
+        if pad_scale == 1.0:
+            padded_shape = real_voxel_grid.shape
+            padded_real_voxel_grid = real_voxel_grid
+        elif pad_scale > 1.0:
+            padded_shape = query_efficient_grid_size(
+                real_voxel_grid.shape,
+                pad_scale=pad_scale,
+            )
+            padded_real_voxel_grid = pad_to_shape(
+                real_voxel_grid, padded_shape, mode=pad_mode
+            )
+        else:
+            raise ValueError(
+                "Invalid value for "
+                "`FourierVoxelGridVolume.from_real_voxel_grid(..., pad_scale=...)`. "
+                f"This must be greater than `1.0`, but got value `{pad_scale}`."
+            )
         if sinc_correction:
             coordinate_grid = make_coordinate_grid(padded_shape)
             correction_mask = SincCorrectionMask(coordinate_grid)
@@ -202,9 +213,8 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
             raise ValueError("`pad_scale` must be greater than 1.0")
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
-        padded_shape = cast(
-            tuple[int, int, int],
-            tuple([int(s * pad_scale) for s in real_voxel_grid.shape]),
+        padded_shape = query_efficient_grid_size(
+            real_voxel_grid.shape, pad_scale=pad_scale, match_parity=True
         )
         padded_real_voxel_grid = pad_to_shape(
             real_voxel_grid, padded_shape, mode=pad_mode

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -214,7 +214,7 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
         padded_shape = query_efficient_grid_size(
-            real_voxel_grid.shape, pad_scale=pad_scale, match_parity=True
+            real_voxel_grid.shape, pad_scale=pad_scale
         )
         padded_real_voxel_grid = pad_to_shape(
             real_voxel_grid, padded_shape, mode=pad_mode

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -16,6 +16,7 @@ from ..._internal import error_if_not_positive
 from ...constants import (
     LobatoScatteringFactorParameters,
     PengScatteringFactorParameters,
+    b_factor_to_variance,
 )
 from ...jax_util import FloatLike, NDArrayLike
 from ...ndimage import (
@@ -160,7 +161,7 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
     """  # noqa: E501
 
     positions: PyTree[Float[Array, "_ 3"]]
-    kernel_fns: PyTree[AbstractFourierOperator] | PyTree[AbstractRealOperator]
+    kernel_fns: PyTree[AbstractFourierOperator] | PyTree[RealGaussian]
     amplitudes: PyTree[Inexact[Array, " _"]] | None
 
     is_frame_rotation: ClassVar[bool] = False
@@ -168,9 +169,7 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
     def __init__(
         self,
         positions: PyTree[Float[NDArrayLike, "_ 3"], "T"],
-        kernel_fns: (
-            PyTree[AbstractFourierOperator, "T"] | PyTree[AbstractRealOperator, "T"]
-        ),
+        kernel_fns: (PyTree[AbstractFourierOperator, "T"] | PyTree[RealGaussian, "T"]),
         amplitudes: PyTree[Inexact[NDArrayLike, " _"], "T"] | None = None,
     ):
         """**Arguments:**
@@ -180,10 +179,12 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         - `kernel_fns`:
             A pytree of functions with the same tree structure
             as `positions`, where each leaf is a
-            [`cryojax.ndimage.AbstractRealOperator`][] or a
+            [`cryojax.ndimage.RealGaussian`][] or a
             [`cryojax.ndimage.AbstractFourierOperator`][].
             Real-space represents the scattering potential, while
             fourier-space represents the scattering factor.
+            [`cryojax.ndimage.RealGaussian`][] classes may have
+            amplitudes and variances with a batch dimension.
         """
         if jax.tree.structure(positions) != jax.tree.structure(
             kernel_fns,
@@ -244,13 +245,31 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         positions_by_element: tuple[Float[NDArrayLike, "_ 3"], ...],
         parameters: PengScatteringFactorParameters | LobatoScatteringFactorParameters,
         *,
+        outputs_real_space: bool = False,
         b_factor_by_element: FloatLike | tuple[FloatLike, ...] | None = None,
     ) -> Self:
         def make_kernel_fn(a, b, b_factor):
             if isinstance(parameters, PengScatteringFactorParameters):
-                return PengScatteringFactor(a, b, b_factor)
+                if outputs_real_space:
+                    b = b + jnp.asarray(b_factor)[None] if b_factor is not None else b
+                    return eqx.filter_vmap(
+                        lambda _a, _b: RealGaussian(
+                            amplitude=_a, variance=b_factor_to_variance(_b)
+                        )
+                    )(a, b)
+                else:
+                    return PengScatteringFactor(a, b, b_factor)
             elif isinstance(parameters, LobatoScatteringFactorParameters):
-                return LobatoScatteringFactor(a, b, b_factor)
+                if outputs_real_space:
+                    raise NotImplementedError(
+                        "`IndependentAtomVolume(..., parameters=..., "
+                        "outputs_real_space=True)` does not support "
+                        "`parameters = LobatoScatteringFactorParameters(...)`. "
+                        "Instead, use `PengScatteringFactorParameters` or set "
+                        "`outputs_real_space = False`."
+                    )
+                else:
+                    return LobatoScatteringFactor(a, b, b_factor)
             else:
                 raise ValueError(
                     "Unrecognized argument `parameters` when "
@@ -423,14 +442,14 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         # Check and modify kernels if using error functions
-        is_real_space = _check_kernel_fns(kernel_fns, spatial_dim=3)
+        is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=3)
         upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
         if is_real_space:
             kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
                 kernel_fns, self.voxel_size, sampling_mode, upsampfac
             )
         # Upsampling arguments
-        if self.upsample_factor > 1:
+        if upsampfac > 1:
             u = _find_exact_upsampfac(self.upsample_factor, self.shape)
             shape_u, voxel_size_u = (
                 (int(u * self.shape[0]), int(u * self.shape[1]), int(u * self.shape[2])),
@@ -610,14 +629,14 @@ class IndependentAtomProjection(
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         # Check and modify kernels if using error functions
-        is_real_space = _check_kernel_fns(kernel_fns, spatial_dim=2)
+        is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=2)
         upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
         if is_real_space:
             kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
                 kernel_fns, pixel_size, sampling_mode, upsampfac
             )
         # Upsampled shape and pixel size
-        if self.upsample_factor > 1:
+        if upsampfac > 1:
             u = _find_exact_upsampfac(self.upsample_factor, shape)
             shape_u, pixel_size_u = (
                 (int(u * shape[0]), int(u * shape[1])),
@@ -685,26 +704,27 @@ IndependentAtomProjection.__doc__ = f"""Integrate atomic parametrization of a vo
 "onto the exit plane from an `IndependentAtomVolume`. {_REAL_VS_FOURIER_DOC}"""
 
 
-def _check_kernel_fns(
-    kernel_pytree: PyTree[AbstractFourierOperator] | PyTree[AbstractRealOperator],
+def _standardize_kernel_fns(
+    kernel_pytree: PyTree[AbstractFourierOperator] | PyTree[RealGaussian],
     *,
     spatial_dim: int,
-) -> bool:
+) -> tuple[bool, PyTree[AbstractFourierOperator] | PyTree[RealGaussian]]:
     kernel_list = jax.tree.leaves(
         kernel_pytree,
         is_leaf=lambda x: isinstance(x, (AbstractFourierOperator, AbstractRealOperator)),
     )
-    if all(isinstance(kernel, AbstractRealOperator) for kernel in kernel_list):
+    if all(isinstance(kernel, RealGaussian) for kernel in kernel_list):
+        # Standardize gaussian kernels for computation
         is_real_space = True
-        for kernel in kernel_list:
-            if 1 not in kernel.spatial_dims:
-                raise ValueError(
-                    "Found that `IndependentAtomVolume.kernel_fns` were "
-                    "`AbstractRealOperator`s, but "
-                    "one or more kernel did not support 1-D arrays as input. "
-                    "The `AbstractRealOperator.spatial_dims` list must include `1` "
-                    "to indicate support for 1D arrays."
-                )
+        # ... pytree leaves have a batch dim
+        kernel_pytree = jax.tree.map(lambda x: jnp.atleast_1d(x), kernel_pytree)
+        # ... amplitude must be spread per dimension
+        replace_fn = lambda fn: eqx.tree_at(
+            lambda _fn: _fn.amplitude, fn, (fn.amplitude ** (1 / spatial_dim))
+        )
+        kernel_pytree = jax.tree.map(
+            replace_fn, kernel_pytree, is_leaf=lambda x: isinstance(x, RealGaussian)
+        )
     elif all(isinstance(kernel, AbstractFourierOperator) for kernel in kernel_list):
         is_real_space = False
         for kernel in kernel_list:
@@ -721,42 +741,36 @@ def _check_kernel_fns(
         raise ValueError(
             "Found that `IndependentAtomVolume.kernel_fns` was not a "
             "PyTree containing only `AbstractFourierOperator`s or "
-            "`AbstractRealOperator`s."
+            "`RealGaussian`s."
         )
 
-    return is_real_space
+    return is_real_space, kernel_pytree
 
 
 def _maybe_gaussians_to_erf(
-    kernel_pytree: PyTree[AbstractRealOperator],
+    kernel_pytree: PyTree[RealGaussian],
     pixel_size: Float[Array, ""],
     sampling_mode: Literal["average", "point"],
     upsampfac: float,
-) -> tuple[PyTree[AbstractRealOperator], Literal["average", "point"], float]:
+) -> tuple[PyTree[RealGaussian], Literal["average", "point"], float]:
     """Modify gaussian kernels at runtime to the error function."""
-    kernel_list = jax.tree.leaves(
-        kernel_pytree,
-        is_leaf=lambda x: isinstance(x, AbstractRealOperator),
-    )
-    if sampling_mode == "point":
-        return kernel_pytree, "point", upsampfac
+    if sampling_mode == "average":
+        return (
+            jax.tree.map(
+                lambda x: _make_erf(x, pixel_size),
+                kernel_pytree,
+                is_leaf=lambda x: isinstance(x, AbstractRealOperator),
+            ),
+            "point",
+            1.0,
+        )
     else:
-        if all(isinstance(kernel, RealGaussian) for kernel in kernel_list):
-            return (
-                jax.tree.map(
-                    lambda x: _IntegratedRealGaussian.from_gaussian(x, pixel_size),
-                    kernel_pytree,
-                    is_leaf=lambda x: isinstance(x, AbstractRealOperator),
-                ),
-                "point",
-                1.0,
-            )
-        return kernel_pytree, "average", upsampfac
+        return (kernel_pytree, "point", upsampfac)
 
 
 def project_impl(
     positions: PyTree[Float[Array, "_ 3"]],
-    kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
+    kernel_fns: PyTree[RealGaussian] | PyTree[AbstractFourierOperator],
     amplitudes: PyTree[Inexact[Array, " _"]],
     *,
     is_real_space: bool,
@@ -791,16 +805,16 @@ def project_impl(
         (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
         xy = 2 * jnp.pi * _positions[:, :2] / box_xy
-        projection = spread_2d(
+        projection = _spread_2d(
+            kernel_fn=_kernel_fn,
+            pixel_size=_ps,
             x=xy[:, 0],
             y=xy[:, 1],
             c=_amplitudes.astype(float),
             nf1=dim,
             nf2=dim,
-            kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_ps, nspread=nspread
-            ),
-            **options,
+            nspread=nspread,
+            options=options,
         )
         return projection
 
@@ -852,7 +866,7 @@ def project_impl(
 
 def render_impl(
     positions: PyTree[Float[Array, "_ 3"]],
-    kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
+    kernel_fns: PyTree[RealGaussian] | PyTree[AbstractFourierOperator],
     amplitudes: PyTree[Inexact[Array, " _"]],
     *,
     is_real_space: bool,
@@ -887,20 +901,20 @@ def render_impl(
         (nz, ny, nx) = _shape
         box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
         xyz = 2 * jnp.pi * _positions / box_xyz
-        projection = spread_3d(
+        rendering = _spread_3d(
+            kernel_fn=_kernel_fn,
+            voxel_size=_vs,
             x=xyz[:, 0],
             y=xyz[:, 1],
             z=xyz[:, 2],
             c=_amplitudes.astype(float),
-            nf1=_shape[2],
-            nf2=_shape[1],
-            nf3=_shape[0],
-            kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_vs, nspread=nspread
-            ),
-            **options,
+            nf1=dim,
+            nf2=dim,
+            nf3=dim,
+            nspread=nspread,
+            options=options,
         )
-        return projection
+        return rendering
 
     def fourier_impl(
         _shape: tuple[int, int, int],
@@ -1040,6 +1054,50 @@ def _nufft3d1(
         )
 
 
+def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, options):
+    assert nf1 == nf2 == nf3
+    dim = nf1
+
+    @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None, None))
+    def spread_3d_impl(_kernel_fn, _voxel_size, _x, _y, _z, _c):
+        return spread_3d(
+            x=_x,
+            y=_y,
+            z=_z,
+            c=_c,
+            nf1=dim,
+            nf2=dim,
+            nf3=dim,
+            kernel_params=_make_nufftax_kernel(
+                _kernel_fn, image_dim=dim, pixel_size=_voxel_size, nspread=nspread
+            ),
+            **options,
+        )
+
+    return jnp.sum(spread_3d_impl(kernel_fn, voxel_size, x, y, z, c), axis=0)
+
+
+def _spread_2d(kernel_fn, pixel_size, x, y, c, nf1, nf2, *, nspread, options):
+    assert nf1 == nf2
+    dim = nf1
+
+    @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None))
+    def spread_2d_impl(_kernel_fn, _pixel_size, _x, _y, _c):
+        return spread_2d(
+            x=_x,
+            y=_y,
+            c=_c,
+            nf1=dim,
+            nf2=dim,
+            kernel_params=_make_nufftax_kernel(
+                _kernel_fn, image_dim=dim, pixel_size=_pixel_size, nspread=nspread
+            ),
+            **options,
+        )
+
+    return jnp.sum(spread_2d_impl(kernel_fn, pixel_size, x, y, c), axis=0)
+
+
 def _eps_to_nspread(eps: float) -> int:
     # FINUFFT heuristic for choosing `nspread` parameter
     # based on desired precision `eps`
@@ -1103,21 +1161,13 @@ def _make_nufftax_kernel(
     )
 
 
-class _IntegratedRealGaussian(AbstractRealOperator, strict=True):
+class _Erf(AbstractRealOperator, strict=True):
     amplitude: Float[Array, ""]
     variance: Float[Array, ""]
 
     pixel_size: Float[Array, ""]
 
     spatial_dims: ClassVar[list[int]] = [1]
-
-    @classmethod
-    def from_gaussian(cls, fn: RealGaussian, pixel_size: Float[Array, ""]):
-        return cls(
-            amplitude=fn.amplitude,
-            variance=fn.variance,
-            pixel_size=pixel_size,
-        )
 
     @override
     def __call__(self, coordinate_grid: Float[Array, " x_dim"]) -> Array:
@@ -1130,6 +1180,13 @@ class _IntegratedRealGaussian(AbstractRealOperator, strict=True):
             jsp.special.erf(scaling * right) - jsp.special.erf(scaling * left)
         )
         return self.amplitude * weight
+
+
+@eqx.filter_vmap(in_axes=(0, None))
+def _make_erf(gaussian: RealGaussian, pixel_size: Float[Array, ""]):
+    return _Erf(
+        amplitude=gaussian.amplitude, variance=gaussian.variance, pixel_size=pixel_size
+    )
 
 
 def _find_exact_upsampfac(input_upsampfac: float, dims: tuple[int, ...]) -> float:

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable, Sequence
 from typing import ClassVar, Literal, Self, TypeVar
 from typing_extensions import override
@@ -6,7 +7,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import nufftax
-from jaxtyping import Array, Complex, Float, Inexact, PyTree
+from jaxtyping import Array, Float, Inexact, PyTree
 
 from ..._internal import error_if_not_positive
 from ...constants import (
@@ -640,7 +641,7 @@ def _check_kernel_fns(
 
 
 def _project_postprocess(
-    projection_out: Complex[Array, "_ _"],
+    projection_out: Inexact[Array, "_ _"],
     *,
     is_real_space: bool,
     compute_shape: tuple[int, int],
@@ -654,8 +655,11 @@ def _project_postprocess(
     reduce_shape = tuple(s // block_size for s in projection_out.shape)
     assert len(reduce_shape) == 2
     if is_real_space:
+        # Optimized code path for case where `render_out`
+        # is in real-space
         raise NotImplementedError()
     else:
+        # ... and fourier-space
         projection_fft = projection_out
         if sampling_mode == "average":
             antialias_fn = FourierSinc(box_width=pixel_size)
@@ -718,6 +722,7 @@ def project_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
+        # nspread = _eps_to_nspread(eps)
         raise NotImplementedError(
             "Projections in real-space using the `IndependentAtomProjection` is not yet "
             "implemented."
@@ -775,7 +780,7 @@ def project_impl(
 
 
 def _render_postprocess(
-    render_fft: Complex[Array, "_ _ _"],
+    render_out: Inexact[Array, "_ _ _"],
     voxel_size: Float[Array, ""],
     *,
     is_real_space: bool,
@@ -786,8 +791,12 @@ def _render_postprocess(
     fftshifted: bool,
 ) -> Inexact[Array, "_ _ _"]:
     if is_real_space:
+        # Optimized code path for case where `render_out`
+        # is in real-space
         raise NotImplementedError()
     else:
+        # ... and fourier-space
+        render_fft = render_out
         if sampling_mode == "average":
             antialias_fn = FourierSinc(box_width=voxel_size)
             render_fft *= antialias_fn(frequency_grid)
@@ -833,6 +842,7 @@ def render_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
+        # nspread = _eps_to_nspread(eps)
         raise NotImplementedError(
             "Rendering in real-space using the `IndependentAtomRenderFn` is not yet "
             "implemented."
@@ -868,13 +878,13 @@ def render_impl(
     render_dispatch = lambda _positions, _kernel_fn: render_impl(
         shape, voxel_size, _positions, _kernel_fn, *render_args
     )
-    render_fft = jax.tree.reduce(
+    render_out = jax.tree.reduce(
         lambda x, y: x + y,
         jax.tree.map(render_dispatch, positions, kernel_fns, is_leaf=is_leaf),
     )
 
     return _render_postprocess(
-        render_fft,
+        render_out,
         is_real_space=is_real_space,
         voxel_size=voxel_size,
         frequency_grid=frequency_grid,
@@ -996,3 +1006,11 @@ def _nufft3d1(
             eps=eps,
             isign=-1,
         )
+
+
+def _eps_to_nspread(eps: float) -> int:
+    # FINUFFT heuristic for choosing `nspread` parameter
+    # based on desired precision `eps`
+    max_nspread = 16
+    log_tol = -math.log10(max(eps, 1e-16))
+    return max(2, min(int(math.ceil(log_tol + 1)), max_nspread))

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -1,7 +1,7 @@
 import functools as ft
 import math
 from collections.abc import Sequence
-from typing import Any, ClassVar, Literal, Self, TypeVar
+from typing import Any, ClassVar, Literal, Self, TypeVar, cast
 from typing_extensions import override
 
 import equinox as eqx
@@ -11,6 +11,8 @@ import jax.scipy as jsp
 import nufftax
 from jaxtyping import Array, Float, Inexact, PyTree
 from nufftax.core import Kernel, spread_2d, spread_3d
+
+from cryojax.ndimage._operators._fourier_operator import FourierGaussian
 
 from ..._internal import error_if_not_positive
 from ...constants import (
@@ -28,6 +30,7 @@ from ...ndimage import (
     fftn,
     ifftn,
     irfftn,
+    make_1d_frequency_grid,
     make_frequency_grid,
     resize_with_crop_or_pad,
     rfftn,
@@ -434,14 +437,15 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             volume_representation.kernel_fns,
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
-        # Check and modify kernels if using error functions
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=3)
-        # Upsample factor logic
-        upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
-        if upsampfac is None:
-            upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
-        upsampfac = _find_exact_upsampfac(upsampfac, self.shape)
+        upsampfac = _standardize_upsampfac(
+            self.upsample_factor,
+            dims=self.shape,
+            sampling_mode=self.sampling_mode,
+            is_real_space=is_real_space,
+        )
         # Modify kernels if using error functions
+        sampling_mode = self.sampling_mode
         if is_real_space:
             kernel_fns, sampling_mode = _maybe_use_erf(
                 kernel_fns,
@@ -461,8 +465,9 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             )
         else:
             shape_u, voxel_size_u = self.shape, self.voxel_size
-        frequency_grid = make_frequency_grid(
-            shape_u, voxel_size_u, outputs_rfftfreqs=False
+        frequencies_1d = tuple(
+            make_1d_frequency_grid(s, voxel_size_u, outputs_rfftfreqs=False)
+            for s in shape_u[::-1]
         )
         # Compute
         rendering_out = render_impl(
@@ -472,8 +477,8 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             is_real_space=is_real_space,
             shape_u=shape_u,
             voxel_size_u=voxel_size_u,
+            frequencies_1d=frequencies_1d,
             backend=self.backend,
-            frequency_grid=frequency_grid,
             eps=self.eps,
             options=self.options,
         )
@@ -498,7 +503,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=self.voxel_size)
-            rendering_fft *= box_fn(frequency_grid)
+            rendering_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if self.shape != shape_u:
             (indices_z, indices_y, indices_x), fac = _build_extraction_mesh(
@@ -632,14 +637,15 @@ class IndependentAtomProjection(
             volume_representation.kernel_fns,
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
-        # Check if real or fourier and do any preprocessing
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=2)
-        # Upsample factor logic
-        upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
-        if upsampfac is None:
-            upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
-        upsampfac = _find_exact_upsampfac(upsampfac, shape)
+        upsampfac = _standardize_upsampfac(
+            self.upsample_factor,
+            dims=shape,
+            sampling_mode=self.sampling_mode,
+            is_real_space=is_real_space,
+        )
         # Modify kernels if using error functions
+        sampling_mode = self.sampling_mode
         if is_real_space:
             kernel_fns, sampling_mode = _maybe_use_erf(
                 kernel_fns,
@@ -653,16 +659,12 @@ class IndependentAtomProjection(
                 (int(upsampfac * shape[0]), int(upsampfac * shape[1])),
                 pixel_size / upsampfac,
             )
-            frequency_grid = make_frequency_grid(
-                shape_u, pixel_size_u, outputs_rfftfreqs=False
-            )
         else:
             shape_u, pixel_size_u = shape, pixel_size
-            frequency_grid = (
-                image_config.get_frequency_grid(padding=True, physical=True, full=True)
-                if shape == image_config.padded_shape
-                else make_frequency_grid(shape, pixel_size, outputs_rfftfreqs=False)
-            )
+        frequencies_1d = tuple(
+            make_1d_frequency_grid(s, pixel_size_u, outputs_rfftfreqs=False)
+            for s in shape_u[::-1]
+        )
         # Compute projection
         projection_out = project_impl(
             positions,
@@ -671,8 +673,8 @@ class IndependentAtomProjection(
             is_real_space=is_real_space,
             shape_u=shape_u,
             pixel_size_u=pixel_size_u,
+            frequencies_1d=frequencies_1d,
             backend=self.backend,
-            frequency_grid=frequency_grid,
             eps=self.eps,
             options=self.options,
         )
@@ -691,7 +693,7 @@ class IndependentAtomProjection(
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=pixel_size)
-            projection_fft *= box_fn(frequency_grid)
+            projection_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if shape != shape_u:
             (indices_y, indices_x), fac = _build_extraction_mesh(
@@ -789,8 +791,8 @@ def project_impl(
     is_real_space: bool,
     shape_u: tuple[int, int],
     pixel_size_u: Float[Array, ""],
+    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
-    frequency_grid: Float[Array, "_ _ 2"],
     eps: float,
     options: dict[str, Any],
 ) -> Array:
@@ -798,6 +800,9 @@ def project_impl(
         (lambda x: isinstance(x, AbstractRealOperator))
         if is_real_space
         else (lambda x: isinstance(x, AbstractFourierOperator))
+    )
+    frequency_grid = _maybe_make_frequency_grid(
+        shape_u, pixel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
 
     def real_impl(
@@ -837,13 +842,14 @@ def project_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractFourierOperator,
         _amplitudes: Inexact[Array, " _"],
-        _frequency_grid: Array,
+        _f_1d: tuple[Array, ...],
+        _f_mesh: Array | None,
     ) -> Array:
         (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny))
         # Compute
         return (
-            _kernel_fn(_frequency_grid)
+            eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh)
             * jnp.fft.ifftshift(
                 _nufft2d1(
                     _shape,  # type: ignore
@@ -858,13 +864,22 @@ def project_impl(
         )
 
     if is_real_space:
-        project_impl, project_args = real_impl, ()
+        project_impl, args = real_impl, ()
     else:
-        project_impl, project_args = fourier_impl, (frequency_grid,)
+        project_impl, args = (
+            fourier_impl,
+            cast(
+                Any,
+                (
+                    frequencies_1d,
+                    frequency_grid,
+                ),
+            ),
+        )
 
     # Project and sum over kernels
     project_dispatch = lambda _positions, _kernel_fn, _amplitudes: project_impl(
-        shape_u, pixel_size_u, _positions, _kernel_fn, _amplitudes, *project_args
+        shape_u, pixel_size_u, _positions, _kernel_fn, _amplitudes, *args
     )
     projection_out = jax.tree.reduce(
         lambda x, y: x + y,
@@ -884,8 +899,8 @@ def render_impl(
     is_real_space: bool,
     shape_u: tuple[int, int, int],
     voxel_size_u: Float[Array, ""],
+    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
-    frequency_grid: Float[Array, "_ _ _ 3"],
     eps: float,
     options: dict[str, Any],
 ) -> Array:
@@ -893,6 +908,9 @@ def render_impl(
         (lambda x: isinstance(x, AbstractRealOperator))
         if is_real_space
         else (lambda x: isinstance(x, AbstractFourierOperator))
+    )
+    frequency_grid = _maybe_make_frequency_grid(
+        shape_u, voxel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
 
     def real_impl(
@@ -934,12 +952,13 @@ def render_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractFourierOperator,
         _amplitudes: Inexact[Array, " _"],
-        _frequency_grid: Array,
+        _f_1d: tuple[Array, ...],
+        _f_mesh: Array | None,
     ) -> Array:
         (nz, ny, nx) = _shape
         box_xyz = _vs * jnp.asarray((nx, ny, nz))
         # Compute
-        return _kernel_fn(_frequency_grid) * (
+        return eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh) * (
             jnp.fft.ifftshift(
                 _nufft3d1(
                     _shape,  # type: ignore
@@ -954,12 +973,12 @@ def render_impl(
         )
 
     if is_real_space:
-        render_impl, render_args = real_impl, ()
+        render_impl, args = real_impl, ()
     else:
-        render_impl, render_args = fourier_impl, (frequency_grid,)
+        render_impl, args = cast(Any, (fourier_impl, (frequencies_1d, frequency_grid)))
 
     render_dispatch = lambda _positions, _kernel_fn, _amplitudes: render_impl(
-        shape_u, voxel_size_u, _positions, _kernel_fn, _amplitudes, *render_args
+        shape_u, voxel_size_u, _positions, _kernel_fn, _amplitudes, *args
     )
     rendering_out = jax.tree.reduce(
         lambda x, y: x + y,
@@ -1215,12 +1234,20 @@ def _make_erf(gaussian: RealGaussian, pixel_size: Float[Array, ""]):
     )
 
 
-def _find_exact_upsampfac(input_upsampfac: float, dims: tuple[int, ...]) -> float:
+def _standardize_upsampfac(
+    upsampfac: float | None,
+    *,
+    dims: tuple[int, ...],
+    is_real_space: bool,
+    sampling_mode: Literal["point", "average"],
+) -> float:
     """Find the upsampfac that perfectly divides the upsampled
     image shape.
     """
+    if upsampfac is None:
+        upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
     gcd = ft.reduce(math.gcd, dims)
-    return round(gcd * input_upsampfac) / gcd
+    return round(gcd * upsampfac) / gcd
 
 
 def _prepare_real_to_fft(a: Array, *, outputs_rfft: bool, fftshifted: bool) -> Array:
@@ -1238,3 +1265,81 @@ def _prepare_fft_to_fft(f: Array, *, outputs_rfft: bool, fftshifted: bool) -> Ar
         return jnp.fft.fftshift(f, axes=(0, 1)) if fftshifted else f
     else:
         return jnp.fft.fftshift(f) if fftshifted else f
+
+
+def _is_separable(kernel_fn: AbstractFourierOperator):
+    return isinstance(kernel_fn, (FourierGaussian, PengScatteringFactor))
+
+
+def _maybe_make_frequency_grid(
+    shape: tuple[int, ...],
+    pixel_size: Float[Array, ""],
+    *,
+    is_real_space: bool,
+    kernel_fns: PyTree[AbstractFourierOperator],
+):
+    is_leaf = lambda x: isinstance(x, AbstractFourierOperator)
+    all_separable = jax.tree.reduce(
+        lambda x, y: x and y,
+        jax.tree.map(lambda x: _is_separable(x), kernel_fns, is_leaf=is_leaf),
+    )
+
+    if is_real_space:
+        frequency_grid = None
+    elif all_separable:
+        frequency_grid = None
+    else:
+        frequency_grid = make_frequency_grid(shape, pixel_size)
+
+    return frequency_grid
+
+
+def eval_kernel_impl(
+    kernel_fn: AbstractFourierOperator, *, f_1d: tuple[Array, ...], f_mesh: Array | None
+):
+    if isinstance(kernel_fn, FourierGaussian):
+        assert f_1d is not None
+        return eval_separable_impl(kernel_fn, f_1d)
+    elif isinstance(kernel_fn, PengScatteringFactor):
+        assert f_1d is not None
+        return eval_peng_impl(kernel_fn, f_1d)
+    else:
+        assert f_mesh is not None
+        return eval_non_separable_impl(kernel_fn, f_mesh)
+
+
+def eval_peng_impl(kernel_fn: PengScatteringFactor, frequencies_1d: tuple[Array, ...]):
+    a, b = kernel_fn.a, kernel_fn.b
+    if kernel_fn.b_factor is not None:
+        b = b + kernel_fn.b_factor[None]
+    # Split amplitude across dimensions so the separable product recovers the
+    # original: (a^(1/ndim))^ndim = a
+    make_gaussians = jax.vmap(lambda _a, _b: FourierGaussian(amplitude=_a, b_factor=_b))
+    eval_gaussians = jax.vmap(eval_separable_impl, in_axes=(0, None))
+    return jnp.sum(eval_gaussians(make_gaussians(a, b), frequencies_1d), axis=0)
+
+
+def eval_separable_impl(
+    kernel_fn: FourierGaussian | FourierSinc, frequencies_1d: tuple[Array, ...]
+):
+    ndim = len(frequencies_1d)
+    assert 1 in kernel_fn.spatial_dims and ndim in [2, 3]
+    if isinstance(kernel_fn, FourierGaussian):
+        kernel_fn = eqx.tree_at(
+            lambda x: x.amplitude, kernel_fn, replace_fn=lambda x: x ** (1 / ndim)
+        )
+    if len(frequencies_1d) == 2:
+        q_x, q_y = frequencies_1d
+        return kernel_fn(q_x)[None, :] * kernel_fn(q_y)[:, None]
+    else:
+        q_x, q_y, q_z = frequencies_1d
+        return (
+            kernel_fn(q_x)[None, None, :]
+            * kernel_fn(q_y)[None, :, None]
+            * kernel_fn(q_z)[:, None, None]
+        )
+
+
+def eval_non_separable_impl(kernel_fn: AbstractFourierOperator, frequency_grid: Array):
+    assert frequency_grid.shape[-1] in [2, 3]
+    return kernel_fn(frequency_grid)

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -851,7 +851,6 @@ def project_impl(
                     xy=2 * jnp.pi * _positions[:, :2] / box_xy,
                     backend=backend,
                     eps=eps,
-                    upsampfac=1.25,
                     options=options,
                 )
                 / _ps**2
@@ -948,7 +947,6 @@ def render_impl(
                     xyz=2 * jnp.pi * _positions / box_xyz,
                     backend=backend,
                     eps=eps,
-                    upsampfac=1.25,
                     options=options,
                 )
                 / _vs**3
@@ -987,9 +985,9 @@ def _nufft2d1(
     *,
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
-    upsampfac: float,
     options: dict[str, Any],
 ):
+    default_upsampfac = 1.25
     if backend == "jax-finufft":
         if jax_finufft is None:
             raise RuntimeError(
@@ -1002,12 +1000,22 @@ def _nufft2d1(
         opts = (
             options.pop("opts")
             if "opts" in options
-            else _make_jax_finufft_opts(upsampfac)
+            else _make_jax_finufft_opts(upsampfac=default_upsampfac)
         )
         return jax_finufft.nufft1(
-            shape, source, xy[:, 1], xy[:, 0], eps=eps, iflag=-1, opts=opts, **options
+            shape,
+            source,
+            xy[:, 1],
+            xy[:, 0],
+            eps=eps,
+            iflag=-1,
+            opts=opts,
+            **options,
         )
     else:
+        upsampfac = (
+            options.pop("upsampfac") if "upsampfac" in options else default_upsampfac
+        )
         return nufftax.nufft2d1(
             n_modes=shape[::-1],
             c=source,
@@ -1015,6 +1023,7 @@ def _nufft2d1(
             y=xy[:, 1],
             eps=eps,
             isign=-1,
+            upsampfac=upsampfac,
             **options,
         )
 
@@ -1026,9 +1035,9 @@ def _nufft3d1(
     *,
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
-    upsampfac: float,
     options: dict[str, Any],
 ):
+    default_upsampfac = 1.25
     if backend == "jax-finufft":
         if jax_finufft is None:
             raise RuntimeError(
@@ -1041,7 +1050,7 @@ def _nufft3d1(
         opts = (
             options.pop("opts")
             if "opts" in options
-            else _make_jax_finufft_opts(upsampfac)
+            else _make_jax_finufft_opts(upsampfac=default_upsampfac)
         )
         return jax_finufft.nufft1(
             shape,
@@ -1055,6 +1064,9 @@ def _nufft3d1(
             **options,
         )
     else:
+        upsampfac = (
+            options.pop("upsampfac") if "upsampfac" in options else default_upsampfac
+        )
         return nufftax.nufft3d1(
             n_modes=shape[::-1],
             c=source,
@@ -1063,6 +1075,7 @@ def _nufft3d1(
             z=xyz[:, 2],
             eps=eps,
             isign=-1,
+            upsampfac=upsampfac,
             **options,
         )
 

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -5,7 +5,8 @@ from typing_extensions import override
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Complex, Float, PyTree
+import nufftax
+from jaxtyping import Array, Complex, Float, Inexact, PyTree
 
 from ..._internal import error_if_not_positive
 from ...constants import (
@@ -38,12 +39,12 @@ from .base_volume import (
 
 
 try:
-    from jax_finufft import nufft1
+    import jax_finufft
     from jax_finufft.options import NestedOpts, Opts
 
     JAX_FINUFFT_IMPORT_ERROR = None
 except ModuleNotFoundError as err:
-    nufft1, Opts, NestedOpts = None, None, None
+    jax_finufft, Opts, NestedOpts = None, None, None
     JAX_FINUFFT_IMPORT_ERROR = err
 
 
@@ -350,6 +351,8 @@ or [`cryojax.ndimage.AbstractRealOperator`][] classes.
 class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], strict=True):
     shape: tuple[int, int, int]
     voxel_size: Float[Array, ""]
+
+    backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
     upsample_factor: tuple[float, float]
     eps: float
@@ -359,6 +362,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         shape: tuple[int, int, int],
         voxel_size: FloatLike,
         *,
+        backend: Literal["nufftax", "jax-finufft"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
         upsample_factor: int | float | tuple[float, float] = 2.0,
         eps: float = 1e-6,
@@ -374,6 +378,12 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             projected volume at a pixel to be the average value of the
             underlying continuous function. If `'point'`, the volume at
             a pixel will be point sampled.
+        - `backend`:
+            The backend for non-uniform FFT computation. This is either
+            `nufftax` for a pure-JAX implementation of FINUFFT,
+            or `jax-finufft` for calling FINUFFT directly.
+            Used only when `IndependentAtomVolume.kernel_fns` are type
+            `AbstractFourierOperator`.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
             See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
@@ -392,8 +402,15 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
                 "pixel or 'point' for point sampling. Got "
                 f"`sampling_mode = {sampling_mode}`."
             )
+        if backend not in ["jax-finufft", "nufftax"]:
+            raise ValueError(
+                "`backend` in `IndependentAtomRenderFn` "
+                "must be either 'jax-finufft' or 'nufftax'. Got "
+                f"`backend = {backend}`."
+            )
         self.shape = shape
         self.voxel_size = jnp.asarray(voxel_size, dtype=float)
+        self.backend = backend
         self.sampling_mode = sampling_mode
         self.upsample_factor = _standardize_upsampfac(upsample_factor)
         self.eps = eps
@@ -433,6 +450,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             volume_representation.kernel_fns,
             shape=self.shape,
             voxel_size=error_if_not_positive(self.voxel_size),
+            backend=self.backend,
             frequency_grid=frequency_grid,
             sampling_mode=self.sampling_mode,
             eps=self.eps,
@@ -452,6 +470,7 @@ class IndependentAtomProjection(
     AbstractVolumeIntegrator[IndependentAtomVolume],
     strict=True,
 ):
+    backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
     upsample_factor: tuple[float, float]
     block_size: int
@@ -463,6 +482,7 @@ class IndependentAtomProjection(
     def __init__(
         self,
         *,
+        backend: Literal["jax-finufft", "nufftax"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
         block_size: int = 1,
         upsample_factor: float | tuple[float, float] = 2.0,
@@ -471,6 +491,12 @@ class IndependentAtomProjection(
     ):
         """**Arguments:**
 
+        - `backend`:
+            The backend for non-uniform FFT computation. This is either
+            `nufftax` for a pure-JAX implementation of FINUFFT,
+            or `jax-finufft` for calling FINUFFT directly.
+            Used only when `IndependentAtomVolume.kernel_fns` are type
+            `AbstractFourierOperator`.
         - `sampling_mode`:
             If `'average'`, convolve with a box function to sample the
             projected volume at a pixel to be the average value of the
@@ -502,6 +528,13 @@ class IndependentAtomProjection(
                 "pixel or 'point' for point sampling. Got "
                 f"`sampling_mode = {sampling_mode}`."
             )
+        if backend not in ["jax-finufft", "nufftax"]:
+            raise ValueError(
+                "`backend` in `IndependentAtomRenderFn` "
+                "must be either 'jax-finufft' or 'nufftax'. Got "
+                f"`backend = {backend}`."
+            )
+        self.backend = backend
         self.sampling_mode = sampling_mode
         self.block_size = block_size
         self.shape = shape
@@ -557,6 +590,7 @@ class IndependentAtomProjection(
             volume_representation.kernel_fns,
             shape=shape_u,
             pixel_size=pixel_size_u,
+            backend=self.backend,
             frequency_grid=frequency_grid,
             sampling_mode=self.sampling_mode,
             eps=self.eps,
@@ -616,7 +650,7 @@ def _project_postprocess(
     block_size: int,
     output_shape: tuple[int, int],
     outputs_real_space: bool,
-) -> Complex[Array, "_ _"]:
+) -> Inexact[Array, "_ _"]:
     reduce_shape = tuple(s // block_size for s in projection_out.shape)
     assert len(reduce_shape) == 2
     if is_real_space:
@@ -666,6 +700,7 @@ def project_impl(
     *,
     shape: tuple[int, int],
     pixel_size: Float[Array, ""],
+    backend: Literal["jax-finufft", "nufftax"],
     frequency_grid: Float[Array, "_ _ 2"],
     sampling_mode: Literal["average", "point"],
     eps: float,
@@ -695,28 +730,22 @@ def project_impl(
         _kernel_fn: AbstractFourierOperator,
         _frequency_grid: Array,
     ) -> Array:
-        if nufft1 is None:
-            raise RuntimeError(
-                "Tried to use the `IndependentAtomProjection` "
-                "class, but `jax-finufft` is not installed. "
-                "See https://github.com/flatironinstitute/jax-finufft "
-                "for installation instructions."
-            ) from JAX_FINUFFT_IMPORT_ERROR
         (ny, nx), num_atoms = _shape, _positions.shape[0]
         box_xy = _ps * jnp.asarray((nx, ny))
-        xy = 2 * jnp.pi * _positions[:, :2] / box_xy
         # Compute
-        return _kernel_fn(_frequency_grid) * jnp.fft.ifftshift(
-            nufft1(
-                _shape,  # type: ignore
-                jnp.full((num_atoms,), 1.0 + 0.0j),
-                xy[:, 1],
-                xy[:, 0],
-                eps=eps,
-                iflag=-1,
-                opts=_make_opts(upsampfac),
+        return (
+            _kernel_fn(_frequency_grid)
+            * jnp.fft.ifftshift(
+                _nufft2d1(
+                    _shape,  # type: ignore
+                    source=jnp.full((num_atoms,), 1.0 + 0.0j),
+                    xy=2 * jnp.pi * _positions[:, :2] / box_xy,
+                    backend=backend,
+                    eps=eps,
+                    upsampfac=upsampfac,
+                )
+                / _ps**2
             )
-            / _ps**2
         )
 
     if is_real_space:
@@ -755,7 +784,7 @@ def _render_postprocess(
     outputs_real_space: bool,
     outputs_rfft: bool,
     fftshifted: bool,
-) -> Complex[Array, "_ _ _"]:
+) -> Inexact[Array, "_ _ _"]:
     if is_real_space:
         raise NotImplementedError()
     else:
@@ -786,6 +815,7 @@ def render_impl(
     *,
     shape: tuple[int, int, int],
     voxel_size: Float[Array, ""],
+    backend: Literal["jax-finufft", "nufftax"],
     frequency_grid: Float[Array, "_ _ _ 3"],
     sampling_mode: Literal["average", "point"],
     eps: float,
@@ -815,27 +845,17 @@ def render_impl(
         _kernel_fn: AbstractFourierOperator,
         _frequency_grid: Array,
     ) -> Array:
-        if nufft1 is None:
-            raise RuntimeError(
-                "Tried to use the `IndependentAtomRenderFn` "
-                "class, but `jax-finufft` is not installed. "
-                "See https://github.com/flatironinstitute/jax-finufft "
-                "for installation instructions."
-            ) from JAX_FINUFFT_IMPORT_ERROR
         (nz, ny, nx), num_atoms = _shape, _positions.shape[0]
         box_xyz = _vs * jnp.asarray((nx, ny, nz))
-        xyz = 2 * jnp.pi * _positions / box_xyz
         # Compute
         return _kernel_fn(_frequency_grid) * (
-            nufft1(
+            _nufft3d1(
                 _shape,  # type: ignore
-                jnp.full((num_atoms,), 1.0 + 0.0j),
-                xyz[:, 2],
-                xyz[:, 1],
-                xyz[:, 0],
+                source=jnp.full((num_atoms,), 1.0 + 0.0j),
+                xyz=2 * jnp.pi * _positions / box_xyz,
+                backend=backend,
                 eps=eps,
-                iflag=-1,
-                opts=_make_opts(upsampfac),
+                upsampfac=upsampfac,
             )
             / _vs**3
         )
@@ -898,3 +918,81 @@ def _make_opts(upsampfac: tuple[float, float]):
         forward=Opts(upsampfac=upsampfac[0], gpu_upsampfac=upsampfac[0]),
         backward=Opts(upsampfac=upsampfac[1], gpu_upsampfac=upsampfac[1]),
     )
+
+
+def _nufft2d1(
+    shape: tuple[int, int],
+    source: Array,
+    xy: Array,
+    *,
+    backend: Literal["jax-finufft", "nufftax"],
+    eps: float,
+    upsampfac: tuple[float, float],
+):
+    if backend == "jax-finufft":
+        if jax_finufft is None:
+            raise RuntimeError(
+                "Tried to use "
+                "`IndependentAtomProjection(..., backend='jax-finufft')`, "
+                "but `jax-finufft` is not installed. "
+                "See https://github.com/flatironinstitute/jax-finufft "
+                "for installation instructions."
+            ) from JAX_FINUFFT_IMPORT_ERROR
+        return jax_finufft.nufft1(
+            shape,
+            source,
+            xy[:, 1],
+            xy[:, 0],
+            eps=eps,
+            iflag=-1,
+            opts=_make_opts(upsampfac),
+        )
+    else:
+        return nufftax.nufft2d1(
+            n_modes=shape[::-1],
+            c=source,
+            x=xy[:, 0],
+            y=xy[:, 1],
+            eps=eps,
+            isign=-1,
+        )
+
+
+def _nufft3d1(
+    shape: tuple[int, int, int],
+    source: Array,
+    xyz: Array,
+    *,
+    backend: Literal["jax-finufft", "nufftax"],
+    eps: float,
+    upsampfac: tuple[float, float],
+):
+    if backend == "jax-finufft":
+        if jax_finufft is None:
+            raise RuntimeError(
+                "Tried to use "
+                "`IndependentAtomRenderFn(..., backend='jax-finufft')`, "
+                "but `jax-finufft` is not installed. "
+                "See https://github.com/flatironinstitute/jax-finufft "
+                "for installation instructions."
+            ) from JAX_FINUFFT_IMPORT_ERROR
+        return jax_finufft.nufft1(
+            shape,
+            source,
+            xyz[:, 2],
+            xyz[:, 1],
+            xyz[:, 0],
+            eps=eps,
+            iflag=-1,
+            opts=_make_opts(upsampfac),
+        )
+    else:
+        return nufftax.nufft3d1(
+            n_modes=shape[::-1],
+            c=source,
+            x=xyz[:, 0],
+            y=xyz[:, 1],
+            z=xyz[:, 2],
+            eps=eps,
+            isign=-1,
+        )

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -461,6 +461,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             amplitudes,
             is_real_space=is_real_space,
             shape_u=cast(tuple[int, int, int], shape_u),
+            shape_out=cast(tuple[int, int, int], self.shape),
             voxel_size_u=voxel_size_u,
             backend=self.backend,
             eps=self.eps,
@@ -647,6 +648,7 @@ class IndependentAtomProjection(
             is_real_space=is_real_space,
             shape_u=cast(tuple[int, int], shape_u),
             pixel_size_u=pixel_size_u,
+            shape_out=cast(tuple[int, int], shape),
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -765,6 +767,7 @@ def project_impl(
     is_real_space: bool,
     shape_u: tuple[int, int],
     pixel_size_u: Float[Array, ""],
+    shape_out: tuple[int, int],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -801,6 +804,13 @@ def project_impl(
         )
         return projection
 
+    # Per-dimension NUFFT offset: 2*pi*(N//2)/N maps physical center (x=0) to
+    # integer pixel index N//2.  For even N this equals pi; for odd N it is
+    # pi*(1 - 1/N).  Must use the original output shape, not the upsampled one.
+    _nufft_offsets_2d = jnp.asarray(
+        [2 * jnp.pi * (s // 2) / s for s in shape_out[::-1][:2]]
+    )
+
     def fourier_impl(
         _shape: tuple[int, int],
         _ps: Float[Array, ""],
@@ -810,13 +820,18 @@ def project_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
+        # Scale positions onto the upsampled grid, then apply the shape_out-based
+        # center offset.  Do NOT apply the shape_u parity correction here: that
+        # correction is for the spread path; the NUFFT offset is entirely
+        # determined by shape_out regardless of the parity of shape_u.
+        _ns = jnp.asarray(_shape[::-1][:2], dtype=float)
+        xy = 2 * jnp.pi * _positions[:, :2] / (_ps * _ns) + _nufft_offsets_2d
         return (
             eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh)
             * _nufft2d1(
                 _shape,  # type: ignore
                 source=_amplitudes.astype(complex),
-                xy=xy + jnp.pi,
+                xy=xy,
                 backend=backend,
                 eps=eps,
                 options=options,
@@ -862,6 +877,7 @@ def render_impl(
     is_real_space: bool,
     shape_u: tuple[int, int, int],
     voxel_size_u: Float[Array, ""],
+    shape_out: tuple[int, int, int],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -875,6 +891,8 @@ def render_impl(
         shape_u, voxel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
     frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=0)
+
+    _nufft_offsets_3d = jnp.asarray([2 * jnp.pi * (s // 2) / s for s in shape_out[::-1]])
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -909,13 +927,13 @@ def render_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        xyz = _normalize_positions(_positions, _shape, _vs)
-        # Compute
+        _ns = jnp.asarray(_shape[::-1], dtype=float)
+        xyz = 2 * jnp.pi * _positions / (_vs * _ns) + _nufft_offsets_3d
         return eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh) * (
             _nufft3d1(
                 _shape,  # type: ignore
                 source=_amplitudes.astype(complex),
-                xyz=xyz + jnp.pi,
+                xyz=xyz,
                 backend=backend,
                 eps=eps,
                 options=options,
@@ -1314,5 +1332,12 @@ def _normalize_positions(
     shape: tuple[int, ...],
     pixel_size: Array,
 ) -> Array:
-    box_size = tuple(pixel_size * s for s in shape[::-1])
-    return 2 * jnp.pi * positions / jnp.asarray(box_size)
+    ndim = positions.shape[-1]
+    # shape is (z, y, x) or (y, x); reverse so first element is x
+    shape_spatial = shape[::-1][:ndim]
+    ns = jnp.asarray(shape_spatial, dtype=float)
+    # Center is at index N//2 for all N (RELION convention).
+    # For even N the offset is 0; for odd N it is -π/N so that x=0 lands
+    # exactly on pixel N//2 after fold_rescale.
+    offsets = jnp.pi * jnp.asarray([-(s % 2) / s for s in shape_spatial])
+    return 2 * jnp.pi * positions / (pixel_size * ns) + offsets

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import jax.scipy as jsp
 import nufftax
 from jaxtyping import Array, Float, Inexact, PyTree
 from nufftax.core import Kernel, spread_2d, spread_3d
@@ -14,13 +15,13 @@ from ..._internal import error_if_not_positive
 from ...constants import (
     LobatoScatteringFactorParameters,
     PengScatteringFactorParameters,
-    b_factor_to_variance,
 )
 from ...jax_util import FloatLike, NDArrayLike
 from ...ndimage import (
     AbstractFourierOperator,
     AbstractRealOperator,
     FourierSinc,
+    RealGaussian,
     block_reduce_downsample,
     convert_fftn_to_rfftn,
     fftn,
@@ -54,50 +55,10 @@ except ModuleNotFoundError as err:
 T = TypeVar("T")
 
 
-class PengScatteringPotential(AbstractRealOperator, strict=True):
-    a: Float[Array, " n"]
-    b: Float[Array, " n"]
-    b_factor: Float[Array, ""] | None
-
-    spatial_dims: ClassVar[list[int]] = [1, 2, 3]
-
-    def __init__(
-        self,
-        a: Float[NDArrayLike, " n"],
-        b: Float[NDArrayLike, " n"],
-        b_factor: FloatLike | None = None,
-    ):
-        self.a = jnp.asarray(a, dtype=float)
-        self.b = jnp.asarray(b, dtype=float)
-        self.b_factor = None if b_factor is None else jnp.asarray(b_factor, dtype=float)
-
-    def __call__(
-        self,
-        coordinate_grid: (
-            Float[Array, " x_dim"]
-            | Float[Array, "y_dim x_dim 2"]
-            | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ):
-        ndim = 1 if coordinate_grid.ndim == 1 else coordinate_grid.ndim - 1
-        if ndim == 1:
-            r_squared = coordinate_grid**2
-        else:
-            r_squared = jnp.sum(coordinate_grid**2, axis=-1)
-        b_factor = 0.0 if self.b_factor is None else error_if_not_positive(self.b_factor)
-        variances = b_factor_to_variance(
-            (error_if_not_positive(self.b) + b_factor) / (8 * jnp.pi**2)
-        )
-        gaussian_fn = lambda _amp, _var: (
-            (_amp / (2 * jnp.pi * _var) ** (ndim / 2)) * jnp.exp(-r_squared / (2 * _var))
-        )
-        return jnp.sum(jax.vmap(gaussian_fn)(self.a, variances), axis=0)
-
-
 class PengScatteringFactor(AbstractFourierOperator, strict=True):
     a: Float[Array, " n"]
     b: Float[Array, " n"]
-    b_factor: Float[Array, ""] | None
+    b_factor: Float[Array, ""] | None = None
 
     spatial_dims: ClassVar[list[int]] = [2, 3]
 
@@ -128,7 +89,7 @@ class PengScatteringFactor(AbstractFourierOperator, strict=True):
 class LobatoScatteringFactor(AbstractFourierOperator, strict=True):
     a: Float[Array, " n"]
     b: Float[Array, " n"]
-    b_factor: Float[Array, ""] | None
+    b_factor: Float[Array, ""] | None = None
 
     spatial_dims: ClassVar[list[int]] = [2, 3]
 
@@ -270,25 +231,12 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         parameters: PengScatteringFactorParameters | LobatoScatteringFactorParameters,
         *,
         b_factor_by_element: FloatLike | tuple[FloatLike, ...] | None = None,
-        outputs_real_space: bool = False,
     ) -> Self:
         def make_kernel_fn(a, b, b_factor):
             if isinstance(parameters, PengScatteringFactorParameters):
-                if outputs_real_space:
-                    return PengScatteringPotential(a, b, b_factor)
-                else:
-                    return PengScatteringFactor(a, b, b_factor)
+                return PengScatteringFactor(a, b, b_factor)
             elif isinstance(parameters, LobatoScatteringFactorParameters):
-                if outputs_real_space:
-                    raise NotImplementedError(
-                        "`IndependentAtomVolume(..., parameters=..., "
-                        "outputs_real_space=True)` does not support "
-                        "`parameters = LobatoScatteringFactorParameters(...)`. "
-                        "Instead, use `PengScatteringFactorParameters` or set "
-                        "`outputs_real_space = False`."
-                    )
-                else:
-                    return LobatoScatteringFactor(a, b, b_factor)
+                return LobatoScatteringFactor(a, b, b_factor)
             else:
                 raise ValueError(
                     "Unrecognized argument `parameters` when "
@@ -674,6 +622,34 @@ def _check_kernel_fns(
     return is_real_space, is_leaf
 
 
+def _maybe_gaussians_to_erf(
+    kernel_pytree: PyTree[AbstractRealOperator],
+    pixel_size: Float[Array, ""],
+    sampling_mode: Literal["average", "point"],
+    upsampfac: float,
+) -> tuple[PyTree[AbstractRealOperator], Literal["average", "point"]]:
+    """Modify gaussian kernels at runtime to the error function."""
+    kernel_list = jax.tree.leaves(
+        kernel_pytree,
+        is_leaf=lambda x: isinstance(x, AbstractRealOperator),
+    )
+    if sampling_mode == "point":
+        return kernel_pytree, "point"
+    else:
+        if all(isinstance(kernel, RealGaussian) for kernel in kernel_list):
+            return (
+                jax.tree.map(
+                    lambda x: _IntegratedRealGaussian.from_gaussians(
+                        x, pixel_size / upsampfac
+                    ),
+                    kernel_pytree,
+                    is_leaf=lambda x: isinstance(x, AbstractRealOperator),
+                ),
+                "point",
+            )
+        return kernel_pytree, "average"
+
+
 def _project_postprocess(
     projection_out: Inexact[Array, "_ _"],
     *,
@@ -744,7 +720,14 @@ def project_impl(
     outputs_real_space: bool,
     options: dict[str, Any],
 ) -> Array:
-    is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=2)
+    is_real_space, is_leaf = _check_kernel_fns(
+        kernel_fns,
+        spatial_dim=2,
+    )
+    if is_real_space:
+        kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
+            kernel_fns, pixel_size, sampling_mode, upsampfac
+        )
 
     def real_impl(
         _shape: tuple[int, int],
@@ -770,8 +753,8 @@ def project_impl(
             ),
             **options,
         )
-        indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
-        return fftn(projection)[indices_y, indices_x]
+        (indices_y, indices_x), fac = _build_extraction_mesh(shape_u, _shape)
+        return fac * fftn(projection)[indices_y, indices_x]
 
     def fourier_impl(
         _shape: tuple[int, int],
@@ -875,6 +858,10 @@ def render_impl(
     options: dict[str, Any],
 ) -> Array:
     is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=3)
+    if is_real_space:
+        kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
+            kernel_fns, voxel_size, sampling_mode, upsampfac
+        )
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -902,8 +889,8 @@ def render_impl(
             ),
             **options,
         )
-        indices_z, indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
-        return fftn(projection)[indices_z, indices_y, indices_x]
+        (indices_z, indices_y, indices_x), fac = _build_extraction_mesh(shape_u, _shape)
+        return fac * fftn(projection)[indices_z, indices_y, indices_x]
 
     def fourier_impl(
         _shape: tuple[int, int, int],
@@ -1088,10 +1075,11 @@ def _build_extraction_mesh(shape: tuple[int, ...], shape_ds: tuple[int, ...]):
 
     assert len(shape) == len(shape_ds)
     assert len(shape) in [2, 3]
+    mean_factor = math.prod(shape_ds) / math.prod(shape)
     indices_1d = tuple(
         _build_extraction_indices_1d(dim, dim_ds) for dim, dim_ds in zip(shape, shape_ds)
     )
-    return jnp.meshgrid(*indices_1d, indexing="ij")
+    return jnp.meshgrid(*indices_1d, indexing="ij"), mean_factor
 
 
 def _build_extraction_indices_1d(dim: int, dim_ds: int):
@@ -1106,3 +1094,32 @@ def _build_extraction_indices_1d(dim: int, dim_ds: int):
     indices = jnp.concatenate([idx_pos, idx_neg])
 
     return indices
+
+
+class _IntegratedRealGaussian(AbstractRealOperator, strict=True):
+    amplitude: Float[Array, ""]
+    variance: Float[Array, ""]
+
+    pixel_size: Float[Array, ""]
+
+    spatial_dims: ClassVar[list[int]] = [1]
+
+    @classmethod
+    def from_gaussians(cls, fn: RealGaussian, pixel_size: Float[Array, ""]):
+        return cls(
+            amplitude=fn.amplitude,
+            variance=fn.variance,
+            pixel_size=pixel_size,
+        )
+
+    @override
+    def __call__(self, coordinate_grid: Float[Array, " x_dim"]) -> Array:
+        scaling = 1.0 / jnp.sqrt(2 * self.variance)
+        left, right = (
+            coordinate_grid - self.pixel_size / 2,
+            coordinate_grid + self.pixel_size / 2,
+        )
+        weight = (1 / (2 * self.pixel_size)) * (
+            jsp.special.erf(scaling * right) - jsp.special.erf(scaling * left)
+        )
+        return self.amplitude * weight

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -161,6 +161,7 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
 
     positions: PyTree[Float[Array, "_ 3"]]
     kernel_fns: PyTree[AbstractFourierOperator] | PyTree[AbstractRealOperator]
+    amplitudes: PyTree[Inexact[Array, " _"]] | None
 
     is_frame_rotation: ClassVar[bool] = False
 
@@ -170,6 +171,7 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         kernel_fns: (
             PyTree[AbstractFourierOperator, "T"] | PyTree[AbstractRealOperator, "T"]
         ),
+        amplitudes: PyTree[Inexact[NDArrayLike, " _"], "T"] | None = None,
     ):
         """**Arguments:**
 
@@ -196,6 +198,18 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
             )
         self.positions = jax.tree.map(lambda x: jnp.asarray(x, dtype=float), positions)
         self.kernel_fns = kernel_fns
+        if amplitudes is None:
+            self.amplitudes = None
+        else:
+            if jax.tree.structure(positions) != jax.tree.structure(amplitudes):
+                raise ValueError(
+                    "When instantiating an `IndependentAtomVolume`, found "
+                    "that the pytree structures of `positions` and "
+                    "`amplitudes` were not equal."
+                )
+            self.amplitudes = jax.tree.map(
+                lambda x: jnp.asarray(x, dtype=float), amplitudes
+            )
 
     @override
     def rotate_to_pose(self, pose: AbstractPose) -> Self:
@@ -409,6 +423,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         return render_impl(
             volume_representation.positions,
             volume_representation.kernel_fns,
+            volume_representation.amplitudes,
             shape=self.shape,
             voxel_size=error_if_not_positive(self.voxel_size),
             backend=self.backend,
@@ -560,6 +575,7 @@ class IndependentAtomProjection(
         return project_impl(
             volume_representation.positions,
             volume_representation.kernel_fns,
+            volume_representation.amplitudes,
             shape=shape_b,
             pixel_size=pixel_size_b,
             backend=self.backend,
@@ -707,6 +723,7 @@ def _project_postprocess(
 def project_impl(
     positions: PyTree[Float[Array, "_ 3"]],
     kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
+    amplitudes: PyTree[Inexact[Array, " _"]] | None,
     *,
     shape: tuple[int, int],
     pixel_size: Float[Array, ""],
@@ -728,23 +745,25 @@ def project_impl(
         kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
             kernel_fns, pixel_size, sampling_mode, upsampfac
         )
+    amplitudes = _standardize_amplitudes(amplitudes, positions)
 
     def real_impl(
         _shape: tuple[int, int],
         _ps: Float[Array, ""],
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
+        _amplitudes: Inexact[Array, " _"],
     ) -> Array:
         u = upsampfac
         nspread = _eps_to_nspread(eps)
         shape_u = (int(u * _shape[0]), int(u * _shape[1]))
-        (ny, nx), num_atoms = _shape, _positions.shape[0]
+        (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
         xy = 2 * jnp.pi * _positions[:, :2] / box_xy
         projection = spread_2d(
             x=xy[:, 0],
             y=xy[:, 1],
-            c=jnp.ones(num_atoms, dtype=float),
+            c=_amplitudes,
             nf1=shape_u[1],
             nf2=shape_u[0],
             kernel_params=Kernel(
@@ -761,9 +780,10 @@ def project_impl(
         _ps: Float[Array, ""],
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractFourierOperator,
+        _amplitudes: Inexact[Array, " _"],
         _frequency_grid: Array,
     ) -> Array:
-        (ny, nx), num_atoms = _shape, _positions.shape[0]
+        (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny))
         # Compute
         return (
@@ -771,7 +791,7 @@ def project_impl(
             * jnp.fft.ifftshift(
                 _nufft2d1(
                     _shape,  # type: ignore
-                    source=jnp.full((num_atoms,), 1.0 + 0.0j),
+                    source=_amplitudes.astype(complex),
                     xy=2 * jnp.pi * _positions[:, :2] / box_xy,
                     backend=backend,
                     eps=eps,
@@ -788,12 +808,14 @@ def project_impl(
         project_impl, project_args = fourier_impl, (frequency_grid,)
 
     # Project and sum over kernels
-    project_dispatch = lambda _positions, _kernel_fn: project_impl(
-        shape, pixel_size, _positions, _kernel_fn, *project_args
+    project_dispatch = lambda _positions, _kernel_fn, _amplitudes: project_impl(
+        shape, pixel_size, _positions, _kernel_fn, _amplitudes, *project_args
     )
     projection_out = jax.tree.reduce(
         lambda x, y: x + y,
-        jax.tree.map(project_dispatch, positions, kernel_fns, is_leaf=is_leaf),
+        jax.tree.map(
+            project_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf
+        ),
     )
     return _project_postprocess(
         projection_out,
@@ -844,6 +866,7 @@ def _render_postprocess(
 def render_impl(
     positions: PyTree[Float[Array, "_ 3"]],
     kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
+    amplitudes: PyTree[Inexact[Array, " _"]] | None,
     *,
     shape: tuple[int, int, int],
     voxel_size: Float[Array, ""],
@@ -862,24 +885,26 @@ def render_impl(
         kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
             kernel_fns, voxel_size, sampling_mode, upsampfac
         )
+    amplitudes = _standardize_amplitudes(amplitudes, positions)
 
     def real_impl(
         _shape: tuple[int, int, int],
         _vs: Float[Array, ""],
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
+        _amplitudes: Inexact[Array, " _"],
     ) -> Array:
         nspread = _eps_to_nspread(eps)
         u = upsampfac
         shape_u = (int(u * _shape[0]), int(u * _shape[1]), int(u * _shape[2]))
-        (nz, ny, nx), num_atoms = _shape, _positions.shape[0]
+        (nz, ny, nx) = _shape
         box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
         xyz = 2 * jnp.pi * _positions / box_xyz
         projection = spread_3d(
             x=xyz[:, 0],
             y=xyz[:, 1],
             z=xyz[:, 2],
-            c=jnp.ones(num_atoms, dtype=float),
+            c=_amplitudes,
             nf1=shape_u[2],
             nf2=shape_u[1],
             nf3=shape_u[0],
@@ -897,15 +922,16 @@ def render_impl(
         _vs: Float[Array, ""],
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractFourierOperator,
+        _amplitudes: Inexact[Array, " _"],
         _frequency_grid: Array,
     ) -> Array:
-        (nz, ny, nx), num_atoms = _shape, _positions.shape[0]
+        (nz, ny, nx) = _shape
         box_xyz = _vs * jnp.asarray((nx, ny, nz))
         # Compute
         return _kernel_fn(_frequency_grid) * (
             _nufft3d1(
                 _shape,  # type: ignore
-                source=jnp.full((num_atoms,), 1.0 + 0.0j),
+                source=_amplitudes.astype(complex),
                 xyz=2 * jnp.pi * _positions / box_xyz,
                 backend=backend,
                 eps=eps,
@@ -920,12 +946,12 @@ def render_impl(
     else:
         render_impl, render_args = fourier_impl, (frequency_grid,)
 
-    render_dispatch = lambda _positions, _kernel_fn: render_impl(
-        shape, voxel_size, _positions, _kernel_fn, *render_args
+    render_dispatch = lambda _positions, _kernel_fn, _amplitudes: render_impl(
+        shape, voxel_size, _positions, _kernel_fn, _amplitudes, *render_args
     )
     render_out = jax.tree.reduce(
         lambda x, y: x + y,
-        jax.tree.map(render_dispatch, positions, kernel_fns, is_leaf=is_leaf),
+        jax.tree.map(render_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf),
     )
 
     return _render_postprocess(
@@ -1094,6 +1120,16 @@ def _build_extraction_indices_1d(dim: int, dim_ds: int):
     indices = jnp.concatenate([idx_pos, idx_neg])
 
     return indices
+
+
+def _standardize_amplitudes(amplitudes: PyTree[Array] | None, positions: PyTree[Array]):
+    if amplitudes is None:
+        return jax.tree.map(
+            lambda x: jnp.ones((x.shape[0],), dtype=complex),
+            positions,
+        )
+    else:
+        return amplitudes
 
 
 class _IntegratedRealGaussian(AbstractRealOperator, strict=True):

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -754,9 +754,16 @@ def project_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
+        dim = _shape[0]
+        if not all(s == dim for s in _shape):
+            raise ValueError(
+                "`IndependentAtomProjection` for real-valued kernels "
+                "only supports rendering square images. Found a shape "
+                f"equal to {(_shape[0] // block_size, _shape[1] // block_size)}"
+            )
         u = upsampfac
         nspread = _eps_to_nspread(eps)
-        shape_u = (int(u * _shape[0]), int(u * _shape[1]))
+        shape_u = (int(u * dim), int(u * dim))
         (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
         xy = 2 * jnp.pi * _positions[:, :2] / box_xy
@@ -766,9 +773,8 @@ def project_impl(
             c=_amplitudes,
             nf1=shape_u[1],
             nf2=shape_u[0],
-            kernel_params=Kernel(
-                nspread=nspread,
-                phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_ps / u) * _z),
+            kernel_params=_make_nufftax_kernel(
+                _kernel_fn, image_dim=dim, pixel_size=_ps / u, nspread=nspread
             ),
             **options,
         )
@@ -894,6 +900,13 @@ def render_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
+        dim = _shape[0]
+        if not all(s == dim for s in _shape):
+            raise ValueError(
+                "`IndependentAtomRenderFn` for real-valued kernels "
+                "only supports rendering square voxel arrays. Found a shape "
+                f"equal to {(_shape[0], _shape[1], _shape[2])}"
+            )
         nspread = _eps_to_nspread(eps)
         u = upsampfac
         shape_u = (int(u * _shape[0]), int(u * _shape[1]), int(u * _shape[2]))
@@ -908,9 +921,8 @@ def render_impl(
             nf1=shape_u[2],
             nf2=shape_u[1],
             nf3=shape_u[0],
-            kernel_params=Kernel(
-                nspread=nspread,
-                phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_vs / u) * _z),
+            kernel_params=_make_nufftax_kernel(
+                _kernel_fn, image_dim=dim, pixel_size=_vs / u, nspread=nspread
             ),
             **options,
         )
@@ -1130,6 +1142,20 @@ def _standardize_amplitudes(amplitudes: PyTree[Array] | None, positions: PyTree[
         )
     else:
         return amplitudes
+
+
+def _make_nufftax_kernel(
+    kernel_fn: AbstractRealOperator,
+    *,
+    image_dim: int,
+    pixel_size: Float[Array, ""],
+    nspread: int,
+):
+    offset = 0.5 if image_dim % 2 == 1 else 0.0
+    return Kernel(
+        nspread=nspread,
+        phi=lambda _z: eqx.filter_vmap(kernel_fn)(pixel_size * (_z + offset)),
+    )
 
 
 class _IntegratedRealGaussian(AbstractRealOperator, strict=True):

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -1,5 +1,6 @@
+import functools as ft
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import Any, ClassVar, Literal, Self, TypeVar
 from typing_extensions import override
 
@@ -22,7 +23,6 @@ from ...ndimage import (
     AbstractRealOperator,
     FourierSinc,
     RealGaussian,
-    block_reduce_downsample,
     convert_fftn_to_rfftn,
     fftn,
     ifftn,
@@ -416,25 +416,80 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             component is in the corner. Does nothing if
             `outputs_real_space = True`.
         """
-        frequency_grid = jnp.fft.fftshift(
-            make_frequency_grid(self.shape, self.voxel_size, outputs_rfftfreqs=False),
-            axes=(0, 1, 2),
-        )
-        return render_impl(
+        # Prepare arguments
+        positions, kernel_fns = (
             volume_representation.positions,
             volume_representation.kernel_fns,
-            volume_representation.amplitudes,
-            shape=self.shape,
-            voxel_size=error_if_not_positive(self.voxel_size),
+        )
+        amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
+        # Check and modify kernels if using error functions
+        is_real_space = _check_kernel_fns(kernel_fns, spatial_dim=3)
+        upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
+        if is_real_space:
+            kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
+                kernel_fns, self.voxel_size, sampling_mode, upsampfac
+            )
+        # Upsampling arguments
+        if self.upsample_factor > 1:
+            u = _find_exact_upsampfac(self.upsample_factor, self.shape)
+            shape_u, voxel_size_u = (
+                (int(u * self.shape[0]), int(u * self.shape[1]), int(u * self.shape[2])),
+                self.voxel_size / u,
+            )
+        else:
+            shape_u, voxel_size_u = self.shape, self.voxel_size
+        frequency_grid = make_frequency_grid(
+            shape_u, voxel_size_u, outputs_rfftfreqs=False
+        )
+        # Compute
+        rendering_out = render_impl(
+            positions,
+            kernel_fns,
+            amplitudes,
+            is_real_space=is_real_space,
+            shape_u=shape_u,
+            voxel_size_u=voxel_size_u,
             backend=self.backend,
             frequency_grid=frequency_grid,
-            sampling_mode=self.sampling_mode,
             eps=self.eps,
-            upsampfac=self.upsample_factor,
-            outputs_real_space=outputs_real_space,
-            outputs_rfft=outputs_rfft,
-            fftshifted=fftshifted,
             options=self.options,
+        )
+        if is_real_space:
+            # Check case where we can return immediately
+            rendering = rendering_out
+            if sampling_mode == "point" and self.shape == shape_u:
+                return (
+                    rendering
+                    if outputs_real_space
+                    else _prepare_real_to_fft(
+                        rendering,
+                        outputs_rfft=outputs_rfft,
+                        fftshifted=fftshifted,
+                    )
+                )
+            else:
+                rendering_fft = fftn(rendering)
+        else:
+            # Otherwise, postprocess in fourier-domain
+            rendering_fft = rendering_out
+        # Average within a pixel size
+        if sampling_mode == "average":
+            antialias_fn = FourierSinc(box_width=self.voxel_size)
+            rendering_fft *= antialias_fn(frequency_grid)
+        # Downsample by extracting fourier modes
+        if self.shape != shape_u:
+            (indices_z, indices_y, indices_x), fac = _build_extraction_mesh(
+                shape_u, self.shape, modeord=1
+            )
+            rendering_fft = fac * rendering_fft[indices_z, indices_y, indices_x]
+        return (
+            ifftn(rendering_fft).real
+            if outputs_real_space
+            else _prepare_fft_to_fft(
+                rendering_fft,
+                outputs_rfft=outputs_rfft,
+                fftshifted=fftshifted,
+            )
         )
 
 
@@ -450,7 +505,6 @@ class IndependentAtomProjection(
     backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
     upsample_factor: float
-    block_size: int
     eps: float
     shape: tuple[int, int] | None
     options: dict[str, Any]
@@ -462,7 +516,6 @@ class IndependentAtomProjection(
         *,
         backend: Literal["jax-finufft", "nufftax"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
-        block_size: int = 1,
         upsample_factor: int | float = 2.0,
         eps: float = 1e-6,
         shape: tuple[int, int] | None = None,
@@ -484,11 +537,6 @@ class IndependentAtomProjection(
             projected volume at a pixel to be the average value of the
             underlying continuous function. If `'point'`, the volume at
             a pixel will be point sampled.
-        - `block_size`:
-            If provided, first compute an image at `voxel_size / block_size`.
-            Then, call [`cryojax.ndimage.block_reduce_downsample`][]
-            to locally average to the correct pixel size. This is useful
-            for reducing aliasing.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
             See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
@@ -522,7 +570,6 @@ class IndependentAtomProjection(
             )
         self.backend = backend
         self.sampling_mode = sampling_mode
-        self.block_size = block_size
         self.shape = shape
         self.upsample_factor = float(upsample_factor)
         self.eps = eps
@@ -556,38 +603,82 @@ class IndependentAtomProjection(
         # Prepare arguments
         pixel_size = image_config.pixel_size
         shape = image_config.padded_shape if self.shape is None else self.shape
-        if self.block_size > 1:
-            shape_b, pixel_size_b = (
-                (self.block_size * shape[0], self.block_size * shape[1]),
-                pixel_size / self.block_size,
+        output_shape = image_config.padded_shape
+        positions, kernel_fns = (
+            volume_representation.positions,
+            volume_representation.kernel_fns,
+        )
+        amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
+        # Check and modify kernels if using error functions
+        is_real_space = _check_kernel_fns(kernel_fns, spatial_dim=2)
+        upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
+        if is_real_space:
+            kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
+                kernel_fns, pixel_size, sampling_mode, upsampfac
+            )
+        # Upsampled shape and pixel size
+        if self.upsample_factor > 1:
+            u = _find_exact_upsampfac(self.upsample_factor, shape)
+            shape_u, pixel_size_u = (
+                (int(u * shape[0]), int(u * shape[1])),
+                pixel_size / u,
             )
             frequency_grid = make_frequency_grid(
-                shape_b, pixel_size_b, outputs_rfftfreqs=False
+                shape_u, pixel_size_u, outputs_rfftfreqs=False
             )
         else:
-            shape_b, pixel_size_b = shape, pixel_size
+            shape_u, pixel_size_u = shape, pixel_size
             frequency_grid = (
                 image_config.get_frequency_grid(padding=True, physical=True, full=True)
                 if shape == image_config.padded_shape
                 else make_frequency_grid(shape, pixel_size, outputs_rfftfreqs=False)
             )
         # Compute projection
-        return project_impl(
-            volume_representation.positions,
-            volume_representation.kernel_fns,
-            volume_representation.amplitudes,
-            shape=shape_b,
-            pixel_size=pixel_size_b,
+        projection_out = project_impl(
+            positions,
+            kernel_fns,
+            amplitudes,
+            is_real_space=is_real_space,
+            shape_u=shape_u,
+            pixel_size_u=pixel_size_u,
             backend=self.backend,
             frequency_grid=frequency_grid,
-            sampling_mode=self.sampling_mode,
             eps=self.eps,
-            upsampfac=self.upsample_factor,
-            block_size=self.block_size,
-            output_shape=image_config.padded_shape,
-            outputs_real_space=outputs_real_space,
             options=self.options,
         )
+        if is_real_space:
+            # Check case where we can return immediately
+            projection = projection_out
+            if sampling_mode == "point" and shape == shape_u:
+                if output_shape != shape:
+                    projection = resize_with_crop_or_pad(projection, output_shape)
+                return projection if outputs_real_space else rfftn(projection)
+            else:
+                projection_fft = fftn(projection)
+        else:
+            # Otherwise, postprocess in fourier-domain
+            projection_fft = projection_out
+        # Average within a pixel size
+        if sampling_mode == "average":
+            antialias_fn = FourierSinc(box_width=pixel_size)
+            projection_fft *= antialias_fn(frequency_grid)
+        # Downsample by extracting fourier modes
+        if shape != shape_u:
+            (indices_y, indices_x), fac = _build_extraction_mesh(
+                shape_u, shape, modeord=1
+            )
+            projection_fft = fac * projection_fft[indices_y, indices_x]
+        projection_fft = convert_fftn_to_rfftn(projection_fft, mode="real")
+        if output_shape == shape:
+            return (
+                irfftn(projection_fft, s=output_shape)
+                if outputs_real_space
+                else projection_fft
+            )
+        else:
+            projection = irfftn(projection_fft, s=shape)
+            projection = resize_with_crop_or_pad(projection, output_shape)
+            return projection if outputs_real_space else rfftn(projection)
 
 
 IndependentAtomProjection.__doc__ = f"""Integrate atomic parametrization of a volume "
@@ -598,14 +689,13 @@ def _check_kernel_fns(
     kernel_pytree: PyTree[AbstractFourierOperator] | PyTree[AbstractRealOperator],
     *,
     spatial_dim: int,
-) -> tuple[bool, Callable]:
+) -> bool:
     kernel_list = jax.tree.leaves(
         kernel_pytree,
         is_leaf=lambda x: isinstance(x, (AbstractFourierOperator, AbstractRealOperator)),
     )
     if all(isinstance(kernel, AbstractRealOperator) for kernel in kernel_list):
         is_real_space = True
-        is_leaf = lambda x: isinstance(x, AbstractRealOperator)
         for kernel in kernel_list:
             if 1 not in kernel.spatial_dims:
                 raise ValueError(
@@ -617,7 +707,6 @@ def _check_kernel_fns(
                 )
     elif all(isinstance(kernel, AbstractFourierOperator) for kernel in kernel_list):
         is_real_space = False
-        is_leaf = lambda x: isinstance(x, AbstractFourierOperator)
         for kernel in kernel_list:
             if spatial_dim not in kernel.spatial_dims:
                 raise ValueError(
@@ -635,7 +724,7 @@ def _check_kernel_fns(
             "`AbstractRealOperator`s."
         )
 
-    return is_real_space, is_leaf
+    return is_real_space
 
 
 def _maybe_gaussians_to_erf(
@@ -643,109 +732,46 @@ def _maybe_gaussians_to_erf(
     pixel_size: Float[Array, ""],
     sampling_mode: Literal["average", "point"],
     upsampfac: float,
-) -> tuple[PyTree[AbstractRealOperator], Literal["average", "point"]]:
+) -> tuple[PyTree[AbstractRealOperator], Literal["average", "point"], float]:
     """Modify gaussian kernels at runtime to the error function."""
     kernel_list = jax.tree.leaves(
         kernel_pytree,
         is_leaf=lambda x: isinstance(x, AbstractRealOperator),
     )
     if sampling_mode == "point":
-        return kernel_pytree, "point"
+        return kernel_pytree, "point", upsampfac
     else:
         if all(isinstance(kernel, RealGaussian) for kernel in kernel_list):
             return (
                 jax.tree.map(
-                    lambda x: _IntegratedRealGaussian.from_gaussian(
-                        x, pixel_size / upsampfac
-                    ),
+                    lambda x: _IntegratedRealGaussian.from_gaussian(x, pixel_size),
                     kernel_pytree,
                     is_leaf=lambda x: isinstance(x, AbstractRealOperator),
                 ),
                 "point",
+                1.0,
             )
-        return kernel_pytree, "average"
-
-
-def _project_postprocess(
-    projection_out: Inexact[Array, "_ _"],
-    *,
-    is_real_space: bool,
-    compute_shape: tuple[int, int],
-    pixel_size: Float[Array, ""],
-    frequency_grid: Float[Array, "_ _ 2"],
-    sampling_mode: Literal["average", "point"],
-    block_size: int,
-    output_shape: tuple[int, int],
-    outputs_real_space: bool,
-) -> Inexact[Array, "_ _"]:
-    reduce_shape = tuple(s // block_size for s in projection_out.shape)
-    assert len(reduce_shape) == 2
-    # Code path is the same for real-space and fourier-space
-    del is_real_space
-    projection_fft = projection_out
-    if sampling_mode == "average":
-        antialias_fn = FourierSinc(box_width=pixel_size)
-        projection_fft *= antialias_fn(frequency_grid)
-    if block_size % 2 == 0:
-        projection_fft = _phase_shift_correct(
-            projection_fft,
-            block_size=block_size,
-            target_shape=reduce_shape,
-            pixel_size=pixel_size,
-            frequency_grid=frequency_grid,
-        )
-    projection_fft = convert_fftn_to_rfftn(projection_fft, mode="real")
-    # Block average and return
-    block_average_fn = lambda x, factor: (
-        block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
-        / factor**x.ndim
-    )
-    if output_shape == reduce_shape:
-        if block_size > 1:
-            projection = block_average_fn(
-                irfftn(projection_fft, s=compute_shape), block_size
-            )
-            return projection if outputs_real_space else rfftn(projection)
-        else:
-            return (
-                irfftn(projection_fft, s=output_shape)
-                if outputs_real_space
-                else projection_fft
-            )
-    else:
-        projection = irfftn(projection_fft, s=compute_shape)
-        if block_size > 1:
-            projection = block_average_fn(projection, block_size)
-        projection = resize_with_crop_or_pad(projection, output_shape)
-        return projection if outputs_real_space else rfftn(projection)
+        return kernel_pytree, "average", upsampfac
 
 
 def project_impl(
     positions: PyTree[Float[Array, "_ 3"]],
     kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
-    amplitudes: PyTree[Inexact[Array, " _"]] | None,
+    amplitudes: PyTree[Inexact[Array, " _"]],
     *,
-    shape: tuple[int, int],
-    pixel_size: Float[Array, ""],
+    is_real_space: bool,
+    shape_u: tuple[int, int],
+    pixel_size_u: Float[Array, ""],
     backend: Literal["jax-finufft", "nufftax"],
     frequency_grid: Float[Array, "_ _ 2"],
-    sampling_mode: Literal["average", "point"],
     eps: float,
-    upsampfac: float,
-    block_size: int,
-    output_shape: tuple[int, int],
-    outputs_real_space: bool,
     options: dict[str, Any],
 ) -> Array:
-    is_real_space, is_leaf = _check_kernel_fns(
-        kernel_fns,
-        spatial_dim=2,
+    is_leaf = (
+        (lambda x: isinstance(x, AbstractRealOperator))
+        if is_real_space
+        else (lambda x: isinstance(x, AbstractFourierOperator))
     )
-    if is_real_space:
-        kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
-            kernel_fns, pixel_size, sampling_mode, upsampfac
-        )
-    amplitudes = _standardize_amplitudes(amplitudes, positions)
 
     def real_impl(
         _shape: tuple[int, int],
@@ -759,27 +785,24 @@ def project_impl(
             raise ValueError(
                 "`IndependentAtomProjection` for real-valued kernels "
                 "only supports rendering square images. Found a shape "
-                f"equal to {(_shape[0] // block_size, _shape[1] // block_size)}"
+                f"equal to {shape_u}."
             )
-        u = upsampfac
         nspread = _eps_to_nspread(eps)
-        shape_u = (int(u * dim), int(u * dim))
         (ny, nx) = _shape
         box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
         xy = 2 * jnp.pi * _positions[:, :2] / box_xy
         projection = spread_2d(
             x=xy[:, 0],
             y=xy[:, 1],
-            c=_amplitudes,
-            nf1=shape_u[1],
-            nf2=shape_u[0],
+            c=_amplitudes.astype(float),
+            nf1=dim,
+            nf2=dim,
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_ps / u, nspread=nspread
+                _kernel_fn, image_dim=dim, pixel_size=_ps, nspread=nspread
             ),
             **options,
         )
-        (indices_y, indices_x), fac = _build_extraction_mesh(shape_u, _shape)
-        return fac * fftn(projection)[indices_y, indices_x]
+        return projection
 
     def fourier_impl(
         _shape: tuple[int, int],
@@ -801,7 +824,7 @@ def project_impl(
                     xy=2 * jnp.pi * _positions[:, :2] / box_xy,
                     backend=backend,
                     eps=eps,
-                    upsampfac=upsampfac,
+                    upsampfac=1.25,
                     options=options,
                 )
                 / _ps**2
@@ -815,7 +838,7 @@ def project_impl(
 
     # Project and sum over kernels
     project_dispatch = lambda _positions, _kernel_fn, _amplitudes: project_impl(
-        shape, pixel_size, _positions, _kernel_fn, _amplitudes, *project_args
+        shape_u, pixel_size_u, _positions, _kernel_fn, _amplitudes, *project_args
     )
     projection_out = jax.tree.reduce(
         lambda x, y: x + y,
@@ -823,75 +846,28 @@ def project_impl(
             project_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf
         ),
     )
-    return _project_postprocess(
-        projection_out,
-        is_real_space=is_real_space,
-        compute_shape=shape,
-        pixel_size=pixel_size,
-        frequency_grid=frequency_grid,
-        sampling_mode=sampling_mode,
-        block_size=block_size,
-        output_shape=output_shape,
-        outputs_real_space=outputs_real_space,
-    )
 
-
-def _render_postprocess(
-    render_out: Inexact[Array, "_ _ _"],
-    voxel_size: Float[Array, ""],
-    *,
-    is_real_space: bool,
-    frequency_grid: Float[Array, "_ _ _ 3"],
-    sampling_mode: Literal["average", "point"],
-    outputs_real_space: bool,
-    outputs_rfft: bool,
-    fftshifted: bool,
-) -> Inexact[Array, "_ _ _"]:
-    # Code path is the same for real-space and fourier-space
-    del is_real_space
-    render_fft = render_out
-    if sampling_mode == "average":
-        antialias_fn = FourierSinc(box_width=voxel_size)
-        render_fft *= antialias_fn(frequency_grid)
-    if outputs_real_space:
-        return ifftn(jnp.fft.ifftshift(render_fft)).real
-    else:
-        if outputs_rfft:
-            render_fft = convert_fftn_to_rfftn(jnp.fft.ifftshift(render_fft), mode="real")
-            if fftshifted:
-                return jnp.fft.fftshift(render_fft, axes=(0, 1))
-            else:
-                return render_fft
-        else:
-            if fftshifted:
-                return render_fft
-            else:
-                return jnp.fft.ifftshift(render_fft)
+    return projection_out
 
 
 def render_impl(
     positions: PyTree[Float[Array, "_ 3"]],
     kernel_fns: PyTree[AbstractRealOperator] | PyTree[AbstractFourierOperator],
-    amplitudes: PyTree[Inexact[Array, " _"]] | None,
+    amplitudes: PyTree[Inexact[Array, " _"]],
     *,
-    shape: tuple[int, int, int],
-    voxel_size: Float[Array, ""],
+    is_real_space: bool,
+    shape_u: tuple[int, int, int],
+    voxel_size_u: Float[Array, ""],
     backend: Literal["jax-finufft", "nufftax"],
     frequency_grid: Float[Array, "_ _ _ 3"],
-    sampling_mode: Literal["average", "point"],
     eps: float,
-    upsampfac: float,
-    outputs_real_space: bool,
-    outputs_rfft: bool,
-    fftshifted: bool,
     options: dict[str, Any],
 ) -> Array:
-    is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=3)
-    if is_real_space:
-        kernel_fns, sampling_mode = _maybe_gaussians_to_erf(
-            kernel_fns, voxel_size, sampling_mode, upsampfac
-        )
-    amplitudes = _standardize_amplitudes(amplitudes, positions)
+    is_leaf = (
+        (lambda x: isinstance(x, AbstractRealOperator))
+        if is_real_space
+        else (lambda x: isinstance(x, AbstractFourierOperator))
+    )
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -908,8 +884,6 @@ def render_impl(
                 f"equal to {(_shape[0], _shape[1], _shape[2])}"
             )
         nspread = _eps_to_nspread(eps)
-        u = upsampfac
-        shape_u = (int(u * _shape[0]), int(u * _shape[1]), int(u * _shape[2]))
         (nz, ny, nx) = _shape
         box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
         xyz = 2 * jnp.pi * _positions / box_xyz
@@ -917,17 +891,16 @@ def render_impl(
             x=xyz[:, 0],
             y=xyz[:, 1],
             z=xyz[:, 2],
-            c=_amplitudes,
-            nf1=shape_u[2],
-            nf2=shape_u[1],
-            nf3=shape_u[0],
+            c=_amplitudes.astype(float),
+            nf1=_shape[2],
+            nf2=_shape[1],
+            nf3=_shape[0],
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_vs / u, nspread=nspread
+                _kernel_fn, image_dim=dim, pixel_size=_vs, nspread=nspread
             ),
             **options,
         )
-        (indices_z, indices_y, indices_x), fac = _build_extraction_mesh(shape_u, _shape)
-        return fac * fftn(projection)[indices_z, indices_y, indices_x]
+        return projection
 
     def fourier_impl(
         _shape: tuple[int, int, int],
@@ -941,16 +914,18 @@ def render_impl(
         box_xyz = _vs * jnp.asarray((nx, ny, nz))
         # Compute
         return _kernel_fn(_frequency_grid) * (
-            _nufft3d1(
-                _shape,  # type: ignore
-                source=_amplitudes.astype(complex),
-                xyz=2 * jnp.pi * _positions / box_xyz,
-                backend=backend,
-                eps=eps,
-                upsampfac=upsampfac,
-                options=options,
+            jnp.fft.ifftshift(
+                _nufft3d1(
+                    _shape,  # type: ignore
+                    source=_amplitudes.astype(complex),
+                    xyz=2 * jnp.pi * _positions / box_xyz,
+                    backend=backend,
+                    eps=eps,
+                    upsampfac=1.25,
+                    options=options,
+                )
+                / _vs**3
             )
-            / _vs**3
         )
 
     if is_real_space:
@@ -959,49 +934,14 @@ def render_impl(
         render_impl, render_args = fourier_impl, (frequency_grid,)
 
     render_dispatch = lambda _positions, _kernel_fn, _amplitudes: render_impl(
-        shape, voxel_size, _positions, _kernel_fn, _amplitudes, *render_args
+        shape_u, voxel_size_u, _positions, _kernel_fn, _amplitudes, *render_args
     )
-    render_out = jax.tree.reduce(
+    rendering_out = jax.tree.reduce(
         lambda x, y: x + y,
         jax.tree.map(render_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf),
     )
 
-    return _render_postprocess(
-        render_out,
-        is_real_space=is_real_space,
-        voxel_size=voxel_size,
-        frequency_grid=frequency_grid,
-        sampling_mode=sampling_mode,
-        outputs_real_space=outputs_real_space,
-        outputs_rfft=outputs_rfft,
-        fftshifted=fftshifted,
-    )
-
-
-def _phase_shift_correct(
-    projection_fft: Array,
-    *,
-    block_size: int,
-    target_shape: tuple[int, int],
-    pixel_size: Array,
-    frequency_grid: Array,
-):
-    if len(set(target_shape)) > 1:
-        raise NotImplementedError(
-            "Even `block_size` and non-square images not "
-            "supported in `IndependentAtomProjection`. "
-            f"Got `block_size = {block_size}` "
-            f"and `shape = {target_shape}`."
-        )
-    dim = target_shape[0]
-    if dim % 2 == 0:
-        shift = jnp.full((2,), (block_size - 1) / 2)
-    else:
-        shift = jnp.full((2,), -0.5)
-    return (
-        jnp.exp(-1.0j * (2 * jnp.pi * jnp.matmul(frequency_grid, pixel_size * shift)))
-        * projection_fft
-    )
+    return rendering_out
 
 
 def _make_jax_finufft_opts(upsampfac: float):
@@ -1108,19 +1048,22 @@ def _eps_to_nspread(eps: float) -> int:
     return max(2, min(int(math.ceil(log_tol + 1)), max_nspread))
 
 
-def _build_extraction_mesh(shape: tuple[int, ...], shape_ds: tuple[int, ...]):
+def _build_extraction_mesh(
+    shape: tuple[int, ...], shape_ds: tuple[int, ...], *, modeord: int
+):
     """Build indices to extract modes from FFT output."""
 
     assert len(shape) == len(shape_ds)
     assert len(shape) in [2, 3]
     mean_factor = math.prod(shape_ds) / math.prod(shape)
     indices_1d = tuple(
-        _build_extraction_indices_1d(dim, dim_ds) for dim, dim_ds in zip(shape, shape_ds)
+        _build_extraction_indices_1d(dim, dim_ds, modeord=modeord)
+        for dim, dim_ds in zip(shape, shape_ds)
     )
     return jnp.meshgrid(*indices_1d, indexing="ij"), mean_factor
 
 
-def _build_extraction_indices_1d(dim: int, dim_ds: int):
+def _build_extraction_indices_1d(dim: int, dim_ds: int, *, modeord: int):
     """Build indices to extract modes from FFT output. Adapted from `nufftax`"""
     q_min = -(dim_ds // 2)
     q_max = (dim_ds - 1) // 2
@@ -1128,8 +1071,10 @@ def _build_extraction_indices_1d(dim: int, dim_ds: int):
     idx_pos = jnp.arange(q_max + 1)
     idx_neg = jnp.arange(dim + q_min, dim)
 
-    # `modeord = 1` case
-    indices = jnp.concatenate([idx_pos, idx_neg])
+    if modeord == 0:
+        indices = jnp.concatenate([idx_neg, idx_pos])
+    else:
+        indices = jnp.concatenate([idx_pos, idx_neg])
 
     return indices
 
@@ -1137,7 +1082,7 @@ def _build_extraction_indices_1d(dim: int, dim_ds: int):
 def _standardize_amplitudes(amplitudes: PyTree[Array] | None, positions: PyTree[Array]):
     if amplitudes is None:
         return jax.tree.map(
-            lambda x: jnp.ones((x.shape[0],), dtype=complex),
+            lambda x: jnp.ones((x.shape[0],), dtype=float),
             positions,
         )
     else:
@@ -1185,3 +1130,28 @@ class _IntegratedRealGaussian(AbstractRealOperator, strict=True):
             jsp.special.erf(scaling * right) - jsp.special.erf(scaling * left)
         )
         return self.amplitude * weight
+
+
+def _find_exact_upsampfac(input_upsampfac: float, dims: tuple[int, ...]) -> float:
+    """Find the upsampfac that perfectly divides the upsampled
+    image shape.
+    """
+    gcd = ft.reduce(math.gcd, dims)
+    return round(gcd * input_upsampfac) / gcd
+
+
+def _prepare_real_to_fft(a: Array, *, outputs_rfft: bool, fftshifted: bool) -> Array:
+    if outputs_rfft:
+        f = rfftn(a)
+        return jnp.fft.fftshift(f, axes=(0, 1)) if fftshifted else f
+    else:
+        f = fftn(a)
+        return jnp.fft.fftshift(f) if fftshifted else f
+
+
+def _prepare_fft_to_fft(f: Array, *, outputs_rfft: bool, fftshifted: bool) -> Array:
+    if outputs_rfft:
+        f = convert_fftn_to_rfftn(f, mode="real")
+        return jnp.fft.fftshift(f, axes=(0, 1)) if fftshifted else f
+    else:
+        return jnp.fft.fftshift(f) if fftshifted else f

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -245,12 +245,12 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
         positions_by_element: tuple[Float[NDArrayLike, "_ 3"], ...],
         parameters: PengScatteringFactorParameters | LobatoScatteringFactorParameters,
         *,
-        outputs_real_space: bool = False,
+        use_real_space: bool = False,
         b_factor_by_element: FloatLike | tuple[FloatLike, ...] | None = None,
     ) -> Self:
         def make_kernel_fn(a, b, b_factor):
             if isinstance(parameters, PengScatteringFactorParameters):
-                if outputs_real_space:
+                if use_real_space:
                     b = b + jnp.asarray(b_factor)[None] if b_factor is not None else b
                     return eqx.filter_vmap(
                         lambda _a, _b: RealGaussian(
@@ -260,13 +260,13 @@ class IndependentAtomVolume(AbstractAtomVolume, strict=True):
                 else:
                     return PengScatteringFactor(a, b, b_factor)
             elif isinstance(parameters, LobatoScatteringFactorParameters):
-                if outputs_real_space:
+                if use_real_space:
                     raise NotImplementedError(
                         "`IndependentAtomVolume(..., parameters=..., "
-                        "outputs_real_space=True)` does not support "
+                        "use_real_space=True)` does not support "
                         "`parameters = LobatoScatteringFactorParameters(...)`. "
                         "Instead, use `PengScatteringFactorParameters` or set "
-                        "`outputs_real_space = False`."
+                        "`use_real_space = False`."
                     )
                 else:
                     return LobatoScatteringFactor(a, b, b_factor)
@@ -338,7 +338,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
 
     backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
-    upsample_factor: float
+    upsample_factor: float | None
     eps: float
     options: dict[str, Any]
 
@@ -349,7 +349,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         *,
         backend: Literal["nufftax", "jax-finufft"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
-        upsample_factor: int | float = 2.0,
+        upsample_factor: int | float | None = None,
         eps: float = 1e-6,
         options: dict[str, Any] = {},
     ):
@@ -359,11 +359,6 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             The shape of the resulting voxel grid.
         - `voxel_size`:
             The voxel size of the resulting voxel grid.
-        - `sampling_mode`:
-            If `'average'`, convolve with a box function to sample the
-            projected volume at a pixel to be the average value of the
-            underlying continuous function. If `'point'`, the volume at
-            a pixel will be point sampled.
         - `backend`:
             The backend for non-uniform FFT computation. This is either
             [`nufftax`](https://github.com/GragasLab/nufftax/tree/custom-kernel-spread)
@@ -373,12 +368,17 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             calling `finufft` directly via `jax.ffi`.
             Used only when `IndependentAtomVolume.kernel_fns` are type
             `AbstractFourierOperator`.
+        - `sampling_mode`:
+            If `'average'`, convolve with a box function to sample the
+            projected volume at a pixel to be the average value of the
+            underlying continuous function. If `'point'`, the volume at
+            a pixel will be point sampled.
+            If `IndependentAtomVolume` is instantiated with real-space
+            gaussians, then error functions are used in
+            `sampling_mode = 'average'`.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
-            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
-            for documentation. If a 2-tuple is passed, `upsample_factor[0]` is
-            used for the forward pass and `upsample_factor[1]` is used for the
-            backward pass.
+            If equal to `None`, choose a default value at run-time.
         - `eps`:
             Controls speed / accuracy tradeoff.
             See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
@@ -405,7 +405,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         self.voxel_size = jnp.asarray(voxel_size, dtype=float)
         self.backend = backend
         self.sampling_mode = sampling_mode
-        self.upsample_factor = float(upsample_factor)
+        self.upsample_factor = None if upsample_factor is None else float(upsample_factor)
         self.eps = eps
         self.options = options
 
@@ -443,17 +443,28 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         # Check and modify kernels if using error functions
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=3)
+        # Upsample factor logic
         upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
+        if upsampfac is None:
+            upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
+        upsampfac = _find_exact_upsampfac(upsampfac, self.shape)
+        # Modify kernels if using error functions
         if is_real_space:
-            kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
-                kernel_fns, self.voxel_size, sampling_mode, upsampfac
+            kernel_fns, sampling_mode = _maybe_use_erf(
+                kernel_fns,
+                pixel_size=self.voxel_size,
+                sampling_mode=sampling_mode,
+                upsampfac=upsampfac,
             )
         # Upsampling arguments
         if upsampfac > 1:
-            u = _find_exact_upsampfac(self.upsample_factor, self.shape)
             shape_u, voxel_size_u = (
-                (int(u * self.shape[0]), int(u * self.shape[1]), int(u * self.shape[2])),
-                self.voxel_size / u,
+                (
+                    int(upsampfac * self.shape[0]),
+                    int(upsampfac * self.shape[1]),
+                    int(upsampfac * self.shape[2]),
+                ),
+                self.voxel_size / upsampfac,
             )
         else:
             shape_u, voxel_size_u = self.shape, self.voxel_size
@@ -493,8 +504,8 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             rendering_fft = rendering_out
         # Average within a pixel size
         if sampling_mode == "average":
-            antialias_fn = FourierSinc(box_width=self.voxel_size)
-            rendering_fft *= antialias_fn(frequency_grid)
+            box_fn = FourierSinc(box_width=self.voxel_size)
+            rendering_fft *= box_fn(frequency_grid)
         # Downsample by extracting fourier modes
         if self.shape != shape_u:
             (indices_z, indices_y, indices_x), fac = _build_extraction_mesh(
@@ -523,7 +534,7 @@ class IndependentAtomProjection(
 ):
     backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
-    upsample_factor: float
+    upsample_factor: float | None
     eps: float
     shape: tuple[int, int] | None
     options: dict[str, Any]
@@ -535,7 +546,7 @@ class IndependentAtomProjection(
         *,
         backend: Literal["jax-finufft", "nufftax"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
-        upsample_factor: int | float = 2.0,
+        upsample_factor: int | float | None = None,
         eps: float = 1e-6,
         shape: tuple[int, int] | None = None,
         options: dict[str, Any] = {},
@@ -556,12 +567,12 @@ class IndependentAtomProjection(
             projected volume at a pixel to be the average value of the
             underlying continuous function. If `'point'`, the volume at
             a pixel will be point sampled.
+            If `IndependentAtomVolume` is instantiated with real-space
+            gaussians, then error functions are used in
+            `sampling_mode = 'average'`.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
-            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
-            for documentation. If a 2-tuple is passed, `upsample_factor[0]` is
-            used for the forward pass and `upsample_factor[1]` is used for the
-            backward pass.
+            If equal to `None`, choose a default value at run-time.
         - `eps`:
             Controls speed / accuracy tradeoff.
             See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
@@ -590,7 +601,7 @@ class IndependentAtomProjection(
         self.backend = backend
         self.sampling_mode = sampling_mode
         self.shape = shape
-        self.upsample_factor = float(upsample_factor)
+        self.upsample_factor = None if upsample_factor is None else float(upsample_factor)
         self.eps = eps
         self.options = options
 
@@ -628,19 +639,26 @@ class IndependentAtomProjection(
             volume_representation.kernel_fns,
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
-        # Check and modify kernels if using error functions
+        # Check if real or fourier and do any preprocessing
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=2)
+        # Upsample factor logic
         upsampfac, sampling_mode = self.upsample_factor, self.sampling_mode
+        if upsampfac is None:
+            upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
+        upsampfac = _find_exact_upsampfac(upsampfac, shape)
+        # Modify kernels if using error functions
         if is_real_space:
-            kernel_fns, sampling_mode, upsampfac = _maybe_gaussians_to_erf(
-                kernel_fns, pixel_size, sampling_mode, upsampfac
+            kernel_fns, sampling_mode = _maybe_use_erf(
+                kernel_fns,
+                pixel_size=pixel_size,
+                sampling_mode=sampling_mode,
+                upsampfac=upsampfac,
             )
         # Upsampled shape and pixel size
         if upsampfac > 1:
-            u = _find_exact_upsampfac(self.upsample_factor, shape)
             shape_u, pixel_size_u = (
-                (int(u * shape[0]), int(u * shape[1])),
-                pixel_size / u,
+                (int(upsampfac * shape[0]), int(upsampfac * shape[1])),
+                pixel_size / upsampfac,
             )
             frequency_grid = make_frequency_grid(
                 shape_u, pixel_size_u, outputs_rfftfreqs=False
@@ -679,8 +697,8 @@ class IndependentAtomProjection(
             projection_fft = projection_out
         # Average within a pixel size
         if sampling_mode == "average":
-            antialias_fn = FourierSinc(box_width=pixel_size)
-            projection_fft *= antialias_fn(frequency_grid)
+            box_fn = FourierSinc(box_width=pixel_size)
+            projection_fft *= box_fn(frequency_grid)
         # Downsample by extracting fourier modes
         if shape != shape_u:
             (indices_y, indices_x), fac = _build_extraction_mesh(
@@ -747,25 +765,27 @@ def _standardize_kernel_fns(
     return is_real_space, kernel_pytree
 
 
-def _maybe_gaussians_to_erf(
+def _maybe_use_erf(
     kernel_pytree: PyTree[RealGaussian],
     pixel_size: Float[Array, ""],
     sampling_mode: Literal["average", "point"],
     upsampfac: float,
-) -> tuple[PyTree[RealGaussian], Literal["average", "point"], float]:
+) -> tuple[PyTree[RealGaussian], Literal["average", "point"]]:
     """Modify gaussian kernels at runtime to the error function."""
     if sampling_mode == "average":
-        return (
-            jax.tree.map(
-                lambda x: _make_erf(x, pixel_size),
-                kernel_pytree,
-                is_leaf=lambda x: isinstance(x, AbstractRealOperator),
-            ),
-            "point",
-            1.0,
-        )
+        if upsampfac == 1.0:
+            return (
+                jax.tree.map(
+                    lambda x: _make_erf(x, pixel_size),
+                    kernel_pytree,
+                    is_leaf=lambda x: isinstance(x, AbstractRealOperator),
+                ),
+                "point",
+            )
+        else:
+            return kernel_pytree, "average"
     else:
-        return (kernel_pytree, "point", upsampfac)
+        return (kernel_pytree, "point")
 
 
 def project_impl(

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -12,8 +12,6 @@ import nufftax
 from jaxtyping import Array, Float, Inexact, PyTree
 from nufftax.core import Kernel, spread_2d, spread_3d
 
-from cryojax.ndimage._operators._fourier_operator import FourierGaussian
-
 from ..._internal import error_if_not_positive
 from ...constants import (
     LobatoScatteringFactorParameters,
@@ -24,14 +22,15 @@ from ...jax_util import FloatLike, NDArrayLike
 from ...ndimage import (
     AbstractFourierOperator,
     AbstractRealOperator,
+    FourierGaussian,
     FourierSinc,
     RealGaussian,
     convert_fftn_to_rfftn,
     fftn,
     ifftn,
     irfftn,
-    make_1d_frequency_grid,
     make_frequency_grid,
+    query_efficient_grid_size,
     resize_with_crop_or_pad,
     rfftn,
 )
@@ -44,6 +43,7 @@ from .base_volume import (
     ProjectionArray,
     VoxelArray,
 )
+from .common import make_frequencies_1d
 
 
 try:
@@ -438,9 +438,10 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=3)
-        upsampfac = _standardize_upsampfac(
-            self.upsample_factor,
-            dims=self.shape,
+        (shape_u, voxel_size_u), upsampfac = _prepare_upsample(
+            shape=self.shape,
+            pixel_size=self.voxel_size,
+            upsampfac=self.upsample_factor,
             sampling_mode=self.sampling_mode,
             is_real_space=is_real_space,
         )
@@ -453,31 +454,14 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
                 sampling_mode=sampling_mode,
                 upsampfac=upsampfac,
             )
-        # Upsampling arguments
-        if upsampfac > 1:
-            shape_u, voxel_size_u = (
-                (
-                    int(upsampfac * self.shape[0]),
-                    int(upsampfac * self.shape[1]),
-                    int(upsampfac * self.shape[2]),
-                ),
-                self.voxel_size / upsampfac,
-            )
-        else:
-            shape_u, voxel_size_u = self.shape, self.voxel_size
-        frequencies_1d = tuple(
-            make_1d_frequency_grid(s, voxel_size_u, outputs_rfftfreqs=False)
-            for s in shape_u[::-1]
-        )
         # Compute
         rendering_out = render_impl(
             positions,
             kernel_fns,
             amplitudes,
             is_real_space=is_real_space,
-            shape_u=shape_u,
+            shape_u=cast(tuple[int, int, int], shape_u),
             voxel_size_u=voxel_size_u,
-            frequencies_1d=frequencies_1d,
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -503,6 +487,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=self.voxel_size)
+            frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=1)
             rendering_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if self.shape != shape_u:
@@ -638,9 +623,10 @@ class IndependentAtomProjection(
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=2)
-        upsampfac = _standardize_upsampfac(
-            self.upsample_factor,
-            dims=shape,
+        (shape_u, pixel_size_u), upsampfac = _prepare_upsample(
+            shape=shape,
+            pixel_size=pixel_size,
+            upsampfac=self.upsample_factor,
             sampling_mode=self.sampling_mode,
             is_real_space=is_real_space,
         )
@@ -653,27 +639,14 @@ class IndependentAtomProjection(
                 sampling_mode=sampling_mode,
                 upsampfac=upsampfac,
             )
-        # Upsampled shape and pixel size
-        if upsampfac > 1:
-            shape_u, pixel_size_u = (
-                (int(upsampfac * shape[0]), int(upsampfac * shape[1])),
-                pixel_size / upsampfac,
-            )
-        else:
-            shape_u, pixel_size_u = shape, pixel_size
-        frequencies_1d = tuple(
-            make_1d_frequency_grid(s, pixel_size_u, outputs_rfftfreqs=False)
-            for s in shape_u[::-1]
-        )
         # Compute projection
         projection_out = project_impl(
             positions,
             kernel_fns,
             amplitudes,
             is_real_space=is_real_space,
-            shape_u=shape_u,
+            shape_u=cast(tuple[int, int], shape_u),
             pixel_size_u=pixel_size_u,
-            frequencies_1d=frequencies_1d,
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -693,6 +666,7 @@ class IndependentAtomProjection(
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=pixel_size)
+            frequencies_1d = make_frequencies_1d(shape_u, pixel_size_u, modeord=1)
             projection_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if shape != shape_u:
@@ -791,7 +765,6 @@ def project_impl(
     is_real_space: bool,
     shape_u: tuple[int, int],
     pixel_size_u: Float[Array, ""],
-    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -804,6 +777,7 @@ def project_impl(
     frequency_grid = _maybe_make_frequency_grid(
         shape_u, pixel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
+    frequencies_1d = make_frequencies_1d(shape_u, pixel_size_u, modeord=0)
 
     def real_impl(
         _shape: tuple[int, int],
@@ -812,25 +786,16 @@ def project_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
-        dim = _shape[0]
-        if not all(s == dim for s in _shape):
-            raise ValueError(
-                "`IndependentAtomProjection` for real-valued kernels "
-                "only supports rendering square images. Found a shape "
-                f"equal to {shape_u}."
-            )
         nspread = _eps_to_nspread(eps)
-        (ny, nx) = _shape
-        box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
-        xy = 2 * jnp.pi * _positions[:, :2] / box_xy
+        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
         projection = _spread_2d(
             kernel_fn=_kernel_fn,
             pixel_size=_ps,
             x=xy[:, 0],
             y=xy[:, 1],
             c=_amplitudes.astype(float),
-            nf1=dim,
-            nf2=dim,
+            nf1=_shape[1],
+            nf2=_shape[0],
             nspread=nspread,
             options=options,
         )
@@ -845,22 +810,18 @@ def project_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        (ny, nx) = _shape
-        box_xy = _ps * jnp.asarray((nx, ny))
-        # Compute
+        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
         return (
             eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh)
-            * jnp.fft.ifftshift(
-                _nufft2d1(
-                    _shape,  # type: ignore
-                    source=_amplitudes.astype(complex),
-                    xy=2 * jnp.pi * _positions[:, :2] / box_xy,
-                    backend=backend,
-                    eps=eps,
-                    options=options,
-                )
-                / _ps**2
+            * _nufft2d1(
+                _shape,  # type: ignore
+                source=_amplitudes.astype(complex),
+                xy=xy + jnp.pi,
+                backend=backend,
+                eps=eps,
+                options=options,
             )
+            / _ps**2
         )
 
     if is_real_space:
@@ -887,6 +848,8 @@ def project_impl(
             project_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf
         ),
     )
+    if not is_real_space:
+        projection_out = jnp.fft.ifftshift(projection_out)
 
     return projection_out
 
@@ -899,7 +862,6 @@ def render_impl(
     is_real_space: bool,
     shape_u: tuple[int, int, int],
     voxel_size_u: Float[Array, ""],
-    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -912,6 +874,7 @@ def render_impl(
     frequency_grid = _maybe_make_frequency_grid(
         shape_u, voxel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
+    frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=0)
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -920,17 +883,8 @@ def render_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
-        dim = _shape[0]
-        if not all(s == dim for s in _shape):
-            raise ValueError(
-                "`IndependentAtomRenderFn` for real-valued kernels "
-                "only supports rendering square voxel arrays. Found a shape "
-                f"equal to {(_shape[0], _shape[1], _shape[2])}"
-            )
         nspread = _eps_to_nspread(eps)
-        (nz, ny, nx) = _shape
-        box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
-        xyz = 2 * jnp.pi * _positions / box_xyz
+        xyz = _normalize_positions(_positions, _shape, _vs)
         rendering = _spread_3d(
             kernel_fn=_kernel_fn,
             voxel_size=_vs,
@@ -938,9 +892,9 @@ def render_impl(
             y=xyz[:, 1],
             z=xyz[:, 2],
             c=_amplitudes.astype(float),
-            nf1=dim,
-            nf2=dim,
-            nf3=dim,
+            nf1=_shape[2],
+            nf2=_shape[1],
+            nf3=_shape[0],
             nspread=nspread,
             options=options,
         )
@@ -955,35 +909,34 @@ def render_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        (nz, ny, nx) = _shape
-        box_xyz = _vs * jnp.asarray((nx, ny, nz))
+        xyz = _normalize_positions(_positions, _shape, _vs)
         # Compute
         return eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh) * (
-            jnp.fft.ifftshift(
-                _nufft3d1(
-                    _shape,  # type: ignore
-                    source=_amplitudes.astype(complex),
-                    xyz=2 * jnp.pi * _positions / box_xyz,
-                    backend=backend,
-                    eps=eps,
-                    options=options,
-                )
-                / _vs**3
+            _nufft3d1(
+                _shape,  # type: ignore
+                source=_amplitudes.astype(complex),
+                xyz=xyz + jnp.pi,
+                backend=backend,
+                eps=eps,
+                options=options,
             )
+            / _vs**3
         )
 
     if is_real_space:
-        render_impl, args = real_impl, ()
+        compute_fn, args = real_impl, ()
     else:
-        render_impl, args = cast(Any, (fourier_impl, (frequencies_1d, frequency_grid)))
+        compute_fn, args = cast(Any, (fourier_impl, (frequencies_1d, frequency_grid)))
 
-    render_dispatch = lambda _positions, _kernel_fn, _amplitudes: render_impl(
+    render_dispatch = lambda _positions, _kernel_fn, _amplitudes: compute_fn(
         shape_u, voxel_size_u, _positions, _kernel_fn, _amplitudes, *args
     )
     rendering_out = jax.tree.reduce(
         lambda x, y: x + y,
         jax.tree.map(render_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf),
     )
+    if not is_real_space:
+        rendering_out = jnp.fft.ifftshift(rendering_out)
 
     return rendering_out
 
@@ -1100,9 +1053,6 @@ def _nufft3d1(
 
 
 def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, options):
-    assert nf1 == nf2 == nf3
-    dim = nf1
-
     @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None, None))
     def spread_3d_impl(_kernel_fn, _voxel_size, _x, _y, _z, _c):
         return spread_3d(
@@ -1110,11 +1060,11 @@ def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, opt
             y=_y,
             z=_z,
             c=_c,
-            nf1=dim,
-            nf2=dim,
-            nf3=dim,
+            nf1=nf1,
+            nf2=nf2,
+            nf3=nf3,
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_voxel_size, nspread=nspread
+                _kernel_fn, pixel_size=_voxel_size, nspread=nspread
             ),
             **options,
         )
@@ -1123,19 +1073,16 @@ def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, opt
 
 
 def _spread_2d(kernel_fn, pixel_size, x, y, c, nf1, nf2, *, nspread, options):
-    assert nf1 == nf2
-    dim = nf1
-
     @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None))
     def spread_2d_impl(_kernel_fn, _pixel_size, _x, _y, _c):
         return spread_2d(
             x=_x,
             y=_y,
             c=_c,
-            nf1=dim,
-            nf2=dim,
+            nf1=nf1,
+            nf2=nf2,
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_pixel_size, nspread=nspread
+                _kernel_fn, pixel_size=_pixel_size, nspread=nspread
             ),
             **options,
         )
@@ -1145,17 +1092,16 @@ def _spread_2d(kernel_fn, pixel_size, x, y, c, nf1, nf2, *, nspread, options):
 
 def _eps_to_nspread(eps: float) -> int:
     # FINUFFT heuristic for choosing `nspread` parameter
-    # based on desired precision `eps`
-    max_nspread = 16
+    # based on desired precision `eps`. In this context it is
+    # used for spreading gaussians, so we let it be unbounded
     log_tol = -math.log10(max(eps, 1e-16))
-    return max(2, min(int(math.ceil(log_tol + 1)), max_nspread))
+    return max(2, int(math.ceil(log_tol + 1)))
 
 
 def _build_extraction_mesh(
     shape: tuple[int, ...], shape_ds: tuple[int, ...], *, modeord: int
 ):
     """Build indices to extract modes from FFT output."""
-
     assert len(shape) == len(shape_ds)
     assert len(shape) in [2, 3]
     mean_factor = math.prod(shape_ds) / math.prod(shape)
@@ -1195,14 +1141,12 @@ def _standardize_amplitudes(amplitudes: PyTree[Array] | None, positions: PyTree[
 def _make_nufftax_kernel(
     kernel_fn: AbstractRealOperator,
     *,
-    image_dim: int,
     pixel_size: Float[Array, ""],
     nspread: int,
 ):
-    offset = 0.5 if image_dim % 2 == 1 else 0.0
     return Kernel(
         nspread=nspread,
-        phi=lambda _z: eqx.filter_vmap(kernel_fn)(pixel_size * (_z + offset)),
+        phi=lambda _z: eqx.filter_vmap(kernel_fn)(pixel_size * _z),
     )
 
 
@@ -1234,20 +1178,40 @@ def _make_erf(gaussian: RealGaussian, pixel_size: Float[Array, ""]):
     )
 
 
-def _standardize_upsampfac(
+def _prepare_upsample(
+    shape: tuple[int, ...],
+    pixel_size: Float[Array, ""],
     upsampfac: float | None,
     *,
-    dims: tuple[int, ...],
     is_real_space: bool,
     sampling_mode: Literal["point", "average"],
-) -> float:
+) -> tuple[tuple[tuple[int, ...], Array], float]:
     """Find the upsampfac that perfectly divides the upsampled
     image shape.
     """
     if upsampfac is None:
         upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
-    gcd = ft.reduce(math.gcd, dims)
-    return round(gcd * upsampfac) / gcd
+    if upsampfac == 1.0:
+        return (shape, pixel_size), upsampfac
+    else:
+        dim = shape[0]
+        if not all(s == dim for s in shape):
+            # If rectangular image focus on accuracy. Make sure
+            # `upsampfac` is mapped directly onto a pixel size
+            # dilation
+            gcd = ft.reduce(math.gcd, shape)
+            upsampfac = round(gcd * upsampfac) / gcd
+            shape_u = tuple(s * upsampfac for s in shape)
+        else:
+            # Otherwise, find an efficient grid for FFTs close to
+            # the requested upsampfac and return the corrected upsampfac
+            shape_u = query_efficient_grid_size(shape, upsampfac, match_parity=False)
+            dim_u = shape_u[0]
+            upsampfac = dim_u / dim
+        return (
+            (tuple(int(upsampfac * s) for s in shape), pixel_size / upsampfac),
+            upsampfac,
+        )
 
 
 def _prepare_real_to_fft(a: Array, *, outputs_rfft: bool, fftshifted: bool) -> Array:
@@ -1289,7 +1253,7 @@ def _maybe_make_frequency_grid(
     elif all_separable:
         frequency_grid = None
     else:
-        frequency_grid = make_frequency_grid(shape, pixel_size)
+        frequency_grid = make_frequency_grid(shape, pixel_size, fftshifted=True)
 
     return frequency_grid
 
@@ -1343,3 +1307,12 @@ def eval_separable_impl(
 def eval_non_separable_impl(kernel_fn: AbstractFourierOperator, frequency_grid: Array):
     assert frequency_grid.shape[-1] in [2, 3]
     return kernel_fn(frequency_grid)
+
+
+def _normalize_positions(
+    positions: Array,
+    shape: tuple[int, ...],
+    pixel_size: Array,
+) -> Array:
+    box_size = tuple(pixel_size * s for s in shape[::-1])
+    return 2 * jnp.pi * positions / jnp.asarray(box_size)

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -8,6 +8,7 @@ import jax
 import jax.numpy as jnp
 import nufftax
 from jaxtyping import Array, Float, Inexact, PyTree
+from nufftax.core import Kernel, spread_2d, spread_3d
 
 from ..._internal import error_if_not_positive
 from ...constants import (
@@ -22,6 +23,7 @@ from ...ndimage import (
     FourierSinc,
     block_reduce_downsample,
     convert_fftn_to_rfftn,
+    fftn,
     ifftn,
     irfftn,
     make_frequency_grid,
@@ -381,21 +383,24 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             a pixel will be point sampled.
         - `backend`:
             The backend for non-uniform FFT computation. This is either
-            `nufftax` for a pure-JAX implementation of FINUFFT,
-            or `jax-finufft` for calling FINUFFT directly.
+            [`nufftax`](https://github.com/GragasLab/nufftax/tree/custom-kernel-spread)
+            for a pure-JAX implementation of the
+            [`finufft`](https://finufft.readthedocs.io) algorithm,
+            or [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft) for
+            calling `finufft` directly via `jax.ffi`.
             Used only when `IndependentAtomVolume.kernel_fns` are type
             `AbstractFourierOperator`.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
-            See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
+            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation. If a 2-tuple is passed, `upsample_factor[0]` is
             used for the forward pass and `upsample_factor[1]` is used for the
             backward pass.
         - `eps`:
             Controls speed / accuracy tradeoff.
-            See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
+            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation.
-        """
+        """  # noqa: E501
         if sampling_mode not in ["average", "point"]:
             raise ValueError(
                 "`sampling_mode` in `IndependentAtomRenderFn` "
@@ -494,8 +499,11 @@ class IndependentAtomProjection(
 
         - `backend`:
             The backend for non-uniform FFT computation. This is either
-            `nufftax` for a pure-JAX implementation of FINUFFT,
-            or `jax-finufft` for calling FINUFFT directly.
+            [`nufftax`](https://github.com/GragasLab/nufftax/tree/custom-kernel-spread)
+            for a pure-JAX implementation of the
+            [`finufft`](https://finufft.readthedocs.io) algorithm,
+            or [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft) for
+            calling `finufft` directly via `jax.ffi`.
             Used only when `IndependentAtomVolume.kernel_fns` are type
             `AbstractFourierOperator`.
         - `sampling_mode`:
@@ -510,18 +518,18 @@ class IndependentAtomProjection(
             for reducing aliasing.
         - `upsample_factor`:
             How much to upsample the grid on which atoms are spread onto.
-            See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
+            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation. If a 2-tuple is passed, `upsample_factor[0]` is
             used for the forward pass and `upsample_factor[1]` is used for the
             backward pass.
         - `eps`:
             Controls speed / accuracy tradeoff.
-            See [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft)
+            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation.
         - `shape`:
             If given, first compute the image at `shape`, then
             pad or crop to `image_config.padded_shape`.
-        """
+        """  # noqa: E501
         if sampling_mode not in ["average", "point"]:
             raise ValueError(
                 "`sampling_mode` in `IndependentAtomProjection` "
@@ -571,15 +579,15 @@ class IndependentAtomProjection(
         pixel_size = image_config.pixel_size
         shape = image_config.padded_shape if self.shape is None else self.shape
         if self.block_size > 1:
-            shape_u, pixel_size_u = (
+            shape_b, pixel_size_b = (
                 (self.block_size * shape[0], self.block_size * shape[1]),
                 pixel_size / self.block_size,
             )
             frequency_grid = make_frequency_grid(
-                shape_u, pixel_size_u, outputs_rfftfreqs=False
+                shape_b, pixel_size_b, outputs_rfftfreqs=False
             )
         else:
-            shape_u, pixel_size_u = shape, pixel_size
+            shape_b, pixel_size_b = shape, pixel_size
             frequency_grid = (
                 image_config.get_frequency_grid(padding=True, physical=True, full=True)
                 if shape == image_config.padded_shape
@@ -589,8 +597,8 @@ class IndependentAtomProjection(
         return project_impl(
             volume_representation.positions,
             volume_representation.kernel_fns,
-            shape=shape_u,
-            pixel_size=pixel_size_u,
+            shape=shape_b,
+            pixel_size=pixel_size_b,
             backend=self.backend,
             frequency_grid=frequency_grid,
             sampling_mode=self.sampling_mode,
@@ -620,6 +628,8 @@ def _standardize_upsampfac(
 
 def _check_kernel_fns(
     kernel_pytree: PyTree[AbstractFourierOperator] | PyTree[AbstractRealOperator],
+    *,
+    spatial_dim: int,
 ) -> tuple[bool, Callable]:
     kernel_list = jax.tree.leaves(
         kernel_pytree,
@@ -628,15 +638,35 @@ def _check_kernel_fns(
     if all(isinstance(kernel, AbstractRealOperator) for kernel in kernel_list):
         is_real_space = True
         is_leaf = lambda x: isinstance(x, AbstractRealOperator)
+        for kernel in kernel_list:
+            if 1 not in kernel.spatial_dims:
+                raise ValueError(
+                    "Found that `IndependentAtomVolume.kernel_fns` were "
+                    "`AbstractRealOperator`s, but "
+                    "one or more kernel did not support 1-D arrays as input. "
+                    "The `AbstractRealOperator.spatial_dims` list must include `1` "
+                    "to indicate support for 1D arrays."
+                )
     elif all(isinstance(kernel, AbstractFourierOperator) for kernel in kernel_list):
         is_real_space = False
         is_leaf = lambda x: isinstance(x, AbstractFourierOperator)
+        for kernel in kernel_list:
+            if spatial_dim not in kernel.spatial_dims:
+                raise ValueError(
+                    "Found that `IndependentAtomVolume.kernel_fns` were "
+                    "`AbstractFourierOperator`s, but "
+                    f"one or more kernel did not support {spatial_dim}-D arrays as "
+                    "input. The `AbstractFourierOperator.spatial_dims` list must "
+                    f"include `{spatial_dim}` to indicate support for {spatial_dim}-D "
+                    "arrays."
+                )
     else:
         raise ValueError(
             "Found that `IndependentAtomVolume.kernel_fns` was not a "
             "PyTree containing only `AbstractFourierOperator`s or "
             "`AbstractRealOperator`s."
         )
+
     return is_real_space, is_leaf
 
 
@@ -654,48 +684,44 @@ def _project_postprocess(
 ) -> Inexact[Array, "_ _"]:
     reduce_shape = tuple(s // block_size for s in projection_out.shape)
     assert len(reduce_shape) == 2
-    if is_real_space:
-        # Optimized code path for case where `render_out`
-        # is in real-space
-        raise NotImplementedError()
-    else:
-        # ... and fourier-space
-        projection_fft = projection_out
-        if sampling_mode == "average":
-            antialias_fn = FourierSinc(box_width=pixel_size)
-            projection_fft *= antialias_fn(frequency_grid)
-        if block_size % 2 == 0:
-            projection_fft = _phase_shift_correct(
-                projection_fft,
-                block_size=block_size,
-                target_shape=reduce_shape,
-                pixel_size=pixel_size,
-                frequency_grid=frequency_grid,
-            )
-        projection_fft = convert_fftn_to_rfftn(projection_fft, mode="real")
-        # Block average and return
-        block_average_fn = lambda x, factor: (
-            block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
-            / factor**x.ndim
+    # Code path is the same for real-space and fourier-space
+    del is_real_space
+    projection_fft = projection_out
+    if sampling_mode == "average":
+        antialias_fn = FourierSinc(box_width=pixel_size)
+        projection_fft *= antialias_fn(frequency_grid)
+    if block_size % 2 == 0:
+        projection_fft = _phase_shift_correct(
+            projection_fft,
+            block_size=block_size,
+            target_shape=reduce_shape,
+            pixel_size=pixel_size,
+            frequency_grid=frequency_grid,
         )
-        if output_shape == reduce_shape:
-            if block_size > 1:
-                projection = block_average_fn(
-                    irfftn(projection_fft, s=compute_shape), block_size
-                )
-                return projection if outputs_real_space else rfftn(projection)
-            else:
-                return (
-                    irfftn(projection_fft, s=output_shape)
-                    if outputs_real_space
-                    else projection_fft
-                )
-        else:
-            projection = irfftn(projection_fft, s=compute_shape)
-            if block_size > 1:
-                projection = block_average_fn(projection, block_size)
-            projection = resize_with_crop_or_pad(projection, output_shape)
+    projection_fft = convert_fftn_to_rfftn(projection_fft, mode="real")
+    # Block average and return
+    block_average_fn = lambda x, factor: (
+        block_reduce_downsample(x, factor, jax.lax.add, center_correct=False)
+        / factor**x.ndim
+    )
+    if output_shape == reduce_shape:
+        if block_size > 1:
+            projection = block_average_fn(
+                irfftn(projection_fft, s=compute_shape), block_size
+            )
             return projection if outputs_real_space else rfftn(projection)
+        else:
+            return (
+                irfftn(projection_fft, s=output_shape)
+                if outputs_real_space
+                else projection_fft
+            )
+    else:
+        projection = irfftn(projection_fft, s=compute_shape)
+        if block_size > 1:
+            projection = block_average_fn(projection, block_size)
+        projection = resize_with_crop_or_pad(projection, output_shape)
+        return projection if outputs_real_space else rfftn(projection)
 
 
 def project_impl(
@@ -713,8 +739,7 @@ def project_impl(
     output_shape: tuple[int, int],
     outputs_real_space: bool,
 ) -> Array:
-
-    is_real_space, is_leaf = _check_kernel_fns(kernel_fns)
+    is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=2)
 
     def real_impl(
         _shape: tuple[int, int],
@@ -722,11 +747,25 @@ def project_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
-        # nspread = _eps_to_nspread(eps)
-        raise NotImplementedError(
-            "Projections in real-space using the `IndependentAtomProjection` is not yet "
-            "implemented."
+        nspread = _eps_to_nspread(eps)
+        u = upsampfac[0]
+        shape_u = (int(u * _shape[0]), int(u * _shape[1]))
+        (ny, nx), num_atoms = _shape, _positions.shape[0]
+        box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
+        xy = 2 * jnp.pi * _positions[:, :2] / box_xy
+        projection = spread_2d(
+            x=xy[:, 0],
+            y=xy[:, 1],
+            c=jnp.ones(num_atoms, dtype=float),
+            nf1=shape_u[1],
+            nf2=shape_u[0],
+            kernel_params=Kernel(
+                nspread=nspread,
+                phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_ps / u) * _z),
+            ),
         )
+        indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
+        return fftn(projection)[indices_y, indices_x]
 
     def fourier_impl(
         _shape: tuple[int, int],
@@ -790,32 +829,26 @@ def _render_postprocess(
     outputs_rfft: bool,
     fftshifted: bool,
 ) -> Inexact[Array, "_ _ _"]:
-    if is_real_space:
-        # Optimized code path for case where `render_out`
-        # is in real-space
-        raise NotImplementedError()
+    # Code path is the same for real-space and fourier-space
+    del is_real_space
+    render_fft = render_out
+    if sampling_mode == "average":
+        antialias_fn = FourierSinc(box_width=voxel_size)
+        render_fft *= antialias_fn(frequency_grid)
+    if outputs_real_space:
+        return ifftn(jnp.fft.ifftshift(render_fft)).real
     else:
-        # ... and fourier-space
-        render_fft = render_out
-        if sampling_mode == "average":
-            antialias_fn = FourierSinc(box_width=voxel_size)
-            render_fft *= antialias_fn(frequency_grid)
-        if outputs_real_space:
-            return ifftn(jnp.fft.ifftshift(render_fft)).real
-        else:
-            if outputs_rfft:
-                render_fft = convert_fftn_to_rfftn(
-                    jnp.fft.ifftshift(render_fft), mode="real"
-                )
-                if fftshifted:
-                    return jnp.fft.fftshift(render_fft, axes=(0, 1))
-                else:
-                    return render_fft
+        if outputs_rfft:
+            render_fft = convert_fftn_to_rfftn(jnp.fft.ifftshift(render_fft), mode="real")
+            if fftshifted:
+                return jnp.fft.fftshift(render_fft, axes=(0, 1))
             else:
-                if fftshifted:
-                    return render_fft
-                else:
-                    return jnp.fft.ifftshift(render_fft)
+                return render_fft
+        else:
+            if fftshifted:
+                return render_fft
+            else:
+                return jnp.fft.ifftshift(render_fft)
 
 
 def render_impl(
@@ -833,8 +866,7 @@ def render_impl(
     outputs_rfft: bool,
     fftshifted: bool,
 ) -> Array:
-
-    is_real_space, is_leaf = _check_kernel_fns(kernel_fns)
+    is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=3)
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -842,11 +874,27 @@ def render_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
-        # nspread = _eps_to_nspread(eps)
-        raise NotImplementedError(
-            "Rendering in real-space using the `IndependentAtomRenderFn` is not yet "
-            "implemented."
+        nspread = _eps_to_nspread(eps)
+        u = upsampfac[0]
+        shape_u = (int(u * _shape[0]), int(u * _shape[1]), int(u * _shape[2]))
+        (nz, ny, nx), num_atoms = _shape, _positions.shape[0]
+        box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
+        xyz = 2 * jnp.pi * _positions / box_xyz
+        projection = spread_3d(
+            x=xyz[:, 0],
+            y=xyz[:, 1],
+            z=xyz[:, 2],
+            c=jnp.ones(num_atoms, dtype=float),
+            nf1=shape_u[2],
+            nf2=shape_u[1],
+            nf3=shape_u[0],
+            kernel_params=Kernel(
+                nspread=nspread,
+                phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_vs / u) * _z),
+            ),
         )
+        indices_z, indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
+        return fftn(projection)[indices_z, indices_y, indices_x]
 
     def fourier_impl(
         _shape: tuple[int, int, int],
@@ -1014,3 +1062,28 @@ def _eps_to_nspread(eps: float) -> int:
     max_nspread = 16
     log_tol = -math.log10(max(eps, 1e-16))
     return max(2, min(int(math.ceil(log_tol + 1)), max_nspread))
+
+
+def _build_extraction_mesh(shape: tuple[int, ...], shape_ds: tuple[int, ...]):
+    """Build indices to extract modes from FFT output."""
+
+    assert len(shape) == len(shape_ds)
+    assert len(shape) in [2, 3]
+    indices_1d = tuple(
+        _build_extraction_indices_1d(dim, dim_ds) for dim, dim_ds in zip(shape, shape_ds)
+    )
+    return jnp.meshgrid(*indices_1d, indexing="ij")
+
+
+def _build_extraction_indices_1d(dim: int, dim_ds: int):
+    """Build indices to extract modes from FFT output. Adapted from `nufftax`"""
+    q_min = -(dim_ds // 2)
+    q_max = (dim_ds - 1) // 2
+
+    idx_pos = jnp.arange(q_max + 1)
+    idx_neg = jnp.arange(dim + q_min, dim)
+
+    # `modeord = 1` case
+    indices = jnp.concatenate([idx_pos, idx_neg])
+
+    return indices

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -73,13 +73,8 @@ class PengScatteringFactor(AbstractFourierOperator, strict=True):
         self.b = jnp.asarray(b, dtype=float)
         self.b_factor = None if b_factor is None else jnp.asarray(b_factor, dtype=float)
 
-    def __call__(
-        self,
-        frequency_grid: (
-            Float[Array, "y_dim x_dim 2"] | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
-    ):
-        q_squared = jnp.sum(frequency_grid**2, axis=-1)
+    def __call__(self, frequencies: Float[Array, "... 2"] | Float[Array, "... 3"]):
+        q_squared = jnp.sum(frequencies**2, axis=-1)
         b_factor = 0.0 if self.b_factor is None else error_if_not_positive(self.b_factor)
         gaussian_fn = lambda _a, _b: _a * jnp.exp(-0.25 * (_b + b_factor) * q_squared)
         return jnp.sum(
@@ -106,11 +101,9 @@ class LobatoScatteringFactor(AbstractFourierOperator, strict=True):
 
     def __call__(
         self,
-        frequency_grid: (
-            Float[Array, "y_dim x_dim 2"] | Float[Array, "z_dim y_dim x_dim 3"]
-        ),
+        frequencies: Float[Array, "... 2"] | Float[Array, "... 3"],
     ):
-        q_squared = jnp.sum(frequency_grid**2, axis=-1)
+        q_squared = jnp.sum(frequencies**2, axis=-1)
         hydrogenic_fn = lambda _a, _b: (
             _a * (2 + _b * q_squared) / (1 + _b * q_squared) ** 2
         )
@@ -1190,11 +1183,11 @@ class _Erf(AbstractRealOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1]
 
     @override
-    def __call__(self, coordinate_grid: Float[Array, " x_dim"]) -> Array:
+    def __call__(self, coordinates: Float[Array, " dim"]) -> Float[Array, " dim"]:
         scaling = 1.0 / jnp.sqrt(2 * self.variance)
         left, right = (
-            coordinate_grid - self.pixel_size / 2,
-            coordinate_grid + self.pixel_size / 2,
+            coordinates - self.pixel_size / 2,
+            coordinates + self.pixel_size / 2,
         )
         weight = (1 / (2 * self.pixel_size)) * (
             jsp.special.erf(scaling * right) - jsp.special.erf(scaling * left)

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Callable, Sequence
-from typing import ClassVar, Literal, Self, TypeVar
+from typing import Any, ClassVar, Literal, Self, TypeVar
 from typing_extensions import override
 
 import equinox as eqx
@@ -357,8 +357,9 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
 
     backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
-    upsample_factor: tuple[float, float]
+    upsample_factor: float
     eps: float
+    options: dict[str, Any]
 
     def __init__(
         self,
@@ -367,8 +368,9 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         *,
         backend: Literal["nufftax", "jax-finufft"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
-        upsample_factor: int | float | tuple[float, float] = 2.0,
+        upsample_factor: int | float = 2.0,
         eps: float = 1e-6,
+        options: dict[str, Any] = {},
     ):
         """**Arguments:**
 
@@ -400,6 +402,10 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             Controls speed / accuracy tradeoff.
             See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation.
+        - `options`:
+            A dictionary of options for advanced usage. This is passed directly to the underlying
+            non-uniform FFT implementation if kernels are in fourier-space, or to the `nufftax`
+            spreading function if kernels are in real-space.
         """  # noqa: E501
         if sampling_mode not in ["average", "point"]:
             raise ValueError(
@@ -418,8 +424,9 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         self.voxel_size = jnp.asarray(voxel_size, dtype=float)
         self.backend = backend
         self.sampling_mode = sampling_mode
-        self.upsample_factor = _standardize_upsampfac(upsample_factor)
+        self.upsample_factor = float(upsample_factor)
         self.eps = eps
+        self.options = options
 
     @override
     def __call__(
@@ -464,6 +471,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             outputs_real_space=outputs_real_space,
             outputs_rfft=outputs_rfft,
             fftshifted=fftshifted,
+            options=self.options,
         )
 
 
@@ -478,10 +486,11 @@ class IndependentAtomProjection(
 ):
     backend: Literal["nufftax", "jax-finufft"]
     sampling_mode: Literal["average", "point"]
-    upsample_factor: tuple[float, float]
+    upsample_factor: float
     block_size: int
     eps: float
     shape: tuple[int, int] | None
+    options: dict[str, Any]
 
     outputs_ewald_sphere: ClassVar[bool] = False
 
@@ -491,9 +500,10 @@ class IndependentAtomProjection(
         backend: Literal["jax-finufft", "nufftax"] = "nufftax",
         sampling_mode: Literal["average", "point"] = "average",
         block_size: int = 1,
-        upsample_factor: float | tuple[float, float] = 2.0,
+        upsample_factor: int | float = 2.0,
         eps: float = 1e-6,
         shape: tuple[int, int] | None = None,
+        options: dict[str, Any] = {},
     ):
         """**Arguments:**
 
@@ -529,6 +539,10 @@ class IndependentAtomProjection(
         - `shape`:
             If given, first compute the image at `shape`, then
             pad or crop to `image_config.padded_shape`.
+        - `options`:
+            A dictionary of options for advanced usage. This is passed directly to the underlying
+            non-uniform FFT implementation if kernels are in fourier-space, or to the `nufftax`
+            spreading function if kernels are in real-space.
         """  # noqa: E501
         if sampling_mode not in ["average", "point"]:
             raise ValueError(
@@ -547,8 +561,9 @@ class IndependentAtomProjection(
         self.sampling_mode = sampling_mode
         self.block_size = block_size
         self.shape = shape
-        self.upsample_factor = _standardize_upsampfac(upsample_factor)
+        self.upsample_factor = float(upsample_factor)
         self.eps = eps
+        self.options = options
 
     @override
     def integrate(
@@ -607,23 +622,12 @@ class IndependentAtomProjection(
             block_size=self.block_size,
             output_shape=image_config.padded_shape,
             outputs_real_space=outputs_real_space,
+            options=self.options,
         )
 
 
 IndependentAtomProjection.__doc__ = f"""Integrate atomic parametrization of a volume "
 "onto the exit plane from an `IndependentAtomVolume`. {_REAL_VS_FOURIER_DOC}"""
-
-
-def _standardize_upsampfac(
-    upsample_factor: int | float | tuple[float, float],
-) -> tuple[float, float]:
-    if isinstance(upsample_factor, (float, int)):
-        u = float(upsample_factor)
-        return (u, u)
-    else:
-        u = tuple(float(fac) for fac in upsample_factor)
-        assert len(u) == 2
-        return u
 
 
 def _check_kernel_fns(
@@ -734,10 +738,11 @@ def project_impl(
     frequency_grid: Float[Array, "_ _ 2"],
     sampling_mode: Literal["average", "point"],
     eps: float,
-    upsampfac: tuple[float, float],
+    upsampfac: float,
     block_size: int,
     output_shape: tuple[int, int],
     outputs_real_space: bool,
+    options: dict[str, Any],
 ) -> Array:
     is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=2)
 
@@ -747,8 +752,8 @@ def project_impl(
         _positions: Float[Array, "_ 3"],
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
+        u = upsampfac
         nspread = _eps_to_nspread(eps)
-        u = upsampfac[0]
         shape_u = (int(u * _shape[0]), int(u * _shape[1]))
         (ny, nx), num_atoms = _shape, _positions.shape[0]
         box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
@@ -763,6 +768,7 @@ def project_impl(
                 nspread=nspread,
                 phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_ps / u) * _z),
             ),
+            **options,
         )
         indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
         return fftn(projection)[indices_y, indices_x]
@@ -787,6 +793,7 @@ def project_impl(
                     backend=backend,
                     eps=eps,
                     upsampfac=upsampfac,
+                    options=options,
                 )
                 / _ps**2
             )
@@ -861,10 +868,11 @@ def render_impl(
     frequency_grid: Float[Array, "_ _ _ 3"],
     sampling_mode: Literal["average", "point"],
     eps: float,
-    upsampfac: tuple[float, float],
+    upsampfac: float,
     outputs_real_space: bool,
     outputs_rfft: bool,
     fftshifted: bool,
+    options: dict[str, Any],
 ) -> Array:
     is_real_space, is_leaf = _check_kernel_fns(kernel_fns, spatial_dim=3)
 
@@ -875,7 +883,7 @@ def render_impl(
         _kernel_fn: AbstractRealOperator,
     ) -> Array:
         nspread = _eps_to_nspread(eps)
-        u = upsampfac[0]
+        u = upsampfac
         shape_u = (int(u * _shape[0]), int(u * _shape[1]), int(u * _shape[2]))
         (nz, ny, nx), num_atoms = _shape, _positions.shape[0]
         box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
@@ -892,6 +900,7 @@ def render_impl(
                 nspread=nspread,
                 phi=lambda _z: eqx.filter_vmap(_kernel_fn)((_vs / u) * _z),
             ),
+            **options,
         )
         indices_z, indices_y, indices_x = _build_extraction_mesh(shape_u, _shape)
         return fftn(projection)[indices_z, indices_y, indices_x]
@@ -914,6 +923,7 @@ def render_impl(
                 backend=backend,
                 eps=eps,
                 upsampfac=upsampfac,
+                options=options,
             )
             / _vs**3
         )
@@ -969,12 +979,12 @@ def _phase_shift_correct(
     )
 
 
-def _make_opts(upsampfac: tuple[float, float]):
+def _make_jax_finufft_opts(upsampfac: float):
     assert NestedOpts is not None
     assert Opts is not None
     return NestedOpts(
-        forward=Opts(upsampfac=upsampfac[0], gpu_upsampfac=upsampfac[0]),
-        backward=Opts(upsampfac=upsampfac[1], gpu_upsampfac=upsampfac[1]),
+        forward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
+        backward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
     )
 
 
@@ -985,7 +995,8 @@ def _nufft2d1(
     *,
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
-    upsampfac: tuple[float, float],
+    upsampfac: float,
+    options: dict[str, Any],
 ):
     if backend == "jax-finufft":
         if jax_finufft is None:
@@ -996,14 +1007,13 @@ def _nufft2d1(
                 "See https://github.com/flatironinstitute/jax-finufft "
                 "for installation instructions."
             ) from JAX_FINUFFT_IMPORT_ERROR
+        opts = (
+            options.pop("opts")
+            if "opts" in options
+            else _make_jax_finufft_opts(upsampfac)
+        )
         return jax_finufft.nufft1(
-            shape,
-            source,
-            xy[:, 1],
-            xy[:, 0],
-            eps=eps,
-            iflag=-1,
-            opts=_make_opts(upsampfac),
+            shape, source, xy[:, 1], xy[:, 0], eps=eps, iflag=-1, opts=opts, **options
         )
     else:
         return nufftax.nufft2d1(
@@ -1013,6 +1023,7 @@ def _nufft2d1(
             y=xy[:, 1],
             eps=eps,
             isign=-1,
+            **options,
         )
 
 
@@ -1023,7 +1034,8 @@ def _nufft3d1(
     *,
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
-    upsampfac: tuple[float, float],
+    upsampfac: float,
+    options: dict[str, Any],
 ):
     if backend == "jax-finufft":
         if jax_finufft is None:
@@ -1034,6 +1046,11 @@ def _nufft3d1(
                 "See https://github.com/flatironinstitute/jax-finufft "
                 "for installation instructions."
             ) from JAX_FINUFFT_IMPORT_ERROR
+        opts = (
+            options.pop("opts")
+            if "opts" in options
+            else _make_jax_finufft_opts(upsampfac)
+        )
         return jax_finufft.nufft1(
             shape,
             source,
@@ -1042,7 +1059,8 @@ def _nufft3d1(
             xyz[:, 0],
             eps=eps,
             iflag=-1,
-            opts=_make_opts(upsampfac),
+            opts=opts,
+            **options,
         )
     else:
         return nufftax.nufft3d1(
@@ -1053,6 +1071,7 @@ def _nufft3d1(
             z=xyz[:, 2],
             eps=eps,
             isign=-1,
+            **options,
         )
 
 

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -639,7 +639,7 @@ def _maybe_gaussians_to_erf(
         if all(isinstance(kernel, RealGaussian) for kernel in kernel_list):
             return (
                 jax.tree.map(
-                    lambda x: _IntegratedRealGaussian.from_gaussians(
+                    lambda x: _IntegratedRealGaussian.from_gaussian(
                         x, pixel_size / upsampfac
                     ),
                     kernel_pytree,
@@ -1105,7 +1105,7 @@ class _IntegratedRealGaussian(AbstractRealOperator, strict=True):
     spatial_dims: ClassVar[list[int]] = [1]
 
     @classmethod
-    def from_gaussians(cls, fn: RealGaussian, pixel_size: Float[Array, ""]):
+    def from_gaussian(cls, fn: RealGaussian, pixel_size: Float[Array, ""]):
         return cls(
             amplitude=fn.amplitude,
             variance=fn.variance,

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -3,11 +3,12 @@ Real voxel-based representations of a volume.
 """
 
 import math
-from typing import ClassVar, Self, cast
+from typing import ClassVar, Literal, Self, cast
 from typing_extensions import override
 
 import equinox as eqx
 import jax.numpy as jnp
+import nufftax
 from jaxtyping import Array, Float
 
 from ...jax_util import NDArrayLike
@@ -18,12 +19,12 @@ from .base_volume import AbstractVolumeIntegrator, AbstractVoxelVolume, Projecti
 
 
 try:
-    from jax_finufft import nufft1
+    import jax_finufft
     from jax_finufft.options import NestedOpts, Opts
 
     JAX_FINUFFT_IMPORT_ERROR = None
 except ModuleNotFoundError as err:
-    nufft1, Opts, NestedOpts = None, None, None
+    jax_finufft, Opts, NestedOpts = None, None, None
     JAX_FINUFFT_IMPORT_ERROR = err
 
 
@@ -213,23 +214,30 @@ class RealVoxelProjection(
     """Integrate points onto the exit plane using non-uniform FFTs."""
 
     eps: float
+    backend: Literal["jax-finufft", "nufftax"]
 
     outputs_ewald_sphere: ClassVar[bool] = False
 
-    def __init__(self, *, eps: float = 1e-6):
+    def __init__(
+        self, *, backend: Literal["jax-finufft", "nufftax"] = "nufftax", eps: float = 1e-6
+    ):
         """**Arguments:**
 
+        - `backend`:
+            The backend for non-uniform FFT computation. This is either
+            `nufftax` for a pure-JAX implementation of FINUFFT,
+            or `jax-finufft` for calling FINUFFT directly.
         - `eps`:
             See [`nufftax`](https://github.com/GragasLab/nufftax)
             for documentation.
         """
-        if nufft1 is None:
-            raise RuntimeError(
-                "Tried to use the `RealVoxelProjection` "
-                "class, but `jax-finufft` is not installed. "
-                "See https://github.com/flatironinstitute/jax-finufft "
-                "for installation instructions."
-            ) from JAX_FINUFFT_IMPORT_ERROR
+        if backend not in ["jax-finufft", "nufftax"]:
+            raise ValueError(
+                "`backend` in `IndependentAtomRenderFn` "
+                "must be either 'jax-finufft' or 'nufftax'. Got "
+                f"`backend = {backend}`."
+            )
+        self.backend = backend
         self.eps = eps
 
     @override
@@ -267,6 +275,7 @@ class RealVoxelProjection(
             volume_representation.weights,
             volume_representation.coordinate_list_in_pixels,
             image_config.padded_shape,
+            backend=self.backend,
             eps=self.eps,
         )
         # Scale by voxel size for units
@@ -278,8 +287,13 @@ class RealVoxelProjection(
         )
 
 
-def _project_with_nufft(weights, coordinate_list, shape, eps=1e-6):
-    assert nufft1 is not None
+def _project_with_nufft(
+    weights,
+    coordinate_list,
+    shape,
+    backend: Literal["jax-finufft", "nufftax"],
+    eps: float,
+):
     weights, coordinate_list = (
         jnp.asarray(weights, dtype=complex),
         jnp.asarray(coordinate_list, dtype=float),
@@ -292,13 +306,31 @@ def _project_with_nufft(weights, coordinate_list, shape, eps=1e-6):
     coordinates_periodic = 2 * jnp.pi * coordinates_xy / box_xy
     # Unpack and compute
     x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
-    fourier_projection = nufft1(
-        shape, weights, y, x, eps=eps, iflag=-1, opts=_make_opts()
-    )
+    if backend == "jax-finufft":
+        if jax_finufft is None:
+            raise RuntimeError(
+                "Tried to use "
+                "`RealVoxelProjection(..., backend='jax-finufft')`, "
+                "but `jax-finufft` is not installed. "
+                "See https://github.com/flatironinstitute/jax-finufft "
+                "for installation instructions."
+            ) from JAX_FINUFFT_IMPORT_ERROR
+        projection_fft = jax_finufft.nufft1(
+            shape, weights, y, x, eps=eps, iflag=-1, opts=_make_opts()
+        )
+    else:
+        projection_fft = nufftax.nufft2d1(
+            n_modes=shape[::-1],
+            c=weights,
+            x=x,
+            y=y,
+            eps=eps,
+            isign=-1,
+        )
     # Shift zero frequency component to corner
-    fourier_projection = jnp.fft.ifftshift(fourier_projection)
+    projection_fft = jnp.fft.ifftshift(projection_fft)
     # Convert to rfftn output
-    return convert_fftn_to_rfftn(fourier_projection, mode="real")
+    return convert_fftn_to_rfftn(projection_fft, mode="real")
 
 
 def _make_opts():

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -306,7 +306,7 @@ def _project_with_nufft(
     # Normalize coordinates betweeen -pi and pi
     ny, nx = shape
     box_xy = jnp.asarray((nx, ny))
-    coordinates_periodic = 2 * jnp.pi * coordinates_xy / box_xy
+    coordinates_periodic = (2 * jnp.pi * coordinates_xy / box_xy) + jnp.pi
     # Unpack and compute
     x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     if backend == "jax-finufft":
@@ -323,17 +323,10 @@ def _project_with_nufft(
         )
     else:
         projection_fft = nufftax.nufft2d1(
-            n_modes=shape[::-1],
-            c=weights,
-            x=x,
-            y=y,
-            eps=eps,
-            isign=-1,
+            n_modes=shape[::-1], c=weights, x=x, y=y, eps=eps, isign=-1
         )
-    # Shift zero frequency component to corner
-    projection_fft = jnp.fft.ifftshift(projection_fft)
     # Convert to rfftn output
-    return convert_fftn_to_rfftn(projection_fft, mode="real")
+    return convert_fftn_to_rfftn(jnp.fft.ifftshift(projection_fft), mode="real")
 
 
 def _make_opts():

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -225,12 +225,15 @@ class RealVoxelProjection(
 
         - `backend`:
             The backend for non-uniform FFT computation. This is either
-            `nufftax` for a pure-JAX implementation of FINUFFT,
-            or `jax-finufft` for calling FINUFFT directly.
+            [`nufftax`](https://github.com/GragasLab/nufftax/tree/custom-kernel-spread)
+            for a pure-JAX implementation of the
+            [`finufft`](https://finufft.readthedocs.io) algorithm,
+            or [`jax-finufft`](https://github.com/flatironinstitute/jax-finufft) for
+            calling `finufft` directly via `jax.ffi`.
         - `eps`:
-            See [`nufftax`](https://github.com/GragasLab/nufftax)
+            See [`finufft`](https://finufft.readthedocs.io/en/latest/opts.html#options-parameters-cpu)
             for documentation.
-        """
+        """  # noqa: E501
         if backend not in ["jax-finufft", "nufftax"]:
             raise ValueError(
                 "`backend` in `IndependentAtomRenderFn` "

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -303,10 +303,13 @@ def _project_with_nufft(
     )
     # Get x and y coordinates
     coordinates_xy = coordinate_list[:, :2]
-    # Normalize coordinates betweeen -pi and pi
+    # Normalize coordinates to [-pi, pi) such that the center voxel (index N//2)
+    # maps to theta = 2*pi*(N//2)/N.  For even N this equals pi (same as before);
+    # for odd N it equals pi*(1 - 1/N).
     ny, nx = shape
-    box_xy = jnp.asarray((nx, ny))
-    coordinates_periodic = (2 * jnp.pi * coordinates_xy / box_xy) + jnp.pi
+    box_xy = jnp.asarray((nx, ny), dtype=float)
+    center_xy = jnp.asarray([nx // 2, ny // 2], dtype=float)
+    coordinates_periodic = 2 * jnp.pi * (coordinates_xy + center_xy) / box_xy
     # Unpack and compute
     x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     if backend == "jax-finufft":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "equinox>=0.11.0",
     "jaxtyping>=0.2.23",
     "lineax",
-    "nufftax",
+    "nufftax>=0.5.1",
     "mrcfile",
     "starfile",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "equinox>=0.11.0",
     "jaxtyping>=0.2.23",
     "lineax",
+    "nufftax",
     "mrcfile",
     "starfile",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "equinox>=0.11.0",
     "jaxtyping>=0.2.23",
     "lineax",
-    "nufftax>=0.5.1",
+    "nufftax>=0.6.0",
     "mrcfile",
     "starfile",
     "pandas",

--- a/tests/test_image_config.py
+++ b/tests/test_image_config.py
@@ -1,6 +1,63 @@
+import math
+
 import cryojax.simulator as cxs
 import equinox as eqx
 import pytest
+
+
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_pad_scale_one_equals_shape(cls_name):
+    cls = getattr(cxs, cls_name)
+    shape = (64, 64)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(shape, pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=1.0, **extra)
+    assert cfg.padded_shape == shape
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+@pytest.mark.parametrize("pad_scale", [1.5, 2.0])
+def test_pad_scale_greater_than_one(cls_name, pad_scale):
+    cls = getattr(cxs, cls_name)
+    shape = (64, 64)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(
+        shape, pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=pad_scale, **extra
+    )
+    for s, p in zip(shape, cfg.padded_shape):
+        assert p >= math.ceil(pad_scale * s)
+        assert _is_smooth(p)
+        assert (s % 2) == (p % 2), "parity not preserved"
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_explicit_padded_shape_overrides_pad_scale(cls_name):
+    cls = getattr(cxs, cls_name)
+    shape, padded_shape = (64, 64), (80, 80)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(
+        shape,
+        pixel_size=1.0,
+        voltage_in_kilovolts=300.0,
+        padded_shape=padded_shape,
+        pad_scale=1.5,
+        **extra,
+    )
+    assert cfg.padded_shape == padded_shape
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_pad_scale_less_than_one_raises(cls_name):
+    cls = getattr(cxs, cls_name)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    with pytest.raises(ValueError, match="pad_scale"):
+        cls((64, 64), pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=0.5, **extra)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_image_config.py
+++ b/tests/test_image_config.py
@@ -33,7 +33,6 @@ def test_pad_scale_greater_than_one(cls_name, pad_scale):
     for s, p in zip(shape, cfg.padded_shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-        assert (s % 2) == (p % 2), "parity not preserved"
 
 
 @pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -15,7 +15,7 @@ def voxel_info(sample_mrc_path):
 
 @pytest.fixture
 def voxel_volume(voxel_info):
-    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(voxel_info[0], pad_scale=1.3)
+    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(voxel_info[0], pad_scale=2.0)
 
 
 @pytest.fixture
@@ -148,7 +148,7 @@ def test_rotation_fn(basic_config, voxel_volume, use_rfft):
 def test_translation_fn(basic_config, voxel_volume, use_rfft):
     pose_notranslate = cxs.EulerAnglePose()
     pose_translate = cxs.EulerAnglePose(
-        offset_x_in_angstroms=50.0, offset_y_in_angstroms=-30.0
+        offset_x_in_angstroms=10.0, offset_y_in_angstroms=-5.0
     )
 
     image_model_notrans = cxs.make_image_model(
@@ -169,7 +169,7 @@ def test_translation_fn(basic_config, voxel_volume, use_rfft):
         grid = basic_config.get_frequency_grid(physical=True, full=True)
 
     shift_fn = im.PhaseShiftFFT(
-        offset=jnp.array([50.0, -30.0]),
+        offset=jnp.array([10.0, -5.0]),
         frequency_grid=grid,
     )
 
@@ -182,7 +182,7 @@ def test_translation_fn(basic_config, voxel_volume, use_rfft):
     else:
         image_trans = im.ifftn(shift_fn(im.fftn(image_notrans))).real
 
-    np.testing.assert_allclose(image_ref, image_trans)
+    np.testing.assert_allclose(image_ref, image_trans, atol=(0.0 if use_rfft else 5e-4))
 
 
 def _get_correlation(im1, im2):

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -18,7 +18,7 @@ def test_downsample_preserves_sum(shape, downsample_factor):
     upsampled_shape = tuple(downsample_factor * s for s in shape)
     rng_key = jr.key(seed=1234)
     upsampled_image = 2.0 + 1.0 * jr.normal(rng_key, upsampled_shape)
-    image = im.fourier_crop_downsample(upsampled_image, downsample_factor)
+    image = im.fourier_crop_to_shape(upsampled_image, shape)
     np.testing.assert_allclose(image.sum(), upsampled_image.sum())
 
 

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -302,7 +302,6 @@ _fourier_operators_common = [
     im.PeakedFourierGaussian(),
     im.FourierConstant(1.0),
     im.FourierSinc(),
-    im.FourierExp2D(),
     im.CustomFourierOperator(lambda _, a, b: a + b, 1.0, b=1.0),
     im.FourierDC(),
     im.FourierConstant(1.0) + im.FourierConstant(1.0),
@@ -318,7 +317,7 @@ _real_operators_common = [
 ]
 
 _fourier_operators_1d = _fourier_operators_common
-_fourier_operators_2d = _fourier_operators_common
+_fourier_operators_2d = [*_fourier_operators_common, im.FourierExp2D()]
 _fourier_operators_3d = _fourier_operators_common
 _real_operators_1d = [*_real_operators_common, im.RealGaussian(offset=1.0)]
 _real_operators_2d = [*_real_operators_common, im.RealGaussian(offset=(1.0, -1.0))]

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -276,6 +276,61 @@ def test_frc_fsc_jit(shape):
 #     np.testing.assert_allclose(crop_1, crop_2)
 
 
+#
+# query_efficient_grid_size
+#
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(10, 10), (11, 11), (13, 17), (100, 100), (10, 10, 10), (11, 13, 17)],
+)
+def test_query_efficient_grid_size_no_padding(shape):
+    result = im.query_efficient_grid_size(shape)
+    assert len(result) == len(shape)
+    for s, r in zip(shape, result):
+        assert r >= s
+        assert _is_smooth(r)
+
+
+@pytest.mark.parametrize(
+    "shape, pad_scale",
+    [((10, 10), 1.5), ((11, 11), 2.0), ((13, 17), 1.25), ((10, 10, 10), 1.5)],
+)
+def test_query_efficient_grid_size_with_pad_scale(shape, pad_scale):
+    import math
+
+    result = im.query_efficient_grid_size(shape, pad_scale=pad_scale)
+    assert len(result) == len(shape)
+    for s, r in zip(shape, result):
+        assert r >= math.ceil(pad_scale * s)
+        assert _is_smooth(r)
+
+
+@pytest.mark.parametrize(
+    "shape", [(10, 10), (11, 11), (10, 11), (10, 10, 10), (11, 13, 15)]
+)
+def test_query_efficient_grid_size_preserves_parity(shape):
+    result = im.query_efficient_grid_size(shape, pad_scale=1.5, match_parity=True)
+    for s, r in zip(shape, result):
+        assert (s % 2) == (r % 2), f"parity mismatch: shape dim {s}, result dim {r}"
+
+
+def test_query_efficient_grid_size_no_parity_constraint():
+    import math
+
+    shape, pad_scale = (11, 13), 1.5
+    result = im.query_efficient_grid_size(shape, pad_scale=pad_scale, match_parity=False)
+    for s, r in zip(shape, result):
+        assert _is_smooth(r)
+        assert r >= math.ceil(pad_scale * s)
+
+
 def test_operators_instantiate():
     frequency_grid_1d = im.make_1d_frequency_grid(10)
     frequency_grid_2d = im.make_frequency_grid((10, 10))

--- a/tests/test_pose.py
+++ b/tests/test_pose.py
@@ -2,6 +2,7 @@ import cryojax.simulator as cxs
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from cryojax.ndimage import FourierPhaseShifts, make_frequency_grid
 from cryojax.rotations import SO3
 
 
@@ -13,6 +14,24 @@ def test_default_pose_arguments():
     np.testing.assert_allclose(
         euler.rotation.as_matrix(), axis_angle.rotation.as_matrix()
     )
+
+
+@pytest.mark.parametrize(
+    "tx, ty, shape, pixel_size",
+    [
+        (1.5, -2.3, (32, 32), 1.0),
+        (0.0, 4.1, (33, 32), 0.5),
+        (-3.0, 0.0, (32, 33), 2.0),
+    ],
+)
+def test_translation_operator_separable(tx, ty, shape, pixel_size):
+    pose = cxs.EulerAnglePose(tx, ty)
+    # New separable implementation
+    result = pose.compute_translation_operator(shape, jnp.asarray(pixel_size))
+    # Reference: evaluate FourierPhaseShifts on the full 2D rfft frequency grid
+    frequency_grid = make_frequency_grid(shape, pixel_size)
+    expected = FourierPhaseShifts(jnp.asarray([tx, ty]))(frequency_grid)
+    np.testing.assert_allclose(np.asarray(result), np.asarray(expected), atol=1e-6)
 
 
 def test_translation_agreement():

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -65,7 +65,14 @@ def test_fft_atom_bad_instantiation():
     ((1.0, (32, 32)), (1.0, (32, 31)), (1.0, (31, 32)), (1.0, (31, 31))),
 )
 def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
-    if jnufft is not None:
+    for backend in ["jax-finufft", "nufftax"]:
+        if jnufft is None and backend == "jax-finufft":
+            warnings.warn(
+                "Could not test projection method `IndependentAtomProjection`, "
+                "most likely because `jax_finufft` is not installed. "
+                f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
+            )
+            continue
         atom_positions, _, _ = pdb_info
         pixel_size, shape = 0.5, (64, 64)
         image_config = cxs.BasicImageConfig(
@@ -85,19 +92,17 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
                 positions=atom_positions,
                 kernel_fns=im.FourierGaussian(amplitude=amplitude, b_factor=b_factor),
             ),
-            cxs.IndependentAtomProjection(sampling_mode="point", eps=1e-10),
+            cxs.IndependentAtomProjection(
+                backend=backend,  # type: ignore
+                sampling_mode="point",
+                eps=1e-10,
+            ),
         )
         proj_by_gaussians = compute_projection(
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
-    else:
-        warnings.warn(
-            "Could not test projection method `IndependentAtomProjection`, "
-            "most likely because `jax_finufft` is not installed. "
-            f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
-        )
 
 
 @pytest.mark.parametrize(
@@ -105,7 +110,9 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
     ((5.0, 0.5, (64, 64)), (1.0, 0.5, (64, 64)), (2.0, 1.0, (32, 32))),
 )
 def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
-    if jnufft is not None:
+    for backend in ["jax-finufft", "nufftax"]:
+        if jnufft is None and backend == "jax-finufft":
+            continue
         atom_positions, _, _ = pdb_info
         gaussian_volume = cxs.GaussianMixtureVolume(
             atom_positions,
@@ -119,7 +126,7 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
             ),
         )
         gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-        atom_integrator = cxs.IndependentAtomProjection(eps=1e-10)
+        atom_integrator = cxs.IndependentAtomProjection(eps=1e-10, backend=backend)  # type: ignore
         padded_shape = (2 * shape[0], 2 * shape[1])
         image_config = cxs.BasicImageConfig(
             shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=padded_shape
@@ -144,32 +151,40 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
     ),
 )
 def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, block_size):
-    atom_positions, atom_ids, _ = pdb_info
-    positions_by_id, unique_atom_ids = split_atoms_by_element(atom_ids, atom_positions)
-    peng_parameters, peng_parameters_by_id = (
-        PengScatteringFactorParameters(atom_ids),
-        PengScatteringFactorParameters(unique_atom_ids),
-    )
-    gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
-        atom_positions,
-        peng_parameters,
-    )
-    atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
-        positions_by_id,
-        peng_parameters_by_id,
-    )
-    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
-    # Check to make sure the implementations are identical, up to the
-    # nufft (don't include anti-aliasing)
-    gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-    atom_integrator = cxs.IndependentAtomProjection(
-        sampling_mode="average", block_size=block_size, eps=1e-10
-    )
-    proj_by_gaussians = compute_projection(
-        gaussian_volume, gaussian_integrator, image_config
-    )
-    proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
+    for backend in ["jax-finufft", "nufftax"]:
+        if jnufft is None and backend == "jax-finufft":
+            continue
+        atom_positions, atom_ids, _ = pdb_info
+        positions_by_id, unique_atom_ids = split_atoms_by_element(
+            atom_ids, atom_positions
+        )
+        peng_parameters, peng_parameters_by_id = (
+            PengScatteringFactorParameters(atom_ids),
+            PengScatteringFactorParameters(unique_atom_ids),
+        )
+        gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+            atom_positions,
+            peng_parameters,
+        )
+        atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
+            positions_by_id,
+            peng_parameters_by_id,
+        )
+        image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
+        # Check to make sure the implementations are identical, up to the
+        # nufft (don't include anti-aliasing)
+        gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
+        atom_integrator = cxs.IndependentAtomProjection(
+            backend=backend,  # type: ignore
+            sampling_mode="average",
+            block_size=block_size,
+            eps=1e-10,
+        )
+        proj_by_gaussians = compute_projection(
+            gaussian_volume, gaussian_integrator, image_config
+        )
+        proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+        np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -203,6 +203,7 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
             positions_by_id,
             peng_parameters_by_id,
             b_factor_by_element=4.0,
+            use_real_space=False,
         )
         image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
         # Check to make sure the implementations are identical, up to the
@@ -247,7 +248,7 @@ def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
         positions_by_id,
         peng_parameters_by_id,
         b_factor_by_element=10.0,
-        outputs_real_space=True,
+        use_real_space=True,
     )
     image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     # Check to make sure the implementations are identical, up to the
@@ -258,6 +259,7 @@ def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+    # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -231,7 +231,6 @@ def test_fft_projection_peng(pdb_info, pixel_size, shape, upsampfac, eps):
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-        # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
@@ -269,6 +268,7 @@ def test_real_projection_peng_erf(pdb_info, pixel_size, shape):
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+    # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=1e-6)
 
 

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -106,6 +106,44 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
 
 
 @pytest.mark.parametrize(
+    "pixel_size, shape",
+    ((0.5, (64, 64)), (0.5, (64, 63)), (0.5, (63, 64)), (0.5, (63, 63))),
+)
+def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
+    atom_positions, _, _ = pdb_info
+    image_config = cxs.BasicImageConfig(
+        shape,
+        pixel_size,
+        voltage_in_kilovolts=300.0,
+    )
+    amplitude, b_factor = 1.0, 40.0
+    variance = b_factor / (8 * np.pi**2)
+    gaussian_volume, gaussian_integrator = (
+        cxs.GaussianMixtureVolume(
+            atom_positions,
+            amplitudes=amplitude,
+            variances=variance,
+        ),
+        cxs.GaussianMixtureProjection(sampling_mode="average"),
+    )
+    atom_volume, atom_integrator = (
+        cxs.IndependentAtomVolume(
+            positions=atom_positions,
+            kernel_fns=im.RealGaussian(amplitude=amplitude, variance=variance),
+        ),
+        cxs.IndependentAtomProjection(
+            sampling_mode="average", eps=1e-10, upsample_factor=2
+        ),
+    )
+    proj_by_gaussians = compute_projection(
+        gaussian_volume, gaussian_integrator, image_config
+    )
+    proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
+    _plot_image_compare(proj_by_gaussians, proj_by_atom)
+    np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
+
+
+@pytest.mark.parametrize(
     "width, pixel_size, shape",
     ((5.0, 0.5, (64, 64)), (1.0, 0.5, (64, 64)), (2.0, 1.0, (32, 32))),
 )
@@ -366,7 +404,7 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
 #     plt.show()
 
 
-@eqx.filter_jit
+# @eqx.filter_jit
 def compute_projection(
     volume: cxs.AbstractVolumeRepresentation,
     integrator: cxs.AbstractVolumeIntegrator,
@@ -418,10 +456,10 @@ def make_spline(real_voxel_grid):
     )
 
 
-# def _plot_image_compare(im1, im2):
-#     from matplotlib import pyplot as plt
+def _plot_image_compare(im1, im2):
+    from matplotlib import pyplot as plt
 
-#     _, axes = plt.subplots(figsize=(7, 4), ncols=2)
-#     axes[0].imshow(im1)
-#     axes[1].imshow(im2)
-#     plt.show()
+    _, axes = plt.subplots(figsize=(7, 4), ncols=2)
+    axes[0].imshow(im1)
+    axes[1].imshow(im2)
+    plt.show()

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -484,6 +484,58 @@ def compute_projection_at_pose(
     )
 
 
+@pytest.mark.parametrize("upsampfac", (1.25, 2.0))
+def test_fft_atom_projection_custom_upsampfac(upsampfac):
+    """Smoke test: passing a custom upsampfac via options runs without error."""
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.5, -0.5]])
+    shape, pixel_size = (8, 8), 1.0
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
+    atom_volume = cxs.IndependentAtomVolume(
+        positions=positions,
+        kernel_fns=im.FourierGaussian(amplitude=1.0, b_factor=100.0),
+    )
+    atom_integrator = cxs.IndependentAtomProjection(
+        backend="nufftax",
+        sampling_mode="point",
+        eps=1e-6,
+        options={"upsampfac": upsampfac},
+    )
+    result = atom_integrator.integrate(
+        atom_volume, image_config, outputs_real_space=False
+    )
+    assert result.shape == (shape[0], shape[1] // 2 + 1)
+
+
+@pytest.mark.parametrize("upsampfac", (1.25, 2.0))
+def test_fft_atom_projection_custom_upsampfac_jax_finufft(upsampfac):
+    """Smoke test: passing custom opts via options to jax-finufft runs without error."""
+    if jnufft is None:
+        pytest.skip("jax-finufft not installed")
+    from jax_finufft.options import NestedOpts, Opts
+
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.5, -0.5]])
+    shape, pixel_size = (8, 8), 1.0
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
+    atom_volume = cxs.IndependentAtomVolume(
+        positions=positions,
+        kernel_fns=im.FourierGaussian(amplitude=1.0, b_factor=100.0),
+    )
+    opts = NestedOpts(
+        forward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
+        backward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
+    )
+    atom_integrator = cxs.IndependentAtomProjection(
+        backend="jax-finufft",
+        sampling_mode="point",
+        eps=1e-6,
+        options={"opts": opts},
+    )
+    result = atom_integrator.integrate(
+        atom_volume, image_config, outputs_real_space=False
+    )
+    assert result.shape == (shape[0], shape[1] // 2 + 1)
+
+
 @eqx.filter_jit
 def make_spline(real_voxel_grid):
     return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -113,7 +113,7 @@ def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
 def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
     atom_positions, _, _ = pdb_info
     image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
-    amplitude, variance = 1.0, 20.0 / (8 * np.pi**2)
+    amplitude, variance = 0.75, 20.0 / (8 * np.pi**2)
     gaussian_volume, gaussian_integrator = (
         cxs.GaussianMixtureVolume(
             atom_positions, amplitudes=amplitude, variances=variance
@@ -125,15 +125,13 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
             positions=atom_positions,
             kernel_fns=im.RealGaussian(amplitude=amplitude, variance=variance),
         ),
-        cxs.IndependentAtomProjection(
-            sampling_mode="average", eps=1e-12, upsample_factor=1.0
-        ),
+        cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-12),
     )
     proj_by_gaussians = compute_projection(
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
-    # _plot_image_compare(proj_by_gaussians, proj_by_atom)
+
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-5)
 
 
@@ -222,7 +220,45 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
         # print(proj_by_atoms.min())
         # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
+        _plot_image_compare(proj_by_gaussians - proj_by_atoms, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
+
+
+@pytest.mark.parametrize(
+    "pixel_size, shape",
+    (
+        (0.5, (64, 64)),
+        (0.5, (63, 63)),
+    ),
+)
+def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
+    atom_positions, atom_ids, _ = pdb_info
+    positions_by_id, unique_atom_ids = split_atoms_by_element(atom_ids, atom_positions)
+    peng_parameters, peng_parameters_by_id = (
+        PengScatteringFactorParameters(atom_ids),
+        PengScatteringFactorParameters(unique_atom_ids),
+    )
+    gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
+        atom_positions,
+        peng_parameters,
+        extra_b_factors=10.0,
+    )
+    atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
+        positions_by_id,
+        peng_parameters_by_id,
+        b_factor_by_element=10.0,
+        outputs_real_space=True,
+    )
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
+    # Check to make sure the implementations are identical, up to the
+    # nufft (don't include anti-aliasing)
+    gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
+    atom_integrator = cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-10)
+    proj_by_gaussians = compute_projection(
+        gaussian_volume, gaussian_integrator, image_config
+    )
+    proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -116,8 +116,7 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
         pixel_size,
         voltage_in_kilovolts=300.0,
     )
-    amplitude, b_factor = 1.0, 40.0
-    variance = b_factor / (8 * np.pi**2)
+    amplitude, variance = 1.0, 20.0 / (8 * np.pi**2)
     gaussian_volume, gaussian_integrator = (
         cxs.GaussianMixtureVolume(
             atom_positions,
@@ -132,7 +131,9 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
             kernel_fns=im.RealGaussian(amplitude=amplitude, variance=variance),
         ),
         cxs.IndependentAtomProjection(
-            sampling_mode="average", eps=1e-10, upsample_factor=2
+            sampling_mode="average",
+            eps=1e-8,
+            upsample_factor=2.0,
         ),
     )
     proj_by_gaussians = compute_projection(
@@ -140,7 +141,7 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
     )
     proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
     _plot_image_compare(proj_by_gaussians, proj_by_atom)
-    np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
+    np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-5)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -1,5 +1,3 @@
-import warnings
-
 import cryojax.ndimage as im
 import cryojax.simulator as cxs
 import equinox as eqx
@@ -25,97 +23,96 @@ def pdb_info(sample_pdb_path):
     return read_atoms_from_pdb(sample_pdb_path, center=True, loads_properties=True)
 
 
-@pytest.mark.parametrize("shape", ((64, 64), (63, 63), (63, 64), (64, 63)))
-def test_gmm_integrator_shape(sample_pdb_path, shape):
-    atom_volume = cxs.load_tabulated_volume(
-        sample_pdb_path,
-        output_type=cxs.GaussianMixtureVolume,
-        include_b_factors=True,
-        selection_string="not element H",
-    )
-    pixel_size = 0.5
+# @pytest.mark.parametrize("shape", ((64, 64), (63, 63), (63, 64), (64, 63)))
+# def test_gmm_integrator_shape(sample_pdb_path, shape):
+#     atom_volume = cxs.load_tabulated_volume(
+#         sample_pdb_path,
+#         output_type=cxs.GaussianMixtureVolume,
+#         include_b_factors=True,
+#         selection_string="not element H",
+#     )
+#     pixel_size = 0.5
 
-    integrator = cxs.GaussianMixtureProjection(shape=(2 * shape[0], 2 * shape[1]))
-    # # ... and the configuration of the imaging instrument
-    image_config = cxs.BasicImageConfig(
-        shape=shape,
-        pixel_size=pixel_size,
-        voltage_in_kilovolts=300.0,
-    )
-    # ... compute the integrated volume
-    fourier_integrated_volume = integrator.integrate(
-        atom_volume, image_config, outputs_real_space=False
-    )
+#     integrator = cxs.GaussianMixtureProjection(shape=(2 * shape[0], 2 * shape[1]))
+#     # # ... and the configuration of the imaging instrument
+#     image_config = cxs.BasicImageConfig(
+#         shape=shape,
+#         pixel_size=pixel_size,
+#         voltage_in_kilovolts=300.0,
+#     )
+#     # ... compute the integrated volume
+#     fourier_integrated_volume = integrator.integrate(
+#         atom_volume, image_config, outputs_real_space=False
+#     )
 
-    assert fourier_integrated_volume.shape == (shape[0], shape[1] // 2 + 1)
+#     assert fourier_integrated_volume.shape == (shape[0], shape[1] // 2 + 1)
 
 
-def test_fft_atom_bad_instantiation():
-    with pytest.raises(ValueError):
-        _ = cxs.IndependentAtomVolume(
-            positions=np.zeros((10, 3)),
-            kernel_fns=(im.FourierGaussian(),),
-        )
-    # with pytest.raises(ValueError):
-    #     _ = cxs.FFTAtomProjection(upsample_factor=2)
+# def test_fft_atom_bad_instantiation():
+#     with pytest.raises(ValueError):
+#         _ = cxs.IndependentAtomVolume(
+#             positions=np.zeros((10, 3)),
+#             kernel_fns=(im.FourierGaussian(),),
+#         )
+#     # with pytest.raises(ValueError):
+#     #     _ = cxs.FFTAtomProjection(upsample_factor=2)
+
+
+# @pytest.mark.parametrize(
+#     "pixel_size, shape",
+#     ((1.0, (32, 32)), (1.0, (32, 31)), (1.0, (31, 32)), (1.0, (31, 31))),
+# )
+# def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
+#     for backend in ["jax-finufft", "nufftax"]:
+#         if jnufft is None and backend == "jax-finufft":
+#             warnings.warn(
+#                 "Could not test projection method `IndependentAtomProjection`, "
+#                 "most likely because `jax_finufft` is not installed. "
+#                 f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
+#             )
+#             continue
+#         atom_positions, _, _ = pdb_info
+#         pixel_size, shape = 0.5, (64, 64)
+#         image_config = cxs.BasicImageConfig(
+#             shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=(128, 128)
+#         )
+#         amplitude, b_factor = 1.0, 100.0
+#         gaussian_volume, gaussian_integrator = (
+#             cxs.GaussianMixtureVolume(
+#                 atom_positions,
+#                 amplitudes=amplitude,
+#                 variances=b_factor / (8 * np.pi**2),
+#             ),
+#             cxs.GaussianMixtureProjection(sampling_mode="point"),
+#         )
+#         atom_volume, atom_integrator = (
+#             cxs.IndependentAtomVolume(
+#                 positions=atom_positions,
+#                 kernel_fns=im.FourierGaussian(amplitude=amplitude, b_factor=b_factor),
+#             ),
+#             cxs.IndependentAtomProjection(
+#                 backend=backend,  # type: ignore
+#                 sampling_mode="point",
+#                 eps=1e-10,
+#             ),
+#         )
+#         proj_by_gaussians = compute_projection(
+#             gaussian_volume, gaussian_integrator, image_config
+#         )
+#         proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
+#         np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
 
 
 @pytest.mark.parametrize(
     "pixel_size, shape",
-    ((1.0, (32, 32)), (1.0, (32, 31)), (1.0, (31, 32)), (1.0, (31, 31))),
-)
-def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
-    for backend in ["jax-finufft", "nufftax"]:
-        if jnufft is None and backend == "jax-finufft":
-            warnings.warn(
-                "Could not test projection method `IndependentAtomProjection`, "
-                "most likely because `jax_finufft` is not installed. "
-                f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
-            )
-            continue
-        atom_positions, _, _ = pdb_info
-        pixel_size, shape = 0.5, (64, 64)
-        image_config = cxs.BasicImageConfig(
-            shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=(128, 128)
-        )
-        amplitude, b_factor = 1.0, 100.0
-        gaussian_volume, gaussian_integrator = (
-            cxs.GaussianMixtureVolume(
-                atom_positions,
-                amplitudes=amplitude,
-                variances=b_factor / (8 * np.pi**2),
-            ),
-            cxs.GaussianMixtureProjection(sampling_mode="point"),
-        )
-        atom_volume, atom_integrator = (
-            cxs.IndependentAtomVolume(
-                positions=atom_positions,
-                kernel_fns=im.FourierGaussian(amplitude=amplitude, b_factor=b_factor),
-            ),
-            cxs.IndependentAtomProjection(
-                backend=backend,  # type: ignore
-                sampling_mode="point",
-                eps=1e-10,
-            ),
-        )
-        proj_by_gaussians = compute_projection(
-            gaussian_volume, gaussian_integrator, image_config
-        )
-        proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
-        np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
-
-
-@pytest.mark.parametrize(
-    "pixel_size, shape",
-    ((0.5, (64, 64)), (0.5, (64, 63)), (0.5, (63, 64)), (0.5, (63, 63))),
+    (
+        (0.5, (63, 63)),
+        (0.5, (64, 64)),
+    ),
 )
 def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
     atom_positions, _, _ = pdb_info
-    image_config = cxs.BasicImageConfig(
-        shape,
-        pixel_size,
-        voltage_in_kilovolts=300.0,
-    )
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     amplitude, variance = 1.0, 20.0 / (8 * np.pi**2)
     gaussian_volume, gaussian_integrator = (
         cxs.GaussianMixtureVolume(
@@ -128,19 +125,22 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
     atom_volume, atom_integrator = (
         cxs.IndependentAtomVolume(
             positions=atom_positions,
-            kernel_fns=im.RealGaussian(amplitude=amplitude, variance=variance),
+            kernel_fns=im.RealGaussian(
+                amplitude=amplitude,
+                variance=variance,
+            ),
         ),
         cxs.IndependentAtomProjection(
             sampling_mode="average",
-            eps=1e-8,
-            upsample_factor=2.0,
+            eps=1e-10,
+            upsample_factor=1.0,
         ),
     )
     proj_by_gaussians = compute_projection(
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
-    # _plot_image_compare(proj_by_gaussians, proj_by_atom)
+    _plot_image_compare(proj_by_gaussians, proj_by_atom)
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-5)
 
 

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -219,9 +219,6 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-        # print(proj_by_atoms.min())
-        # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
-        _plot_image_compare(proj_by_gaussians - proj_by_atoms, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
@@ -494,12 +491,12 @@ def make_spline(real_voxel_grid):
     )
 
 
-def _plot_image_compare(im1, im2):
-    from matplotlib import pyplot as plt
+# def _plot_image_compare(im1, im2):
+#     from matplotlib import pyplot as plt
 
-    fig, axes = plt.subplots(figsize=(9, 4), ncols=2, constrained_layout=True)
-    mappable1 = axes[0].imshow(im1)
-    mappable2 = axes[1].imshow(im2)
-    fig.colorbar(mappable1)
-    fig.colorbar(mappable2)
-    plt.show()
+#     fig, axes = plt.subplots(figsize=(9, 4), ncols=2, constrained_layout=True)
+#     mappable1 = axes[0].imshow(im1)
+#     mappable2 = axes[1].imshow(im2)
+#     fig.colorbar(mappable1)
+#     fig.colorbar(mappable2)
+#     plt.show()

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -229,8 +229,13 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     other_projection_methods = [
         cxs.FourierSliceExtraction(),
         cxs.FourierSliceExtraction(),
-        cxs.RealVoxelProjection(eps=1e-15),
+        cxs.RealVoxelProjection(eps=1e-15, backend="nufftax"),
     ]
+    if jnufft is not None:
+        other_volumes.append(other_volumes[-1])
+        other_projection_methods.append(
+            cxs.RealVoxelProjection(eps=1e-15, backend="jax-finufft")  # type: ignore
+        )
 
     projection_by_gaussian_integration = compute_projection(
         base_volume, base_method, image_config

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -140,7 +140,7 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
-    _plot_image_compare(proj_by_gaussians, proj_by_atom)
+    # _plot_image_compare(proj_by_gaussians, proj_by_atom)
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-5)
 
 

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -219,6 +219,7 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+        # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
@@ -439,7 +440,7 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
 #     plt.show()
 
 
-# @eqx.filter_jit
+@eqx.filter_jit
 def compute_projection(
     volume: cxs.AbstractVolumeRepresentation,
     integrator: cxs.AbstractVolumeIntegrator,
@@ -469,7 +470,8 @@ def compute_projection_at_pose(
         rotated_volume, image_config, outputs_real_space=False
     )
     translation_operator = pose.compute_translation_operator(
-        image_config.get_frequency_grid(padding=True, physical=True)
+        image_config.padded_shape,
+        image_config.pixel_size,
     )
     return im.crop_to_shape(
         im.irfftn(
@@ -543,12 +545,12 @@ def make_spline(real_voxel_grid):
     )
 
 
-# def _plot_image_compare(im1, im2):
-#     from matplotlib import pyplot as plt
+def _plot_image_compare(im1, im2):
+    from matplotlib import pyplot as plt
 
-#     fig, axes = plt.subplots(figsize=(9, 4), ncols=2, constrained_layout=True)
-#     mappable1 = axes[0].imshow(im1)
-#     mappable2 = axes[1].imshow(im2)
-#     fig.colorbar(mappable1)
-#     fig.colorbar(mappable2)
-#     plt.show()
+    fig, axes = plt.subplots(figsize=(9, 4), ncols=2, constrained_layout=True)
+    mappable1 = axes[0].imshow(im1)
+    mappable2 = axes[1].imshow(im2)
+    fig.colorbar(mappable1)
+    fig.colorbar(mappable2)
+    plt.show()

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -174,15 +174,27 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 
 
 @pytest.mark.parametrize(
-    "pixel_size, shape, upsampfac",
+    "pixel_size, shape, upsampfac, eps",
     (
-        (0.25, (134, 134), 2.62),
-        (0.25, (133, 133), 2),
-        (0.25, (134, 133), 3),
-        (0.25, (133, 133), 3),
+        (0.25, (134, 134), 2, 1e-5),
+        (0.25, (133, 133), 2, 1e-5),
+        (0.25, (134, 133), 2, 1e-5),
+        (0.25, (133, 134), 2, 1e-5),
+        (0.25, (134, 134), 3, 1e-5),
+        (0.25, (133, 133), 3, 1e-5),
+        (0.25, (134, 133), 3.0, 1e-5),
+        (0.25, (133, 134), 3.0, 1e-5),
+        (0.25, (134, 134), 2, 1e-6),
+        (0.25, (133, 133), 2, 1e-6),
+        (0.25, (134, 133), 2, 1e-6),
+        (0.25, (133, 134), 2, 1e-6),
+        (0.25, (134, 134), 3, 1e-6),
+        (0.25, (133, 133), 3, 1e-6),
+        (0.25, (134, 133), 3, 1e-6),
+        (0.25, (133, 134), 3, 1e-6),
     ),
 )
-def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
+def test_fft_projection_peng(pdb_info, pixel_size, shape, upsampfac, eps):
     for backend in ["jax-finufft", "nufftax"]:
         if jnufft is None and backend == "jax-finufft":
             continue
@@ -228,9 +240,11 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
     (
         (0.5, (64, 64)),
         (0.5, (63, 63)),
+        (0.5, (64, 63)),
+        (0.5, (63, 64)),
     ),
 )
-def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
+def test_real_projection_peng_erf(pdb_info, pixel_size, shape):
     atom_positions, atom_ids, _ = pdb_info
     positions_by_id, unique_atom_ids = split_atoms_by_element(atom_ids, atom_positions)
     peng_parameters, peng_parameters_by_id = (
@@ -240,35 +254,27 @@ def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
     gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
         atom_positions,
         peng_parameters,
-        extra_b_factors=10.0,
     )
     atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
         positions_by_id,
         peng_parameters_by_id,
-        b_factor_by_element=10.0,
         use_real_space=True,
     )
     image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     # Check to make sure the implementations are identical, up to the
     # nufft (don't include anti-aliasing)
     gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-    atom_integrator = cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-10)
+    atom_integrator = cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-16)
     proj_by_gaussians = compute_projection(
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-    # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
-    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
+    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=1e-6)
 
 
 @pytest.mark.parametrize(
     "pixel_size, shape",
-    (
-        (1.0, (32, 32)),
-        (1.0, (31, 31)),
-        (1.0, (31, 32)),
-        (1.0, (32, 31)),
-    ),
+    ((1.0, (32, 32)), (1.0, (33, 33)), (1.0, (38, 38)), (1.0, (37, 37))),
 )
 def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     """
@@ -277,15 +283,9 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     """
     # Unpack PDB info
     atom_positions, atom_types, atom_properties = pdb_info
-    # Objects for imaging
-    image_config = cxs.BasicImageConfig(
-        shape,
-        pixel_size,
-        voltage_in_kilovolts=300.0,
-    )
     # Real vs fourier volumes
     dim = max(*shape)  # Make sure to use `padded_shape` here
-
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     peng_parameters = PengScatteringFactorParameters(atom_types)
     base_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
         atom_positions,
@@ -320,6 +320,9 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
         projection_by_other_method = compute_projection(
             volume, projection_method, image_config
         )
+        # _plot_image_compare(
+        #     projection_by_gaussian_integration, projection_by_other_method
+        # )
         # fig, axes = plt.subplots(figsize=(12, 4), ncols=3)
         # axes[0].imshow(projection_by_gaussian_integration)
         # axes[1].imshow(projection_by_other_method)

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -1,3 +1,5 @@
+import warnings
+
 import cryojax.ndimage as im
 import cryojax.simulator as cxs
 import equinox as eqx
@@ -23,84 +25,82 @@ def pdb_info(sample_pdb_path):
     return read_atoms_from_pdb(sample_pdb_path, center=True, loads_properties=True)
 
 
-# @pytest.mark.parametrize("shape", ((64, 64), (63, 63), (63, 64), (64, 63)))
-# def test_gmm_integrator_shape(sample_pdb_path, shape):
-#     atom_volume = cxs.load_tabulated_volume(
-#         sample_pdb_path,
-#         output_type=cxs.GaussianMixtureVolume,
-#         include_b_factors=True,
-#         selection_string="not element H",
-#     )
-#     pixel_size = 0.5
+@pytest.mark.parametrize("shape", ((64, 64), (63, 63), (63, 64), (64, 63)))
+def test_gmm_integrator_shape(sample_pdb_path, shape):
+    atom_volume = cxs.load_tabulated_volume(
+        sample_pdb_path,
+        output_type=cxs.GaussianMixtureVolume,
+        include_b_factors=True,
+        selection_string="not element H",
+    )
+    pixel_size = 0.5
 
-#     integrator = cxs.GaussianMixtureProjection(shape=(2 * shape[0], 2 * shape[1]))
-#     # # ... and the configuration of the imaging instrument
-#     image_config = cxs.BasicImageConfig(
-#         shape=shape,
-#         pixel_size=pixel_size,
-#         voltage_in_kilovolts=300.0,
-#     )
-#     # ... compute the integrated volume
-#     fourier_integrated_volume = integrator.integrate(
-#         atom_volume, image_config, outputs_real_space=False
-#     )
+    integrator = cxs.GaussianMixtureProjection(shape=(2 * shape[0], 2 * shape[1]))
+    # # ... and the configuration of the imaging instrument
+    image_config = cxs.BasicImageConfig(
+        shape=shape,
+        pixel_size=pixel_size,
+        voltage_in_kilovolts=300.0,
+    )
+    # ... compute the integrated volume
+    fourier_integrated_volume = integrator.integrate(
+        atom_volume, image_config, outputs_real_space=False
+    )
 
-#     assert fourier_integrated_volume.shape == (shape[0], shape[1] // 2 + 1)
-
-
-# def test_fft_atom_bad_instantiation():
-#     with pytest.raises(ValueError):
-#         _ = cxs.IndependentAtomVolume(
-#             positions=np.zeros((10, 3)),
-#             kernel_fns=(im.FourierGaussian(),),
-#         )
-#     # with pytest.raises(ValueError):
-#     #     _ = cxs.FFTAtomProjection(upsample_factor=2)
+    assert fourier_integrated_volume.shape == (shape[0], shape[1] // 2 + 1)
 
 
-# @pytest.mark.parametrize(
-#     "pixel_size, shape",
-#     ((1.0, (32, 32)), (1.0, (32, 31)), (1.0, (31, 32)), (1.0, (31, 31))),
-# )
-# def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
-#     for backend in ["jax-finufft", "nufftax"]:
-#         if jnufft is None and backend == "jax-finufft":
-#             warnings.warn(
-#                 "Could not test projection method `IndependentAtomProjection`, "
-#                 "most likely because `jax_finufft` is not installed. "
-#                 f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
-#             )
-#             continue
-#         atom_positions, _, _ = pdb_info
-#         pixel_size, shape = 0.5, (64, 64)
-#         image_config = cxs.BasicImageConfig(
-#             shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=(128, 128)
-#         )
-#         amplitude, b_factor = 1.0, 100.0
-#         gaussian_volume, gaussian_integrator = (
-#             cxs.GaussianMixtureVolume(
-#                 atom_positions,
-#                 amplitudes=amplitude,
-#                 variances=b_factor / (8 * np.pi**2),
-#             ),
-#             cxs.GaussianMixtureProjection(sampling_mode="point"),
-#         )
-#         atom_volume, atom_integrator = (
-#             cxs.IndependentAtomVolume(
-#                 positions=atom_positions,
-#                 kernel_fns=im.FourierGaussian(amplitude=amplitude, b_factor=b_factor),
-#             ),
-#             cxs.IndependentAtomProjection(
-#                 backend=backend,  # type: ignore
-#                 sampling_mode="point",
-#                 eps=1e-10,
-#             ),
-#         )
-#         proj_by_gaussians = compute_projection(
-#             gaussian_volume, gaussian_integrator, image_config
-#         )
-#         proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
-#         np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
+def test_fft_atom_bad_instantiation():
+    with pytest.raises(ValueError):
+        _ = cxs.IndependentAtomVolume(
+            positions=np.zeros((10, 3)),
+            kernel_fns=(im.FourierGaussian(),),
+        )
+
+
+@pytest.mark.parametrize(
+    "pixel_size, shape",
+    ((1.0, (32, 32)), (1.0, (32, 31)), (1.0, (31, 32)), (1.0, (31, 31))),
+)
+def test_fft_atom_projection_exact(pdb_info, pixel_size, shape):
+    for backend in ["jax-finufft", "nufftax"]:
+        if jnufft is None and backend == "jax-finufft":
+            warnings.warn(
+                "Could not test projection method `IndependentAtomProjection`, "
+                "most likely because `jax_finufft` is not installed. "
+                f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
+            )
+            continue
+        atom_positions, _, _ = pdb_info
+        pixel_size, shape = 0.5, (64, 64)
+        image_config = cxs.BasicImageConfig(
+            shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=(128, 128)
+        )
+        amplitude, b_factor = 1.0, 100.0
+        gaussian_volume, gaussian_integrator = (
+            cxs.GaussianMixtureVolume(
+                atom_positions,
+                amplitudes=amplitude,
+                variances=b_factor / (8 * np.pi**2),
+            ),
+            cxs.GaussianMixtureProjection(sampling_mode="point"),
+        )
+        atom_volume, atom_integrator = (
+            cxs.IndependentAtomVolume(
+                positions=atom_positions,
+                kernel_fns=im.FourierGaussian(amplitude=amplitude, b_factor=b_factor),
+            ),
+            cxs.IndependentAtomProjection(
+                backend=backend,  # type: ignore
+                sampling_mode="point",
+                eps=1e-10,
+            ),
+        )
+        proj_by_gaussians = compute_projection(
+            gaussian_volume, gaussian_integrator, image_config
+        )
+        proj_by_atom = compute_projection(atom_volume, atom_integrator, image_config)
+        np.testing.assert_allclose(proj_by_gaussians, proj_by_atom, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -116,24 +116,17 @@ def test_real_atom_projection_exact(pdb_info, pixel_size, shape):
     amplitude, variance = 1.0, 20.0 / (8 * np.pi**2)
     gaussian_volume, gaussian_integrator = (
         cxs.GaussianMixtureVolume(
-            atom_positions,
-            amplitudes=amplitude,
-            variances=variance,
+            atom_positions, amplitudes=amplitude, variances=variance
         ),
         cxs.GaussianMixtureProjection(sampling_mode="average"),
     )
     atom_volume, atom_integrator = (
         cxs.IndependentAtomVolume(
             positions=atom_positions,
-            kernel_fns=im.RealGaussian(
-                amplitude=amplitude,
-                variance=variance,
-            ),
+            kernel_fns=im.RealGaussian(amplitude=amplitude, variance=variance),
         ),
         cxs.IndependentAtomProjection(
-            sampling_mode="average",
-            eps=1e-10,
-            upsample_factor=1.0,
+            sampling_mode="average", eps=1e-12, upsample_factor=1.0
         ),
     )
     proj_by_gaussians = compute_projection(
@@ -165,7 +158,11 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
             ),
         )
         gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-        atom_integrator = cxs.IndependentAtomProjection(eps=1e-10, backend=backend)  # type: ignore
+        atom_integrator = cxs.IndependentAtomProjection(
+            eps=1e-10,
+            backend=backend,  # type: ignore
+            upsample_factor=2.0,
+        )
         padded_shape = (2 * shape[0], 2 * shape[1])
         image_config = cxs.BasicImageConfig(
             shape, pixel_size, voltage_in_kilovolts=300.0, padded_shape=padded_shape
@@ -179,17 +176,15 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 
 
 @pytest.mark.parametrize(
-    "pixel_size, shape, block_size",
+    "pixel_size, shape, upsampfac",
     (
-        (0.25, (134, 134), 4),
-        (0.25, (133, 133), 4),
-        (0.25, (134, 133), 5),
-        (0.25, (133, 133), 5),
-        (0.25, (133, 134), 5),
-        (0.25, (134, 133), 5),
+        (0.25, (134, 134), 2.62),
+        (0.25, (133, 133), 2),
+        (0.25, (134, 133), 3),
+        (0.25, (133, 133), 3),
     ),
 )
-def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, block_size):
+def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
     for backend in ["jax-finufft", "nufftax"]:
         if jnufft is None and backend == "jax-finufft":
             continue
@@ -204,10 +199,12 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, block_size):
         gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
             atom_positions,
             peng_parameters,
+            extra_b_factors=4.0,
         )
         atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
             positions_by_id,
             peng_parameters_by_id,
+            b_factor_by_element=4.0,
         )
         image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
         # Check to make sure the implementations are identical, up to the
@@ -216,13 +213,15 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, block_size):
         atom_integrator = cxs.IndependentAtomProjection(
             backend=backend,  # type: ignore
             sampling_mode="average",
-            block_size=block_size,
+            upsample_factor=upsampfac,
             eps=1e-10,
         )
         proj_by_gaussians = compute_projection(
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+        # print(proj_by_atoms.min())
+        # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
@@ -460,7 +459,9 @@ def make_spline(real_voxel_grid):
 def _plot_image_compare(im1, im2):
     from matplotlib import pyplot as plt
 
-    _, axes = plt.subplots(figsize=(7, 4), ncols=2)
-    axes[0].imshow(im1)
-    axes[1].imshow(im2)
+    fig, axes = plt.subplots(figsize=(9, 4), ncols=2, constrained_layout=True)
+    mappable1 = axes[0].imshow(im1)
+    mappable2 = axes[1].imshow(im2)
+    fig.colorbar(mappable1)
+    fig.colorbar(mappable2)
     plt.show()

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -317,10 +317,23 @@ def test_render_options(pdb_info):
 
 @pytest.mark.parametrize(
     "width, voxel_size, shape",
-    ((1.0, 0.5, (64, 64, 64)), (1.0, 0.5, (63, 63, 63))),
+    (
+        (1.0, 0.5, (64, 64, 64)),
+        (1.0, 0.5, (63, 63, 63)),
+        (1.0, 0.5, (64, 64, 64)),
+        (1.0, 0.5, (63, 63, 63)),
+    ),
 )
 def test_fft_atom_render(pdb_info, width, voxel_size, shape):
-    if jnufft is not None:
+    for backend in ["jax-finufft", "nufftax"]:
+        if jnufft is None and backend == "jax-finufft":
+            warnings.warn(
+                "Could not test rendering method `IndependentAtomRenderFn`, "
+                "with backend `'jax-finufft'` mostly likely because it is "
+                "not installed. "
+                f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
+            )
+            continue
         atom_positions, _, _ = pdb_info
         gaussian_volume = cxs.GaussianMixtureVolume(
             atom_positions,
@@ -334,17 +347,16 @@ def test_fft_atom_render(pdb_info, width, voxel_size, shape):
             ),
         )
         gaussian_render_fn = cxs.GaussianMixtureRenderFn(shape, voxel_size)
-        atom_render_fn = cxs.IndependentAtomRenderFn(shape, voxel_size, eps=1e-10)
+        atom_render_fn = cxs.IndependentAtomRenderFn(
+            shape,
+            voxel_size,
+            eps=1e-10,
+            backend=backend,  # type: ignore
+        )
         voxels_by_gaussians = gaussian_render_fn(gaussian_volume)
         voxels_by_atoms = atom_render_fn(atom_volume)
 
         np.testing.assert_allclose(voxels_by_gaussians, voxels_by_atoms, atol=1e-8)
-    else:
-        warnings.warn(
-            "Could not test rendering method `IndependentAtomRenderFn`, "
-            "most likely because `jax_finufft` is not installed. "
-            f"Error traceback is:\n{JAX_FINUFFT_IMPORT_ERROR}"
-        )
 
 
 #

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -595,6 +595,54 @@ def test_gmm_shape():
     )
 
 
+@pytest.mark.parametrize("upsampfac", (1.25, 2.0))
+def test_fft_atom_render_custom_upsampfac(upsampfac):
+    """Smoke test: passing a custom upsampfac via options runs without error."""
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.5, -0.5]])
+    shape, voxel_size = (8, 8, 8), 1.0
+    atom_volume = cxs.IndependentAtomVolume(
+        positions=positions,
+        kernel_fns=im.FourierGaussian(amplitude=1.0, b_factor=100.0),
+    )
+    render_fn = cxs.IndependentAtomRenderFn(
+        shape,
+        voxel_size,
+        backend="nufftax",
+        eps=1e-6,
+        options={"upsampfac": upsampfac},
+    )
+    result = render_fn(atom_volume, outputs_real_space=True)
+    assert result.shape == shape
+
+
+@pytest.mark.parametrize("upsampfac", (1.25, 2.0))
+def test_fft_atom_render_custom_upsampfac_jax_finufft(upsampfac):
+    """Smoke test: passing custom opts via options to jax-finufft runs without error."""
+    if jnufft is None:
+        pytest.skip("jax-finufft not installed")
+    from jax_finufft.options import NestedOpts, Opts
+
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.5, -0.5]])
+    shape, voxel_size = (8, 8, 8), 1.0
+    atom_volume = cxs.IndependentAtomVolume(
+        positions=positions,
+        kernel_fns=im.FourierGaussian(amplitude=1.0, b_factor=100.0),
+    )
+    opts = NestedOpts(
+        forward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
+        backward=Opts(upsampfac=upsampfac, gpu_upsampfac=upsampfac),
+    )
+    render_fn = cxs.IndependentAtomRenderFn(
+        shape,
+        voxel_size,
+        backend="jax-finufft",
+        eps=1e-6,
+        options={"opts": opts},
+    )
+    result = render_fn(atom_volume, outputs_real_space=True)
+    assert result.shape == shape
+
+
 def _make_scattering_parameters(
     atomic_numbers: np.ndarray, tabulation: Literal["peng", "lobato"]
 ):

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -193,6 +193,42 @@ def test_voxel_volume_loaders():
     assert isinstance(real_volume.coordinate_grid_in_pixels, Float[Array, "_ _ _ 3"])  # type: ignore
 
 
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize("pad_scale", (1.5, 2.0))
+def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
+    import math
+
+    shape = (10, 10, 10)
+    real_voxel_grid = jnp.zeros(shape, dtype=float)
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        real_voxel_grid, pad_scale=pad_scale
+    )
+    padded_shape = vol.fourier_voxel_grid.shape
+    for s, p in zip(shape, padded_shape):
+        assert p >= math.ceil(pad_scale * s)
+        assert _is_smooth(p)
+        assert (s % 2) == (p % 2), "parity not preserved"
+
+
+def test_fourier_voxel_grid_pad_scale_one_unchanged():
+    shape = (10, 10, 10)
+    real_voxel_grid = jnp.zeros(shape, dtype=float)
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=1.0)
+    assert vol.fourier_voxel_grid.shape == shape
+
+
+def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
+    real_voxel_grid = jnp.zeros((10, 10, 10), dtype=float)
+    with pytest.raises(ValueError, match="pad_scale"):
+        cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=0.5)
+
+
 @pytest.mark.parametrize("pad_scale", (1, 1.1))
 def test_sinc_correction(sample_mrc_path, pad_scale):
     real_voxel_grid = read_array_from_mrc(sample_mrc_path)

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -213,7 +213,6 @@ def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
     for s, p in zip(shape, padded_shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-        assert (s % 2) == (p % 2), "parity not preserved"
 
 
 def test_fourier_voxel_grid_pad_scale_one_unchanged():


### PR DESCRIPTION
We can adopt `nufftax` in the near future to support usage of `IndependentAtomVolume` without need to install `jax-finufft`. Since FINUFFT is highly optimized, we keep this as an option via `IndependentAtomProjection(..., backend="jax-finufft")`.

Additionally, https://github.com/GragasLab/nufftax/pull/11 adds the ability to spread custom kernels onto the plane, and #583 sets up the API / backend for a real-space method. If real-space kernels are passed, we can use `nufftax.core.spread_*d` functions to directly spread gaussians onto the plane.