### PR TITLE
Update branch

### DIFF
--- a/cryojax/ndimage/__init__.py
+++ b/cryojax/ndimage/__init__.py
@@ -35,6 +35,7 @@ from ._fourier_statistics import (
 from ._fourier_utils import (
     convert_fftn_to_rfftn as convert_fftn_to_rfftn,
     enforce_rfftn_self_conjugates as enforce_rfftn_self_conjugates,
+    query_efficient_grid_size as query_efficient_grid_size,
 )
 from ._map_coordinates import (
     compute_spline_coefficients as compute_spline_coefficients,

--- a/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
+++ b/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
@@ -68,6 +68,7 @@ def make_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """Create a fourier-space cartesian coordinate system on a grid.
     The zero-frequency component is in the corner.
@@ -93,6 +94,7 @@ def make_frequency_grid(
         grid_spacing=grid_spacing,
         outputs_real_space=False,
         outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
     return frequency_grid
 
@@ -101,6 +103,7 @@ def make_radial_frequency_grid(
     shape: tuple[int, ...],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, " *shape"]:
     """Create a fourier-space radial coordinate system on a grid.
     The zero-frequency component is in the corner.
@@ -127,7 +130,10 @@ def make_radial_frequency_grid(
     """
     # Make a cartesian grid
     frequency_grid = make_frequency_grid(
-        shape=shape, grid_spacing=grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs
+        shape=shape,
+        grid_spacing=grid_spacing,
+        outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
 
     # Now compute the magnitude of the frequency vector
@@ -140,6 +146,7 @@ def make_frequency_slice(
     shape: tuple[int, int],
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = False,
+    fftshifted: bool = True,
 ) -> Float[Array, "1 {shape[0]} {shape[1]} 3"]:
     """Create a fourier-space cartesian coordinate system on a grid, where
     zero-frequency component is in the *center* of the grid.
@@ -180,12 +187,8 @@ def make_frequency_slice(
     zero-frequency component is in the *center* of the grid.
     """  # noqa: E501
     frequency_slice = make_frequency_grid(
-        shape, grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs
+        shape, grid_spacing, outputs_rfftfreqs=outputs_rfftfreqs, fftshifted=fftshifted
     )
-    if outputs_rfftfreqs:
-        frequency_slice = jnp.fft.fftshift(frequency_slice, axes=(0,))
-    else:
-        frequency_slice = jnp.fft.fftshift(frequency_slice, axes=(0, 1))
     frequency_slice = jnp.expand_dims(
         jnp.pad(
             frequency_slice,
@@ -201,6 +204,7 @@ def make_frequency_slice(
 def make_1d_coordinate_grid(
     size: int,
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """
     Create a 1D real-space cartesian coordinate array.
@@ -218,7 +222,7 @@ def make_1d_coordinate_grid(
     A 1D cartesian coordinate array in real space.
     """
     coordinate_array = _make_coordinates_or_frequencies_1d(
-        size, grid_spacing=grid_spacing, outputs_real_space=True
+        size, grid_spacing=grid_spacing, outputs_real_space=True, fftshifted=fftshifted
     )
     return coordinate_array
 
@@ -227,6 +231,7 @@ def make_1d_frequency_grid(
     size: int,
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     """Create a 1D fourier-space cartesian coordinate array.
     If `outputs_rfftfreqs = False`, the zero-frequency component is in the beginning.
@@ -252,6 +257,7 @@ def make_1d_frequency_grid(
         grid_spacing=grid_spacing,
         outputs_real_space=False,
         outputs_rfftfreqs=outputs_rfftfreqs,
+        fftshifted=fftshifted,
     )
     return frequency_array
 
@@ -261,13 +267,14 @@ def _make_coordinates_or_frequencies(
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""] = 1.0,
     outputs_real_space: bool = False,
     outputs_rfftfreqs: bool = True,
+    fftshifted: bool = False,
 ) -> Float[Array, "*shape ndim"]:
     ndim = len(shape)
     coords1D = []
     for idx in range(ndim):
         if outputs_real_space:
             c1D = _make_coordinates_or_frequencies_1d(
-                shape[idx], grid_spacing, outputs_real_space
+                shape[idx], grid_spacing, outputs_real_space, fftshifted=fftshifted
             )
         else:
             if not outputs_rfftfreqs:
@@ -275,7 +282,11 @@ def _make_coordinates_or_frequencies(
             else:
                 rfftfreq = False if idx < ndim - 1 else True
             c1D = _make_coordinates_or_frequencies_1d(
-                shape[idx], grid_spacing, outputs_real_space, rfftfreq
+                shape[idx],
+                grid_spacing,
+                outputs_real_space,
+                rfftfreq,
+                fftshifted=fftshifted,
             )
         coords1D.append(c1D)
     if ndim == 2:
@@ -303,15 +314,22 @@ def _make_coordinates_or_frequencies_1d(
     grid_spacing: float | Float[np.ndarray, ""] | Float[Array, ""],
     outputs_real_space: bool = False,
     outputs_rfftfreqs: bool | None = None,
+    fftshifted: bool = False,
 ) -> Float[Array, " size"]:
     """One-dimensional coordinates in real or fourier space"""
     if outputs_real_space:
-        make_1d = lambda size, dx: jnp.fft.fftshift(jnp.fft.fftfreq(size, 1 / dx)) * size
+        make_1d = lambda size, dx: dx * (jnp.arange(size, dtype=float) - size / 2)
     else:
         if outputs_rfftfreqs is None:
             raise ValueError("Internal error in `cryojax.coordinates`.")
         else:
-            fn = jnp.fft.rfftfreq if outputs_rfftfreqs else jnp.fft.fftfreq
+            if outputs_rfftfreqs:
+                fn = jnp.fft.rfftfreq
+            else:
+                if fftshifted:
+                    fn = lambda *x: jnp.fft.fftshift(jnp.fft.fftfreq(*x))
+                else:
+                    fn = jnp.fft.fftfreq
             make_1d = lambda size, dx: fn(size, dx)
 
     return make_1d(size, grid_spacing)

--- a/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
+++ b/cryojax/ndimage/_coordinates/_make_coordinate_grids.py
@@ -318,7 +318,7 @@ def _make_coordinates_or_frequencies_1d(
 ) -> Float[Array, " size"]:
     """One-dimensional coordinates in real or fourier space"""
     if outputs_real_space:
-        make_1d = lambda size, dx: dx * (jnp.arange(size, dtype=float) - size / 2)
+        make_1d = lambda size, dx: jnp.fft.fftshift(jnp.fft.fftfreq(size, 1 / dx) * size)
     else:
         if outputs_rfftfreqs is None:
             raise ValueError("Internal error in `cryojax.coordinates`.")

--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -237,14 +237,14 @@ def _fft_ds_real_signal_to_shape(
     outputs_rfft: bool = True,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
     # Forward Hartley Transform
-    hartley_array = jnp.fft.fftshift(fftn(image_or_volume))
+    hartley_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(image_or_volume)))
     hartley_array = hartley_array.real - hartley_array.imag
 
     # Crop to the desired shape
     ds_array = crop_to_shape(hartley_array, downsampled_shape)
 
     # Inverse Hartley Transform
-    ds_array = jnp.fft.fftshift(fftn(ds_array))
+    ds_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(ds_array)))
     ds_array /= ds_array.size
     ds_array = ds_array.real - ds_array.imag
 

--- a/cryojax/ndimage/_edges.py
+++ b/cryojax/ndimage/_edges.py
@@ -15,10 +15,9 @@ def crop_to_shape(
     image_or_volume: (
         Inexact[NDArrayLike, "y_dim x_dim"] | Inexact[NDArrayLike, "z_dim y_dim x_dim"]
     ),
-    shape: tuple[int, int] | tuple[int, int, int],
+    shape: tuple[int, ...],
     center: (
-        tuple[int, int]
-        | tuple[int, int, int]
+        tuple[int, ...]
         | tuple[Int[NDArrayLike, ""], Int[NDArrayLike, ""]]
         | tuple[Int[NDArrayLike, ""], Int[NDArrayLike, ""], Int[NDArrayLike, ""]]
         | None
@@ -98,7 +97,7 @@ def pad_to_shape(
     image_or_volume: (
         Inexact[NDArrayLike, "y_dim x_dim"] | Inexact[NDArrayLike, "z_dim y_dim x_dim"]
     ),
-    shape: tuple[int, int] | tuple[int, int, int],
+    shape: tuple[int, ...],
     **kwargs: Any,
 ) -> (
     Inexact[Array, " {shape[0]} {shape[1]}"]
@@ -135,7 +134,7 @@ def pad_to_shape(
 
 
 def resize_with_crop_or_pad(
-    image: Inexact[NDArrayLike, "y_dim x_dim"], shape: tuple[int, int], **kwargs
+    image: Inexact[NDArrayLike, "y_dim x_dim"], shape: tuple[int, ...], **kwargs
 ) -> Inexact[Array, " {shape[0]} {shape[1]}"]:
     """Resize an image to a new shape using padding and cropping."""
     if image.ndim != 2 or len(shape) != 2:

--- a/cryojax/ndimage/_fft.py
+++ b/cryojax/ndimage/_fft.py
@@ -26,7 +26,7 @@ def ifftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.ifftn(ft, s=s, axes=axes), axes=axes)
+    ift = jnp.fft.ifftn(ft, s=s, axes=axes)
 
     return ift
 
@@ -49,7 +49,7 @@ def fftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.fftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
+    ft = jnp.fft.fftn(ift, s=s, axes=axes)
 
     return ft
 
@@ -72,7 +72,7 @@ def irfftn(
     ift :
         Inverse fourier transform.
     """
-    ift = jnp.fft.fftshift(jnp.fft.irfftn(ft, s=s, axes=axes), axes=axes)
+    ift = jnp.fft.irfftn(ft, s=s, axes=axes)
 
     return ift
 
@@ -94,6 +94,6 @@ def rfftn(
     ft :
         Fourier transform of array.
     """
-    ft = jnp.fft.rfftn(jnp.fft.ifftshift(ift, axes=axes), s=s, axes=axes)
+    ft = jnp.fft.rfftn(ift, axes=axes, s=s)
 
     return ft

--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -179,7 +179,7 @@ def enforce_rfftn_self_conjugates(
 
 
 def query_efficient_grid_size(
-    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = True
+    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = False
 ) -> tuple[int, ...]:
     """Select an efficient grid size for FFT"""
 

--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -1,3 +1,4 @@
+import math
 from typing import Literal
 
 from jaxtyping import Array, Complex
@@ -175,3 +176,69 @@ def enforce_rfftn_self_conjugates(
             f"Passed an array with `ndim = {rfftn_array.ndim}`."
         )
     return rfftn_array
+
+
+def query_efficient_grid_size(
+    shape: tuple[int, ...], pad_scale: float = 1.0, match_parity: bool = True
+) -> tuple[int, ...]:
+    """Select an efficient grid size for FFT"""
+
+    if match_parity:
+        is_same_parity = lambda n1, n2: (n1 % 2) == (n2 % 2)
+    else:
+        is_same_parity = lambda *_: True
+
+    padded_shape = tuple(int(math.ceil(pad_scale * s)) for s in shape)
+
+    def next_smooth_int(n: int, nf: int) -> int:
+        # Check if n is already smooth
+        def is_smooth(x):
+            for p in [2, 3, 5]:
+                while x % p == 0:
+                    x //= p
+            return x == 1
+
+        # Find next smooth number
+        candidate = nf
+        while not (is_smooth(candidate) and is_same_parity(n, candidate)):
+            candidate += 1
+        return candidate
+
+    return tuple(next_smooth_int(n, nf) for n, nf in zip(shape, padded_shape))
+
+
+# def _make_fftshift_phase(
+#     shape: tuple[int, ...],
+#     axes: tuple[int, ...] | None = None,
+# ) -> Array:
+#     """Build the `(-1)^(k1+k2+...)` sign pattern for the full (non-real) FFT.
+
+#     Multiplying `jnp.fft.fftn(x)` by this pattern gives the same result as
+#     `jnp.fft.fftn(jnp.fft.ifftshift(x))`, so the output has DC at corner
+#     (modeord=0 convention). Then `jnp.fft.fftshift` moves DC back to center
+#     if needed for storage.
+
+#     Only exact for even-sized dimensions.
+
+#     **Arguments:**
+
+#     - `shape`: shape of the FFT output array (same as input when s=None).
+#     - `axes`: axes to include; defaults to all axes.
+
+#     **Returns:**
+
+#     Broadcastable ±1 array with the same number of dimensions as `shape`.
+#     """
+#     ndim = len(shape)
+#     if axes is None:
+#         axes = tuple(range(ndim))
+#     else:
+#         axes = tuple(ax % ndim for ax in axes)
+#     phase = jnp.ones(())
+#     for ax in axes:
+#         n = shape[ax]
+#         p = jnp.where(jnp.arange(n) % 2 == 0, 1.0, -1.0)
+#         reshape = [1] * ndim
+#         reshape[ax] = n
+#         phase = phase * p.reshape(reshape)
+#     return phase

--- a/cryojax/simulator/_image_config.py
+++ b/cryojax/simulator/_image_config.py
@@ -3,7 +3,7 @@
 import math
 import warnings
 from functools import cached_property
-from typing import Literal
+from typing import Literal, cast
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -18,7 +18,11 @@ from ..constants import (
     wavelength_from_kilovolts,
 )
 from ..jax_util import FloatLike
-from ..ndimage import make_coordinate_grid, make_frequency_grid
+from ..ndimage import (
+    make_coordinate_grid,
+    make_frequency_grid,
+    query_efficient_grid_size,
+)
 
 
 _get_deprecation_msg = lambda self, prop, func: (
@@ -548,6 +552,7 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
         voltage_in_kilovolts: FloatLike,
         *,
         padded_shape: tuple[int, int] | None = None,
+        pad_scale: float = 1.0,
         precompute_mode: Literal[
             "none", "rfft", "fft", "all", "compile_time_eval"
         ] = "none",
@@ -564,6 +569,12 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
         - `padded_shape`:
             The shape of the image after padding. By default, equal
             to `shape`.
+        - `pad_scale`:
+            A scale factor used to determine the `padded_shape`.
+            Used only if `padded_shape` is not directly provided.
+            Unless `pad_scale = 1.0`, it is only an approximation
+            of the resulting `padded_shape`. By default, a good
+            array size for FFT efficiency is chosen.
         - `precompute_mode`:
             How to pre-compute coordinate and frequency grids stored in
             the `image_config`. Options are
@@ -598,7 +609,7 @@ class BasicImageConfig(AbstractImageConfig, strict=True):
             )
             padded_shape = pad_options["shape"]
         self.shape = shape
-        self.padded_shape = shape if padded_shape is None else padded_shape
+        self.padded_shape = _set_padded_shape(type(self), shape, padded_shape, pad_scale)
         # Finally, grid precompute
         if precompute_mode == "rfft":
             self.precomputed_grids = PrecomputedGrids(
@@ -641,6 +652,7 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
         electron_dose: FloatLike,
         *,
         padded_shape: tuple[int, int] | None = None,
+        pad_scale: float = 1.0,
         precompute_mode: Literal[
             "none", "rfft", "fft", "all", "compile_time_eval"
         ] = "none",
@@ -660,6 +672,12 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
         - `padded_shape`:
             The shape of the image after padding. By default, equal
             to `shape`.
+        - `pad_scale`:
+            A scale factor used to determine the `padded_shape`.
+            Used only if `padded_shape` is not directly provided.
+            Unless `pad_scale = 1.0`, it is only an approximation
+            of the resulting `padded_shape`. By default, a good
+            array size for FFT efficiency is chosen.
         - `precompute_mode`:
             How to pre-compute coordinate and frequency grids stored in
             the `image_config`. Options are
@@ -695,7 +713,7 @@ class DoseImageConfig(AbstractImageConfig, strict=True):
             )
             padded_shape = pad_options["shape"]
         self.shape = shape
-        self.padded_shape = shape if padded_shape is None else padded_shape
+        self.padded_shape = _set_padded_shape(type(self), shape, padded_shape, pad_scale)
         # Finally, grid precompute
         if precompute_mode == "rfft":
             self.precomputed_grids = PrecomputedGrids(
@@ -739,3 +757,22 @@ def _safe_multiply_by_constant(
         grid = grid.at[:, s2 // 2, 0].multiply(constant)
         grid = grid.at[s1 // 2, :, 1].multiply(constant)
     return grid
+
+
+def _set_padded_shape(
+    cls, shape: tuple[int, int], padded_shape: tuple[int, int] | None, pad_scale: float
+):
+    if padded_shape is not None:
+        return padded_shape
+    elif pad_scale == 1.0:
+        return shape
+    elif pad_scale > 1.0:
+        return cast(
+            tuple[int, int],
+            query_efficient_grid_size(shape, pad_scale=pad_scale),
+        )
+    else:
+        raise ValueError(
+            f"Invalid value for `{cls.__name__}(..., pad_scale=...)`. "
+            f"This must be greater than `1.0`, but got value `{pad_scale}`."
+        )

--- a/cryojax/simulator/_pose.py
+++ b/cryojax/simulator/_pose.py
@@ -119,10 +119,11 @@ class AbstractPose(Module, strict=True):
         grid of in-plane phase shifts $\\exp{(- 2 \\pi i (t_x q_x + t_y q_y))}$.
         """
         tx, ty = self.offset_in_angstroms[0], self.offset_in_angstroms[1]
-        q_x = make_1d_frequency_grid(shape[1], pixel_size, outputs_rfftfreqs=True)
-        q_y = make_1d_frequency_grid(shape[0], pixel_size, outputs_rfftfreqs=False)
-        phase_x = FourierPhaseShifts(tx)(q_x)
-        phase_y = FourierPhaseShifts(ty)(q_y)
+        q_x, q_y = (
+            make_1d_frequency_grid(shape[1], pixel_size, outputs_rfftfreqs=True),
+            make_1d_frequency_grid(shape[0], pixel_size, outputs_rfftfreqs=False),
+        )
+        phase_x, phase_y = (FourierPhaseShifts(tx)(q_x), FourierPhaseShifts(ty)(q_y))
         return phase_y[:, None] * phase_x[None, :]
 
     @cached_property

--- a/cryojax/simulator/_volume/common.py
+++ b/cryojax/simulator/_volume/common.py
@@ -1,0 +1,21 @@
+"""Shared helpers for volume rendering backends."""
+
+from jaxtyping import Array, Float
+
+from ...ndimage import make_1d_frequency_grid
+
+
+def make_frequencies_1d(
+    shape_u: tuple[int, ...],
+    pixel_size_u: Float[Array, ""],
+    modeord: int = 0,
+):
+    return tuple(
+        make_1d_frequency_grid(
+            s,
+            pixel_size_u,
+            outputs_rfftfreqs=False,
+            fftshifted=(True if modeord == 0 else False),
+        )
+        for s in shape_u[::-1]
+    )

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -22,6 +22,7 @@ from ...ndimage import (
     map_coordinates,
     map_coordinates_spline,
     pad_to_shape,
+    query_efficient_grid_size,
     resize_with_crop_or_pad,
     rfftn,
 )
@@ -110,17 +111,27 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         # Cast to jax array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Pad template
-        if pad_scale < 1.0:
+        if isinstance(pad_scale, float) and pad_scale < 1.0:
             raise ValueError("`pad_scale` must be greater than 1.0")
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
-        padded_shape = cast(
-            tuple[int, int, int],
-            tuple([int(s * pad_scale) for s in real_voxel_grid.shape]),
-        )
-        padded_real_voxel_grid = pad_to_shape(
-            real_voxel_grid, padded_shape, mode=pad_mode
-        )
+        if pad_scale == 1.0:
+            padded_shape = real_voxel_grid.shape
+            padded_real_voxel_grid = real_voxel_grid
+        elif pad_scale > 1.0:
+            padded_shape = query_efficient_grid_size(
+                real_voxel_grid.shape,
+                pad_scale=pad_scale,
+            )
+            padded_real_voxel_grid = pad_to_shape(
+                real_voxel_grid, padded_shape, mode=pad_mode
+            )
+        else:
+            raise ValueError(
+                "Invalid value for "
+                "`FourierVoxelGridVolume.from_real_voxel_grid(..., pad_scale=...)`. "
+                f"This must be greater than `1.0`, but got value `{pad_scale}`."
+            )
         if sinc_correction:
             coordinate_grid = make_coordinate_grid(padded_shape)
             correction_mask = SincCorrectionMask(coordinate_grid)
@@ -202,9 +213,8 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
             raise ValueError("`pad_scale` must be greater than 1.0")
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
-        padded_shape = cast(
-            tuple[int, int, int],
-            tuple([int(s * pad_scale) for s in real_voxel_grid.shape]),
+        padded_shape = query_efficient_grid_size(
+            real_voxel_grid.shape, pad_scale=pad_scale, match_parity=True
         )
         padded_real_voxel_grid = pad_to_shape(
             real_voxel_grid, padded_shape, mode=pad_mode

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -214,7 +214,7 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         # ... always pad to even size to avoid interpolation issues in
         # fourier slice extraction.
         padded_shape = query_efficient_grid_size(
-            real_voxel_grid.shape, pad_scale=pad_scale, match_parity=True
+            real_voxel_grid.shape, pad_scale=pad_scale
         )
         padded_real_voxel_grid = pad_to_shape(
             real_voxel_grid, padded_shape, mode=pad_mode

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -461,6 +461,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
             amplitudes,
             is_real_space=is_real_space,
             shape_u=cast(tuple[int, int, int], shape_u),
+            shape_out=cast(tuple[int, int, int], self.shape),
             voxel_size_u=voxel_size_u,
             backend=self.backend,
             eps=self.eps,
@@ -647,6 +648,7 @@ class IndependentAtomProjection(
             is_real_space=is_real_space,
             shape_u=cast(tuple[int, int], shape_u),
             pixel_size_u=pixel_size_u,
+            shape_out=cast(tuple[int, int], shape),
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -765,6 +767,7 @@ def project_impl(
     is_real_space: bool,
     shape_u: tuple[int, int],
     pixel_size_u: Float[Array, ""],
+    shape_out: tuple[int, int],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -801,6 +804,13 @@ def project_impl(
         )
         return projection
 
+    # Per-dimension NUFFT offset: 2*pi*(N//2)/N maps physical center (x=0) to
+    # integer pixel index N//2.  For even N this equals pi; for odd N it is
+    # pi*(1 - 1/N).  Must use the original output shape, not the upsampled one.
+    _nufft_offsets_2d = jnp.asarray(
+        [2 * jnp.pi * (s // 2) / s for s in shape_out[::-1][:2]]
+    )
+
     def fourier_impl(
         _shape: tuple[int, int],
         _ps: Float[Array, ""],
@@ -810,13 +820,18 @@ def project_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
+        # Scale positions onto the upsampled grid, then apply the shape_out-based
+        # center offset.  Do NOT apply the shape_u parity correction here: that
+        # correction is for the spread path; the NUFFT offset is entirely
+        # determined by shape_out regardless of the parity of shape_u.
+        _ns = jnp.asarray(_shape[::-1][:2], dtype=float)
+        xy = 2 * jnp.pi * _positions[:, :2] / (_ps * _ns) + _nufft_offsets_2d
         return (
             eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh)
             * _nufft2d1(
                 _shape,  # type: ignore
                 source=_amplitudes.astype(complex),
-                xy=xy + jnp.pi,
+                xy=xy,
                 backend=backend,
                 eps=eps,
                 options=options,
@@ -862,6 +877,7 @@ def render_impl(
     is_real_space: bool,
     shape_u: tuple[int, int, int],
     voxel_size_u: Float[Array, ""],
+    shape_out: tuple[int, int, int],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -875,6 +891,8 @@ def render_impl(
         shape_u, voxel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
     frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=0)
+
+    _nufft_offsets_3d = jnp.asarray([2 * jnp.pi * (s // 2) / s for s in shape_out[::-1]])
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -909,13 +927,13 @@ def render_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        xyz = _normalize_positions(_positions, _shape, _vs)
-        # Compute
+        _ns = jnp.asarray(_shape[::-1], dtype=float)
+        xyz = 2 * jnp.pi * _positions / (_vs * _ns) + _nufft_offsets_3d
         return eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh) * (
             _nufft3d1(
                 _shape,  # type: ignore
                 source=_amplitudes.astype(complex),
-                xyz=xyz + jnp.pi,
+                xyz=xyz,
                 backend=backend,
                 eps=eps,
                 options=options,
@@ -1314,5 +1332,12 @@ def _normalize_positions(
     shape: tuple[int, ...],
     pixel_size: Array,
 ) -> Array:
-    box_size = tuple(pixel_size * s for s in shape[::-1])
-    return 2 * jnp.pi * positions / jnp.asarray(box_size)
+    ndim = positions.shape[-1]
+    # shape is (z, y, x) or (y, x); reverse so first element is x
+    shape_spatial = shape[::-1][:ndim]
+    ns = jnp.asarray(shape_spatial, dtype=float)
+    # Center is at index N//2 for all N (RELION convention).
+    # For even N the offset is 0; for odd N it is -π/N so that x=0 lands
+    # exactly on pixel N//2 after fold_rescale.
+    offsets = jnp.pi * jnp.asarray([-(s % 2) / s for s in shape_spatial])
+    return 2 * jnp.pi * positions / (pixel_size * ns) + offsets

--- a/cryojax/simulator/_volume/independent_atom_volume.py
+++ b/cryojax/simulator/_volume/independent_atom_volume.py
@@ -12,8 +12,6 @@ import nufftax
 from jaxtyping import Array, Float, Inexact, PyTree
 from nufftax.core import Kernel, spread_2d, spread_3d
 
-from cryojax.ndimage._operators._fourier_operator import FourierGaussian
-
 from ..._internal import error_if_not_positive
 from ...constants import (
     LobatoScatteringFactorParameters,
@@ -24,14 +22,15 @@ from ...jax_util import FloatLike, NDArrayLike
 from ...ndimage import (
     AbstractFourierOperator,
     AbstractRealOperator,
+    FourierGaussian,
     FourierSinc,
     RealGaussian,
     convert_fftn_to_rfftn,
     fftn,
     ifftn,
     irfftn,
-    make_1d_frequency_grid,
     make_frequency_grid,
+    query_efficient_grid_size,
     resize_with_crop_or_pad,
     rfftn,
 )
@@ -44,6 +43,7 @@ from .base_volume import (
     ProjectionArray,
     VoxelArray,
 )
+from .common import make_frequencies_1d
 
 
 try:
@@ -438,9 +438,10 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=3)
-        upsampfac = _standardize_upsampfac(
-            self.upsample_factor,
-            dims=self.shape,
+        (shape_u, voxel_size_u), upsampfac = _prepare_upsample(
+            shape=self.shape,
+            pixel_size=self.voxel_size,
+            upsampfac=self.upsample_factor,
             sampling_mode=self.sampling_mode,
             is_real_space=is_real_space,
         )
@@ -453,31 +454,14 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
                 sampling_mode=sampling_mode,
                 upsampfac=upsampfac,
             )
-        # Upsampling arguments
-        if upsampfac > 1:
-            shape_u, voxel_size_u = (
-                (
-                    int(upsampfac * self.shape[0]),
-                    int(upsampfac * self.shape[1]),
-                    int(upsampfac * self.shape[2]),
-                ),
-                self.voxel_size / upsampfac,
-            )
-        else:
-            shape_u, voxel_size_u = self.shape, self.voxel_size
-        frequencies_1d = tuple(
-            make_1d_frequency_grid(s, voxel_size_u, outputs_rfftfreqs=False)
-            for s in shape_u[::-1]
-        )
         # Compute
         rendering_out = render_impl(
             positions,
             kernel_fns,
             amplitudes,
             is_real_space=is_real_space,
-            shape_u=shape_u,
+            shape_u=cast(tuple[int, int, int], shape_u),
             voxel_size_u=voxel_size_u,
-            frequencies_1d=frequencies_1d,
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -503,6 +487,7 @@ class IndependentAtomRenderFn(AbstractVolumeRenderFn[IndependentAtomVolume], str
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=self.voxel_size)
+            frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=1)
             rendering_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if self.shape != shape_u:
@@ -638,9 +623,10 @@ class IndependentAtomProjection(
         )
         amplitudes = _standardize_amplitudes(volume_representation.amplitudes, positions)
         is_real_space, kernel_fns = _standardize_kernel_fns(kernel_fns, spatial_dim=2)
-        upsampfac = _standardize_upsampfac(
-            self.upsample_factor,
-            dims=shape,
+        (shape_u, pixel_size_u), upsampfac = _prepare_upsample(
+            shape=shape,
+            pixel_size=pixel_size,
+            upsampfac=self.upsample_factor,
             sampling_mode=self.sampling_mode,
             is_real_space=is_real_space,
         )
@@ -653,27 +639,14 @@ class IndependentAtomProjection(
                 sampling_mode=sampling_mode,
                 upsampfac=upsampfac,
             )
-        # Upsampled shape and pixel size
-        if upsampfac > 1:
-            shape_u, pixel_size_u = (
-                (int(upsampfac * shape[0]), int(upsampfac * shape[1])),
-                pixel_size / upsampfac,
-            )
-        else:
-            shape_u, pixel_size_u = shape, pixel_size
-        frequencies_1d = tuple(
-            make_1d_frequency_grid(s, pixel_size_u, outputs_rfftfreqs=False)
-            for s in shape_u[::-1]
-        )
         # Compute projection
         projection_out = project_impl(
             positions,
             kernel_fns,
             amplitudes,
             is_real_space=is_real_space,
-            shape_u=shape_u,
+            shape_u=cast(tuple[int, int], shape_u),
             pixel_size_u=pixel_size_u,
-            frequencies_1d=frequencies_1d,
             backend=self.backend,
             eps=self.eps,
             options=self.options,
@@ -693,6 +666,7 @@ class IndependentAtomProjection(
         # Average within a pixel size
         if sampling_mode == "average":
             box_fn = FourierSinc(box_width=pixel_size)
+            frequencies_1d = make_frequencies_1d(shape_u, pixel_size_u, modeord=1)
             projection_fft *= eval_separable_impl(box_fn, frequencies_1d)
         # Downsample by extracting fourier modes
         if shape != shape_u:
@@ -791,7 +765,6 @@ def project_impl(
     is_real_space: bool,
     shape_u: tuple[int, int],
     pixel_size_u: Float[Array, ""],
-    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -804,6 +777,7 @@ def project_impl(
     frequency_grid = _maybe_make_frequency_grid(
         shape_u, pixel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
+    frequencies_1d = make_frequencies_1d(shape_u, pixel_size_u, modeord=0)
 
     def real_impl(
         _shape: tuple[int, int],
@@ -812,25 +786,16 @@ def project_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
-        dim = _shape[0]
-        if not all(s == dim for s in _shape):
-            raise ValueError(
-                "`IndependentAtomProjection` for real-valued kernels "
-                "only supports rendering square images. Found a shape "
-                f"equal to {shape_u}."
-            )
         nspread = _eps_to_nspread(eps)
-        (ny, nx) = _shape
-        box_xy = _ps * jnp.asarray((nx, ny), dtype=float)
-        xy = 2 * jnp.pi * _positions[:, :2] / box_xy
+        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
         projection = _spread_2d(
             kernel_fn=_kernel_fn,
             pixel_size=_ps,
             x=xy[:, 0],
             y=xy[:, 1],
             c=_amplitudes.astype(float),
-            nf1=dim,
-            nf2=dim,
+            nf1=_shape[1],
+            nf2=_shape[0],
             nspread=nspread,
             options=options,
         )
@@ -845,22 +810,18 @@ def project_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        (ny, nx) = _shape
-        box_xy = _ps * jnp.asarray((nx, ny))
-        # Compute
+        xy = _normalize_positions(_positions[:, :2], _shape, _ps)
         return (
             eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh)
-            * jnp.fft.ifftshift(
-                _nufft2d1(
-                    _shape,  # type: ignore
-                    source=_amplitudes.astype(complex),
-                    xy=2 * jnp.pi * _positions[:, :2] / box_xy,
-                    backend=backend,
-                    eps=eps,
-                    options=options,
-                )
-                / _ps**2
+            * _nufft2d1(
+                _shape,  # type: ignore
+                source=_amplitudes.astype(complex),
+                xy=xy + jnp.pi,
+                backend=backend,
+                eps=eps,
+                options=options,
             )
+            / _ps**2
         )
 
     if is_real_space:
@@ -887,6 +848,8 @@ def project_impl(
             project_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf
         ),
     )
+    if not is_real_space:
+        projection_out = jnp.fft.ifftshift(projection_out)
 
     return projection_out
 
@@ -899,7 +862,6 @@ def render_impl(
     is_real_space: bool,
     shape_u: tuple[int, int, int],
     voxel_size_u: Float[Array, ""],
-    frequencies_1d: tuple[Array, ...],
     backend: Literal["jax-finufft", "nufftax"],
     eps: float,
     options: dict[str, Any],
@@ -912,6 +874,7 @@ def render_impl(
     frequency_grid = _maybe_make_frequency_grid(
         shape_u, voxel_size_u, is_real_space=is_real_space, kernel_fns=kernel_fns
     )
+    frequencies_1d = make_frequencies_1d(shape_u, voxel_size_u, modeord=0)
 
     def real_impl(
         _shape: tuple[int, int, int],
@@ -920,17 +883,8 @@ def render_impl(
         _kernel_fn: AbstractRealOperator,
         _amplitudes: Inexact[Array, " _"],
     ) -> Array:
-        dim = _shape[0]
-        if not all(s == dim for s in _shape):
-            raise ValueError(
-                "`IndependentAtomRenderFn` for real-valued kernels "
-                "only supports rendering square voxel arrays. Found a shape "
-                f"equal to {(_shape[0], _shape[1], _shape[2])}"
-            )
         nspread = _eps_to_nspread(eps)
-        (nz, ny, nx) = _shape
-        box_xyz = _vs * jnp.asarray((nx, ny, nz), dtype=float)
-        xyz = 2 * jnp.pi * _positions / box_xyz
+        xyz = _normalize_positions(_positions, _shape, _vs)
         rendering = _spread_3d(
             kernel_fn=_kernel_fn,
             voxel_size=_vs,
@@ -938,9 +892,9 @@ def render_impl(
             y=xyz[:, 1],
             z=xyz[:, 2],
             c=_amplitudes.astype(float),
-            nf1=dim,
-            nf2=dim,
-            nf3=dim,
+            nf1=_shape[2],
+            nf2=_shape[1],
+            nf3=_shape[0],
             nspread=nspread,
             options=options,
         )
@@ -955,35 +909,34 @@ def render_impl(
         _f_1d: tuple[Array, ...],
         _f_mesh: Array | None,
     ) -> Array:
-        (nz, ny, nx) = _shape
-        box_xyz = _vs * jnp.asarray((nx, ny, nz))
+        xyz = _normalize_positions(_positions, _shape, _vs)
         # Compute
         return eval_kernel_impl(_kernel_fn, f_1d=_f_1d, f_mesh=_f_mesh) * (
-            jnp.fft.ifftshift(
-                _nufft3d1(
-                    _shape,  # type: ignore
-                    source=_amplitudes.astype(complex),
-                    xyz=2 * jnp.pi * _positions / box_xyz,
-                    backend=backend,
-                    eps=eps,
-                    options=options,
-                )
-                / _vs**3
+            _nufft3d1(
+                _shape,  # type: ignore
+                source=_amplitudes.astype(complex),
+                xyz=xyz + jnp.pi,
+                backend=backend,
+                eps=eps,
+                options=options,
             )
+            / _vs**3
         )
 
     if is_real_space:
-        render_impl, args = real_impl, ()
+        compute_fn, args = real_impl, ()
     else:
-        render_impl, args = cast(Any, (fourier_impl, (frequencies_1d, frequency_grid)))
+        compute_fn, args = cast(Any, (fourier_impl, (frequencies_1d, frequency_grid)))
 
-    render_dispatch = lambda _positions, _kernel_fn, _amplitudes: render_impl(
+    render_dispatch = lambda _positions, _kernel_fn, _amplitudes: compute_fn(
         shape_u, voxel_size_u, _positions, _kernel_fn, _amplitudes, *args
     )
     rendering_out = jax.tree.reduce(
         lambda x, y: x + y,
         jax.tree.map(render_dispatch, positions, kernel_fns, amplitudes, is_leaf=is_leaf),
     )
+    if not is_real_space:
+        rendering_out = jnp.fft.ifftshift(rendering_out)
 
     return rendering_out
 
@@ -1100,9 +1053,6 @@ def _nufft3d1(
 
 
 def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, options):
-    assert nf1 == nf2 == nf3
-    dim = nf1
-
     @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None, None))
     def spread_3d_impl(_kernel_fn, _voxel_size, _x, _y, _z, _c):
         return spread_3d(
@@ -1110,11 +1060,11 @@ def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, opt
             y=_y,
             z=_z,
             c=_c,
-            nf1=dim,
-            nf2=dim,
-            nf3=dim,
+            nf1=nf1,
+            nf2=nf2,
+            nf3=nf3,
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_voxel_size, nspread=nspread
+                _kernel_fn, pixel_size=_voxel_size, nspread=nspread
             ),
             **options,
         )
@@ -1123,19 +1073,16 @@ def _spread_3d(kernel_fn, voxel_size, x, y, z, c, nf1, nf2, nf3, *, nspread, opt
 
 
 def _spread_2d(kernel_fn, pixel_size, x, y, c, nf1, nf2, *, nspread, options):
-    assert nf1 == nf2
-    dim = nf1
-
     @eqx.filter_vmap(in_axes=(eqx.if_array(0), None, None, None, None))
     def spread_2d_impl(_kernel_fn, _pixel_size, _x, _y, _c):
         return spread_2d(
             x=_x,
             y=_y,
             c=_c,
-            nf1=dim,
-            nf2=dim,
+            nf1=nf1,
+            nf2=nf2,
             kernel_params=_make_nufftax_kernel(
-                _kernel_fn, image_dim=dim, pixel_size=_pixel_size, nspread=nspread
+                _kernel_fn, pixel_size=_pixel_size, nspread=nspread
             ),
             **options,
         )
@@ -1145,17 +1092,16 @@ def _spread_2d(kernel_fn, pixel_size, x, y, c, nf1, nf2, *, nspread, options):
 
 def _eps_to_nspread(eps: float) -> int:
     # FINUFFT heuristic for choosing `nspread` parameter
-    # based on desired precision `eps`
-    max_nspread = 16
+    # based on desired precision `eps`. In this context it is
+    # used for spreading gaussians, so we let it be unbounded
     log_tol = -math.log10(max(eps, 1e-16))
-    return max(2, min(int(math.ceil(log_tol + 1)), max_nspread))
+    return max(2, int(math.ceil(log_tol + 1)))
 
 
 def _build_extraction_mesh(
     shape: tuple[int, ...], shape_ds: tuple[int, ...], *, modeord: int
 ):
     """Build indices to extract modes from FFT output."""
-
     assert len(shape) == len(shape_ds)
     assert len(shape) in [2, 3]
     mean_factor = math.prod(shape_ds) / math.prod(shape)
@@ -1195,14 +1141,12 @@ def _standardize_amplitudes(amplitudes: PyTree[Array] | None, positions: PyTree[
 def _make_nufftax_kernel(
     kernel_fn: AbstractRealOperator,
     *,
-    image_dim: int,
     pixel_size: Float[Array, ""],
     nspread: int,
 ):
-    offset = 0.5 if image_dim % 2 == 1 else 0.0
     return Kernel(
         nspread=nspread,
-        phi=lambda _z: eqx.filter_vmap(kernel_fn)(pixel_size * (_z + offset)),
+        phi=lambda _z: eqx.filter_vmap(kernel_fn)(pixel_size * _z),
     )
 
 
@@ -1234,20 +1178,40 @@ def _make_erf(gaussian: RealGaussian, pixel_size: Float[Array, ""]):
     )
 
 
-def _standardize_upsampfac(
+def _prepare_upsample(
+    shape: tuple[int, ...],
+    pixel_size: Float[Array, ""],
     upsampfac: float | None,
     *,
-    dims: tuple[int, ...],
     is_real_space: bool,
     sampling_mode: Literal["point", "average"],
-) -> float:
+) -> tuple[tuple[tuple[int, ...], Array], float]:
     """Find the upsampfac that perfectly divides the upsampled
     image shape.
     """
     if upsampfac is None:
         upsampfac = 1.0 if (is_real_space and sampling_mode == "average") else 2.0
-    gcd = ft.reduce(math.gcd, dims)
-    return round(gcd * upsampfac) / gcd
+    if upsampfac == 1.0:
+        return (shape, pixel_size), upsampfac
+    else:
+        dim = shape[0]
+        if not all(s == dim for s in shape):
+            # If rectangular image focus on accuracy. Make sure
+            # `upsampfac` is mapped directly onto a pixel size
+            # dilation
+            gcd = ft.reduce(math.gcd, shape)
+            upsampfac = round(gcd * upsampfac) / gcd
+            shape_u = tuple(s * upsampfac for s in shape)
+        else:
+            # Otherwise, find an efficient grid for FFTs close to
+            # the requested upsampfac and return the corrected upsampfac
+            shape_u = query_efficient_grid_size(shape, upsampfac, match_parity=False)
+            dim_u = shape_u[0]
+            upsampfac = dim_u / dim
+        return (
+            (tuple(int(upsampfac * s) for s in shape), pixel_size / upsampfac),
+            upsampfac,
+        )
 
 
 def _prepare_real_to_fft(a: Array, *, outputs_rfft: bool, fftshifted: bool) -> Array:
@@ -1289,7 +1253,7 @@ def _maybe_make_frequency_grid(
     elif all_separable:
         frequency_grid = None
     else:
-        frequency_grid = make_frequency_grid(shape, pixel_size)
+        frequency_grid = make_frequency_grid(shape, pixel_size, fftshifted=True)
 
     return frequency_grid
 
@@ -1343,3 +1307,12 @@ def eval_separable_impl(
 def eval_non_separable_impl(kernel_fn: AbstractFourierOperator, frequency_grid: Array):
     assert frequency_grid.shape[-1] in [2, 3]
     return kernel_fn(frequency_grid)
+
+
+def _normalize_positions(
+    positions: Array,
+    shape: tuple[int, ...],
+    pixel_size: Array,
+) -> Array:
+    box_size = tuple(pixel_size * s for s in shape[::-1])
+    return 2 * jnp.pi * positions / jnp.asarray(box_size)

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -306,7 +306,7 @@ def _project_with_nufft(
     # Normalize coordinates betweeen -pi and pi
     ny, nx = shape
     box_xy = jnp.asarray((nx, ny))
-    coordinates_periodic = 2 * jnp.pi * coordinates_xy / box_xy
+    coordinates_periodic = (2 * jnp.pi * coordinates_xy / box_xy) + jnp.pi
     # Unpack and compute
     x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     if backend == "jax-finufft":
@@ -323,17 +323,10 @@ def _project_with_nufft(
         )
     else:
         projection_fft = nufftax.nufft2d1(
-            n_modes=shape[::-1],
-            c=weights,
-            x=x,
-            y=y,
-            eps=eps,
-            isign=-1,
+            n_modes=shape[::-1], c=weights, x=x, y=y, eps=eps, isign=-1
         )
-    # Shift zero frequency component to corner
-    projection_fft = jnp.fft.ifftshift(projection_fft)
     # Convert to rfftn output
-    return convert_fftn_to_rfftn(projection_fft, mode="real")
+    return convert_fftn_to_rfftn(jnp.fft.ifftshift(projection_fft), mode="real")
 
 
 def _make_opts():

--- a/cryojax/simulator/_volume/real_voxels.py
+++ b/cryojax/simulator/_volume/real_voxels.py
@@ -303,10 +303,13 @@ def _project_with_nufft(
     )
     # Get x and y coordinates
     coordinates_xy = coordinate_list[:, :2]
-    # Normalize coordinates betweeen -pi and pi
+    # Normalize coordinates to [-pi, pi) such that the center voxel (index N//2)
+    # maps to theta = 2*pi*(N//2)/N.  For even N this equals pi (same as before);
+    # for odd N it equals pi*(1 - 1/N).
     ny, nx = shape
-    box_xy = jnp.asarray((nx, ny))
-    coordinates_periodic = (2 * jnp.pi * coordinates_xy / box_xy) + jnp.pi
+    box_xy = jnp.asarray((nx, ny), dtype=float)
+    center_xy = jnp.asarray([nx // 2, ny // 2], dtype=float)
+    coordinates_periodic = 2 * jnp.pi * (coordinates_xy + center_xy) / box_xy
     # Unpack and compute
     x, y = coordinates_periodic[:, 0], coordinates_periodic[:, 1]
     if backend == "jax-finufft":

--- a/tests/test_image_config.py
+++ b/tests/test_image_config.py
@@ -1,6 +1,63 @@
+import math
+
 import cryojax.simulator as cxs
 import equinox as eqx
 import pytest
+
+
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_pad_scale_one_equals_shape(cls_name):
+    cls = getattr(cxs, cls_name)
+    shape = (64, 64)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(shape, pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=1.0, **extra)
+    assert cfg.padded_shape == shape
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+@pytest.mark.parametrize("pad_scale", [1.5, 2.0])
+def test_pad_scale_greater_than_one(cls_name, pad_scale):
+    cls = getattr(cxs, cls_name)
+    shape = (64, 64)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(
+        shape, pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=pad_scale, **extra
+    )
+    for s, p in zip(shape, cfg.padded_shape):
+        assert p >= math.ceil(pad_scale * s)
+        assert _is_smooth(p)
+        assert (s % 2) == (p % 2), "parity not preserved"
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_explicit_padded_shape_overrides_pad_scale(cls_name):
+    cls = getattr(cxs, cls_name)
+    shape, padded_shape = (64, 64), (80, 80)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    cfg = cls(
+        shape,
+        pixel_size=1.0,
+        voltage_in_kilovolts=300.0,
+        padded_shape=padded_shape,
+        pad_scale=1.5,
+        **extra,
+    )
+    assert cfg.padded_shape == padded_shape
+
+
+@pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])
+def test_pad_scale_less_than_one_raises(cls_name):
+    cls = getattr(cxs, cls_name)
+    extra = {"electron_dose": 20.0} if cls_name == "DoseImageConfig" else {}
+    with pytest.raises(ValueError, match="pad_scale"):
+        cls((64, 64), pixel_size=1.0, voltage_in_kilovolts=300.0, pad_scale=0.5, **extra)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_image_config.py
+++ b/tests/test_image_config.py
@@ -33,7 +33,6 @@ def test_pad_scale_greater_than_one(cls_name, pad_scale):
     for s, p in zip(shape, cfg.padded_shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-        assert (s % 2) == (p % 2), "parity not preserved"
 
 
 @pytest.mark.parametrize("cls_name", ["BasicImageConfig", "DoseImageConfig"])

--- a/tests/test_image_transforms.py
+++ b/tests/test_image_transforms.py
@@ -15,7 +15,7 @@ def voxel_info(sample_mrc_path):
 
 @pytest.fixture
 def voxel_volume(voxel_info):
-    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(voxel_info[0], pad_scale=1.3)
+    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(voxel_info[0], pad_scale=2.0)
 
 
 @pytest.fixture
@@ -148,7 +148,7 @@ def test_rotation_fn(basic_config, voxel_volume, use_rfft):
 def test_translation_fn(basic_config, voxel_volume, use_rfft):
     pose_notranslate = cxs.EulerAnglePose()
     pose_translate = cxs.EulerAnglePose(
-        offset_x_in_angstroms=50.0, offset_y_in_angstroms=-30.0
+        offset_x_in_angstroms=10.0, offset_y_in_angstroms=-5.0
     )
 
     image_model_notrans = cxs.make_image_model(
@@ -169,7 +169,7 @@ def test_translation_fn(basic_config, voxel_volume, use_rfft):
         grid = basic_config.get_frequency_grid(physical=True, full=True)
 
     shift_fn = im.PhaseShiftFFT(
-        offset=jnp.array([50.0, -30.0]),
+        offset=jnp.array([10.0, -5.0]),
         frequency_grid=grid,
     )
 
@@ -182,7 +182,7 @@ def test_translation_fn(basic_config, voxel_volume, use_rfft):
     else:
         image_trans = im.ifftn(shift_fn(im.fftn(image_notrans))).real
 
-    np.testing.assert_allclose(image_ref, image_trans)
+    np.testing.assert_allclose(image_ref, image_trans, atol=(0.0 if use_rfft else 5e-4))
 
 
 def _get_correlation(im1, im2):

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -18,7 +18,7 @@ def test_downsample_preserves_sum(shape, downsample_factor):
     upsampled_shape = tuple(downsample_factor * s for s in shape)
     rng_key = jr.key(seed=1234)
     upsampled_image = 2.0 + 1.0 * jr.normal(rng_key, upsampled_shape)
-    image = im.fourier_crop_downsample(upsampled_image, downsample_factor)
+    image = im.fourier_crop_to_shape(upsampled_image, shape)
     np.testing.assert_allclose(image.sum(), upsampled_image.sum())
 
 

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -276,6 +276,61 @@ def test_frc_fsc_jit(shape):
 #     np.testing.assert_allclose(crop_1, crop_2)
 
 
+#
+# query_efficient_grid_size
+#
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(10, 10), (11, 11), (13, 17), (100, 100), (10, 10, 10), (11, 13, 17)],
+)
+def test_query_efficient_grid_size_no_padding(shape):
+    result = im.query_efficient_grid_size(shape)
+    assert len(result) == len(shape)
+    for s, r in zip(shape, result):
+        assert r >= s
+        assert _is_smooth(r)
+
+
+@pytest.mark.parametrize(
+    "shape, pad_scale",
+    [((10, 10), 1.5), ((11, 11), 2.0), ((13, 17), 1.25), ((10, 10, 10), 1.5)],
+)
+def test_query_efficient_grid_size_with_pad_scale(shape, pad_scale):
+    import math
+
+    result = im.query_efficient_grid_size(shape, pad_scale=pad_scale)
+    assert len(result) == len(shape)
+    for s, r in zip(shape, result):
+        assert r >= math.ceil(pad_scale * s)
+        assert _is_smooth(r)
+
+
+@pytest.mark.parametrize(
+    "shape", [(10, 10), (11, 11), (10, 11), (10, 10, 10), (11, 13, 15)]
+)
+def test_query_efficient_grid_size_preserves_parity(shape):
+    result = im.query_efficient_grid_size(shape, pad_scale=1.5, match_parity=True)
+    for s, r in zip(shape, result):
+        assert (s % 2) == (r % 2), f"parity mismatch: shape dim {s}, result dim {r}"
+
+
+def test_query_efficient_grid_size_no_parity_constraint():
+    import math
+
+    shape, pad_scale = (11, 13), 1.5
+    result = im.query_efficient_grid_size(shape, pad_scale=pad_scale, match_parity=False)
+    for s, r in zip(shape, result):
+        assert _is_smooth(r)
+        assert r >= math.ceil(pad_scale * s)
+
+
 def test_operators_instantiate():
     frequency_grid_1d = im.make_1d_frequency_grid(10)
     frequency_grid_2d = im.make_frequency_grid((10, 10))

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -231,7 +231,6 @@ def test_fft_projection_peng(pdb_info, pixel_size, shape, upsampfac, eps):
             gaussian_volume, gaussian_integrator, image_config
         )
         proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-        # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
         np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
 
 
@@ -269,6 +268,7 @@ def test_real_projection_peng_erf(pdb_info, pixel_size, shape):
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
+    # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
     np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=1e-6)
 
 

--- a/tests/test_volume_integrators.py
+++ b/tests/test_volume_integrators.py
@@ -174,15 +174,27 @@ def test_fft_atom_projection_antialias(pdb_info, width, pixel_size, shape):
 
 
 @pytest.mark.parametrize(
-    "pixel_size, shape, upsampfac",
+    "pixel_size, shape, upsampfac, eps",
     (
-        (0.25, (134, 134), 2.62),
-        (0.25, (133, 133), 2),
-        (0.25, (134, 133), 3),
-        (0.25, (133, 133), 3),
+        (0.25, (134, 134), 2, 1e-5),
+        (0.25, (133, 133), 2, 1e-5),
+        (0.25, (134, 133), 2, 1e-5),
+        (0.25, (133, 134), 2, 1e-5),
+        (0.25, (134, 134), 3, 1e-5),
+        (0.25, (133, 133), 3, 1e-5),
+        (0.25, (134, 133), 3.0, 1e-5),
+        (0.25, (133, 134), 3.0, 1e-5),
+        (0.25, (134, 134), 2, 1e-6),
+        (0.25, (133, 133), 2, 1e-6),
+        (0.25, (134, 133), 2, 1e-6),
+        (0.25, (133, 134), 2, 1e-6),
+        (0.25, (134, 134), 3, 1e-6),
+        (0.25, (133, 133), 3, 1e-6),
+        (0.25, (134, 133), 3, 1e-6),
+        (0.25, (133, 134), 3, 1e-6),
     ),
 )
-def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
+def test_fft_projection_peng(pdb_info, pixel_size, shape, upsampfac, eps):
     for backend in ["jax-finufft", "nufftax"]:
         if jnufft is None and backend == "jax-finufft":
             continue
@@ -228,9 +240,11 @@ def test_fft_atom_projection_peng(pdb_info, pixel_size, shape, upsampfac):
     (
         (0.5, (64, 64)),
         (0.5, (63, 63)),
+        (0.5, (64, 63)),
+        (0.5, (63, 64)),
     ),
 )
-def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
+def test_real_projection_peng_erf(pdb_info, pixel_size, shape):
     atom_positions, atom_ids, _ = pdb_info
     positions_by_id, unique_atom_ids = split_atoms_by_element(atom_ids, atom_positions)
     peng_parameters, peng_parameters_by_id = (
@@ -240,35 +254,27 @@ def test_real_atom_projection_peng(pdb_info, pixel_size, shape):
     gaussian_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
         atom_positions,
         peng_parameters,
-        extra_b_factors=10.0,
     )
     atom_volume = cxs.IndependentAtomVolume.from_tabulated_parameters(
         positions_by_id,
         peng_parameters_by_id,
-        b_factor_by_element=10.0,
         use_real_space=True,
     )
     image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     # Check to make sure the implementations are identical, up to the
     # nufft (don't include anti-aliasing)
     gaussian_integrator = cxs.GaussianMixtureProjection(sampling_mode="average")
-    atom_integrator = cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-10)
+    atom_integrator = cxs.IndependentAtomProjection(sampling_mode="average", eps=1e-16)
     proj_by_gaussians = compute_projection(
         gaussian_volume, gaussian_integrator, image_config
     )
     proj_by_atoms = compute_projection(atom_volume, atom_integrator, image_config)
-    # _plot_image_compare(proj_by_gaussians, proj_by_atoms)
-    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=5e-3)
+    np.testing.assert_allclose(proj_by_gaussians, proj_by_atoms, atol=1e-6)
 
 
 @pytest.mark.parametrize(
     "pixel_size, shape",
-    (
-        (1.0, (32, 32)),
-        (1.0, (31, 31)),
-        (1.0, (31, 32)),
-        (1.0, (32, 31)),
-    ),
+    ((1.0, (32, 32)), (1.0, (33, 33)), (1.0, (38, 38)), (1.0, (37, 37))),
 )
 def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     """
@@ -277,15 +283,9 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
     """
     # Unpack PDB info
     atom_positions, atom_types, atom_properties = pdb_info
-    # Objects for imaging
-    image_config = cxs.BasicImageConfig(
-        shape,
-        pixel_size,
-        voltage_in_kilovolts=300.0,
-    )
     # Real vs fourier volumes
     dim = max(*shape)  # Make sure to use `padded_shape` here
-
+    image_config = cxs.BasicImageConfig(shape, pixel_size, voltage_in_kilovolts=300.0)
     peng_parameters = PengScatteringFactorParameters(atom_types)
     base_volume = cxs.GaussianMixtureVolume.from_tabulated_parameters(
         atom_positions,
@@ -320,6 +320,9 @@ def test_analytic_vs_voxels_nopose(pdb_info, pixel_size, shape):
         projection_by_other_method = compute_projection(
             volume, projection_method, image_config
         )
+        # _plot_image_compare(
+        #     projection_by_gaussian_integration, projection_by_other_method
+        # )
         # fig, axes = plt.subplots(figsize=(12, 4), ncols=3)
         # axes[0].imshow(projection_by_gaussian_integration)
         # axes[1].imshow(projection_by_other_method)

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -193,6 +193,42 @@ def test_voxel_volume_loaders():
     assert isinstance(real_volume.coordinate_grid_in_pixels, Float[Array, "_ _ _ 3"])  # type: ignore
 
 
+def _is_smooth(n: int) -> bool:
+    for p in (2, 3, 5):
+        while n % p == 0:
+            n //= p
+    return n == 1
+
+
+@pytest.mark.parametrize("pad_scale", (1.5, 2.0))
+def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
+    import math
+
+    shape = (10, 10, 10)
+    real_voxel_grid = jnp.zeros(shape, dtype=float)
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        real_voxel_grid, pad_scale=pad_scale
+    )
+    padded_shape = vol.fourier_voxel_grid.shape
+    for s, p in zip(shape, padded_shape):
+        assert p >= math.ceil(pad_scale * s)
+        assert _is_smooth(p)
+        assert (s % 2) == (p % 2), "parity not preserved"
+
+
+def test_fourier_voxel_grid_pad_scale_one_unchanged():
+    shape = (10, 10, 10)
+    real_voxel_grid = jnp.zeros(shape, dtype=float)
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=1.0)
+    assert vol.fourier_voxel_grid.shape == shape
+
+
+def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
+    real_voxel_grid = jnp.zeros((10, 10, 10), dtype=float)
+    with pytest.raises(ValueError, match="pad_scale"):
+        cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=0.5)
+
+
 @pytest.mark.parametrize("pad_scale", (1, 1.1))
 def test_sinc_correction(sample_mrc_path, pad_scale):
     real_voxel_grid = read_array_from_mrc(sample_mrc_path)

--- a/tests/test_volume_representations.py
+++ b/tests/test_volume_representations.py
@@ -213,7 +213,6 @@ def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
     for s, p in zip(shape, padded_shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-        assert (s % 2) == (p % 2), "parity not preserved"
 
 
 def test_fourier_voxel_grid_pad_scale_one_unchanged():


### PR DESCRIPTION
I found a while ago that my reconstructions in RELION weren't working. This may be why? Box size of odd image dim has zero in the center [-L/2, L/2], but we had zero where FFTs place their zero frequency. In reality, x = 0 is actually between two pixels.

This explained why it was a big pain to get finufft to match our conventions how we expect as well, so this PR includes some improvements and optimizations on that front now that conventions match. This is a somewhat significant PR, so let's take time to test things and merge.