### PR TITLE
Faster, more exact `cryojax.ndimage.fourier_crop_downsample`

### DIFF
--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -141,7 +141,7 @@ def fourier_crop_downsample(
     outputs_real_space: bool = True,
     preserve_mean: bool = False,
     *,
-    outputs_resolved_factor: Literal[False] = False,
+    outputs_factor: Literal[False] = False,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]: ...
 
 
@@ -152,7 +152,7 @@ def fourier_crop_downsample(
     outputs_real_space: bool = True,
     preserve_mean: bool = False,
     *,
-    outputs_resolved_factor: Literal[True],
+    outputs_factor: Literal[True],
 ) -> tuple[Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"], tuple[float, ...]]: ...
 
 
@@ -162,7 +162,7 @@ def fourier_crop_downsample(
     outputs_real_space: bool = True,
     preserve_mean: bool = False,
     *,
-    outputs_resolved_factor: bool = False,
+    outputs_factor: bool = False,
 ) -> (
     Inexact[Array, "_ _"]
     | Inexact[Array, "_ _ _"]
@@ -183,7 +183,7 @@ def fourier_crop_downsample(
     achievable with integer-pixel padding; the new shape and padding are
     instead chosen to make the achieved ratio as close to `downsample_factor`
     as possible (error shrinking as the output size grows), and this resolved
-    ratio can be recovered with `outputs_resolved_factor = True`.
+    ratio can be recovered with `outputs_factor = True`.
 
     **Arguments:**
 
@@ -198,7 +198,7 @@ def fourier_crop_downsample(
     - `preserve_mean`:
         Preserve the mean of the volume after downsampling, rather
         than the sum.
-    - `outputs_resolved_factor`:
+    - `outputs_factor`:
         If `True`, also return the downsample factor actually resolved on
         each axis, as a tuple the same length as `image_or_volume.ndim`.
         Equal to `downsample_factor` on every axis when `downsample_factor`
@@ -207,7 +207,7 @@ def fourier_crop_downsample(
     **Returns:**
 
     The downsampled `image_or_volume` at shape reduced by
-    `downsample_factor`. If `outputs_resolved_factor = True`, a
+    `downsample_factor`. If `outputs_factor = True`, a
     `(downsampled_array, resolved_downsample_factor)` tuple instead.
     """
     downsample_factor = float(downsample_factor)
@@ -248,7 +248,7 @@ def fourier_crop_downsample(
         shift=shift,
     )
 
-    if outputs_resolved_factor:
+    if outputs_factor:
         return downsampled_array, resolved_factor
     else:
         return downsampled_array
@@ -329,10 +329,7 @@ def _fourier_crop_to_shape(
             shift=shift,
         )
     n_pixels, n_pixels_ds = math.prod(image_or_volume.shape), math.prod(shape)
-    if outputs_real_space:
-        return signal
-    else:
-        return (n_pixels_ds / n_pixels) * signal if preserve_mean else signal
+    return (n_pixels_ds / n_pixels) * signal if preserve_mean else signal
 
 
 def _phase_shift_factor(

--- a/cryojax/ndimage/_downsample.py
+++ b/cryojax/ndimage/_downsample.py
@@ -2,6 +2,7 @@
 
 import math
 from collections.abc import Callable
+from typing import Literal, overload
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -9,7 +10,7 @@ from jax import lax
 from jaxtyping import Array, Complex, Float, Inexact
 
 from ..jax_util import NDArrayLike
-from ._coordinates import make_frequency_grid
+from ._coordinates import make_1d_frequency_grid, make_frequency_grid
 from ._edges import crop_to_shape
 from ._fft import fftn, ifftn, rfftn
 
@@ -109,13 +110,80 @@ def block_reduce_downsample(
     return array_ds
 
 
+def _resolve_downsample_shape_and_padding(
+    shape: tuple[int, ...], downsample_factor: float
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[float, ...]]:
+    """For each axis, find the new (downsampled) length and the amount of
+    real-space padding needed so that `(length + padding) / new_length` is as
+    close as possible to `downsample_factor` -- exactly equal, if
+    `downsample_factor` is an integer.
+    """
+    new_shape = []
+    pad_widths = []
+    achieved_factor = []
+    for length in shape:
+        new_length = max(1, round(length / downsample_factor))
+        padded_length = round(new_length * downsample_factor)
+        if padded_length < length:
+            # only pad up, never crop away input data
+            new_length += 1
+            padded_length = round(new_length * downsample_factor)
+        new_shape.append(new_length)
+        pad_widths.append(padded_length - length)
+        achieved_factor.append(padded_length / new_length)
+    return tuple(new_shape), tuple(pad_widths), tuple(achieved_factor)
+
+
+@overload
 def fourier_crop_downsample(
     image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
     downsample_factor: float | int,
     outputs_real_space: bool = True,
     preserve_mean: bool = False,
-) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
+    *,
+    outputs_resolved_factor: Literal[False] = False,
+) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]: ...
+
+
+@overload
+def fourier_crop_downsample(
+    image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
+    downsample_factor: float | int,
+    outputs_real_space: bool = True,
+    preserve_mean: bool = False,
+    *,
+    outputs_resolved_factor: Literal[True],
+) -> tuple[Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"], tuple[float, ...]]: ...
+
+
+def fourier_crop_downsample(
+    image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
+    downsample_factor: float | int,
+    outputs_real_space: bool = True,
+    preserve_mean: bool = False,
+    *,
+    outputs_resolved_factor: bool = False,
+) -> (
+    Inexact[Array, "_ _"]
+    | Inexact[Array, "_ _ _"]
+    | tuple[Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"], tuple[float, ...]]
+):
     """Downsample an array using fourier cropping.
+
+    To make `downsample_factor` exact (i.e. so that a caller can rescale a
+    pixel/voxel size by exactly `downsample_factor`, rather than by the ratio
+    implied by naively truncating `shape / downsample_factor`), the array is
+    first padded (by edge replication) so that its shape is an exact multiple
+    of the new, downsampled shape, then a sub-pixel phase shift is applied
+    before cropping in fourier space so that the downsampled array's center
+    stays anchored to the original (unpadded) array's own center.
+
+    This is exact whenever `downsample_factor` is an integer. For a
+    non-integer `downsample_factor`, an exact ratio is generally not
+    achievable with integer-pixel padding; the new shape and padding are
+    instead chosen to make the achieved ratio as close to `downsample_factor`
+    as possible (error shrinking as the output size grows), and this resolved
+    ratio can be recovered with `outputs_resolved_factor = True`.
 
     **Arguments:**
 
@@ -130,50 +198,60 @@ def fourier_crop_downsample(
     - `preserve_mean`:
         Preserve the mean of the volume after downsampling, rather
         than the sum.
+    - `outputs_resolved_factor`:
+        If `True`, also return the downsample factor actually resolved on
+        each axis, as a tuple the same length as `image_or_volume.ndim`.
+        Equal to `downsample_factor` on every axis when `downsample_factor`
+        is an integer.
 
     **Returns:**
 
     The downsampled `image_or_volume` at shape reduced by
-    `downsample_factor`.
+    `downsample_factor`. If `outputs_resolved_factor = True`, a
+    `(downsampled_array, resolved_downsample_factor)` tuple instead.
     """
     downsample_factor = float(downsample_factor)
     if downsample_factor < 1.0:
         raise ValueError(
             "Called `fourier_crop_downsample` with `downsample_factor` less than 1."
         )
-    if image_or_volume.ndim == 2:
-        image = image_or_volume
-        new_shape = (
-            int(image.shape[0] / downsample_factor),
-            int(image.shape[1] / downsample_factor),
-        )
-        downsampled_array = fourier_crop_to_shape(
-            image,
-            new_shape,
-            preserve_mean=preserve_mean,
-            outputs_real_space=outputs_real_space,
-        )
-    elif image_or_volume.ndim == 3:
-        volume = image_or_volume
-        new_shape = (
-            int(volume.shape[0] / downsample_factor),
-            int(volume.shape[1] / downsample_factor),
-            int(volume.shape[2] / downsample_factor),
-        )
-        downsampled_array = fourier_crop_to_shape(
-            volume,
-            new_shape,
-            preserve_mean=preserve_mean,
-            outputs_real_space=outputs_real_space,
-        )
-    else:
+    if image_or_volume.ndim not in (2, 3):
         raise ValueError(
             "`fourier_crop_downsample` was passed an array with "
             f"`ndim = {image_or_volume.ndim}`, but this function "
             "only supports images and volumes as input."
         )
+    new_shape, pad_widths, resolved_factor = _resolve_downsample_shape_and_padding(
+        image_or_volume.shape, downsample_factor
+    )
+    if any(pad_widths):
+        padded_array = jnp.pad(
+            image_or_volume, tuple((0, p) for p in pad_widths), mode="edge"
+        )
+        # For a given axis, padding by `p` pixels shifts that axis's center by
+        # `p / 2` in the common case -- except that `crop_to_shape`'s crop
+        # window is asymmetric by one pixel whenever the *padded* length on
+        # that axis is odd, which requires rounding `p / 2` down instead of up
+        # to compensate.
+        shift = tuple(
+            p // 2 if (s + p) % 2 == 1 else (p + 1) // 2
+            for s, p in zip(image_or_volume.shape, pad_widths)
+        )
+    else:
+        padded_array = image_or_volume
+        shift = None
+    downsampled_array = _fourier_crop_to_shape(
+        padded_array,
+        new_shape,  # type: ignore
+        outputs_real_space=outputs_real_space,
+        preserve_mean=preserve_mean,
+        shift=shift,
+    )
 
-    return downsampled_array
+    if outputs_resolved_factor:
+        return downsampled_array, resolved_factor
+    else:
+        return downsampled_array
 
 
 def fourier_crop_to_shape(
@@ -212,9 +290,35 @@ def fourier_crop_to_shape(
     The downsampled `image_or_volume`, at the new real-space shape
     `shape`.
     """
+    return _fourier_crop_to_shape(
+        image_or_volume,
+        shape,
+        outputs_real_space=outputs_real_space,
+        outputs_rfft=outputs_rfft,
+        preserve_mean=preserve_mean,
+    )
+
+
+def _fourier_crop_to_shape(
+    image_or_volume: Inexact[NDArrayLike, "_ _"] | Inexact[NDArrayLike, "_ _ _"],
+    shape: tuple[int, int] | tuple[int, int, int],
+    outputs_real_space: bool = True,
+    outputs_rfft: bool = True,
+    preserve_mean: bool = False,
+    shift: tuple[float, ...] | None = None,
+) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
+    """Shared backend for `fourier_crop_to_shape` and `fourier_crop_downsample`.
+
+    `shift` is an optional per-axis sub-pixel shift (in pixels/voxels of
+    `image_or_volume`), applied before cropping in fourier space. It is
+    private to this module: `fourier_crop_downsample` uses it to correct for
+    the real-space padding it applies before calling here, so the downsampled
+    array's center stays anchored to the original (unpadded) array's own
+    center; `fourier_crop_to_shape` always calls with `shift = None`.
+    """
     if jnp.iscomplexobj(image_or_volume):
         signal = _fft_ds_complex_signal_to_shape(
-            image_or_volume, shape, outputs_real_space=outputs_real_space
+            image_or_volume, shape, outputs_real_space=outputs_real_space, shift=shift
         )
     else:
         signal = _fft_ds_real_signal_to_shape(
@@ -222,6 +326,7 @@ def fourier_crop_to_shape(
             shape,
             outputs_real_space=outputs_real_space,
             outputs_rfft=outputs_rfft,
+            shift=shift,
         )
     n_pixels, n_pixels_ds = math.prod(image_or_volume.shape), math.prod(shape)
     if outputs_real_space:
@@ -230,22 +335,89 @@ def fourier_crop_to_shape(
         return (n_pixels_ds / n_pixels) * signal if preserve_mean else signal
 
 
+def _phase_shift_factor(
+    shape: tuple[int, ...], shift: tuple[float, ...], *, last_axis_is_rfft: bool
+) -> Array:
+    """Build the N-D phase ramp `exp(-2pi*i*sum(freq * shift))` as an outer
+    product of per-axis 1D phase factors, applied via broadcasting rather than
+    materializing a full N-D frequency grid."""
+    ndim = len(shape)
+    phase = jnp.asarray(1.0)
+    for axis in range(ndim):
+        freqs_1d = make_1d_frequency_grid(
+            shape[axis],
+            outputs_rfftfreqs=(last_axis_is_rfft and axis == ndim - 1),
+            fftshifted=not last_axis_is_rfft,
+        )
+        reshape = [1] * ndim
+        reshape[axis] = freqs_1d.shape[0]
+        phase = phase * jnp.exp(
+            -1.0j * 2 * jnp.pi * shift[axis] * freqs_1d.reshape(reshape)
+        )
+    return phase
+
+
 def _fft_ds_real_signal_to_shape(
     image_or_volume: Float[NDArrayLike, "_ _"] | Float[NDArrayLike, "_ _ _"],
     downsampled_shape: tuple[int, int] | tuple[int, int, int],
     outputs_real_space: bool = True,
     outputs_rfft: bool = True,
+    shift: tuple[float, ...] | None = None,
 ) -> Inexact[Array, "_ _"] | Inexact[Array, "_ _ _"]:
-    # Forward Hartley Transform
-    hartley_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(image_or_volume)))
+    shape = image_or_volume.shape
+    ndim = len(shape)
+
+    # Forward Hartley Transform, computed via `rfftn` (roughly half the
+    # compute/memory of a full `fftn`, since the input is real) instead of a
+    # full complex FFT. `rfftn` stores only the non-negative-frequency half of
+    # the last axis, in natural (DC-at-corner) order.
+    rfft_array = rfftn(jnp.fft.ifftshift(image_or_volume))
+    if shift is not None:
+        rfft_array = (
+            _phase_shift_factor(shape, shift, last_axis_is_rfft=True) * rfft_array
+        )
+
+    # Per axis, the natural-order indices of the low-frequency modes kept by
+    # `crop_to_shape`'s centered crop window (positive frequencies, then the
+    # wrapped negative frequencies), gathered directly by index rather than via
+    # `fftshift` + `crop_to_shape` + `ifftshift` on the full-size spectrum.
+    def _extraction_indices(dim: int, dim_ds: int) -> tuple[Array, Array]:
+        q_min = -(dim_ds // 2)
+        q_max = (dim_ds - 1) // 2
+        return jnp.arange(q_max + 1), jnp.arange(dim + q_min, dim)
+
+    idx_pos, idx_neg = zip(
+        *(
+            _extraction_indices(dim, dim_ds)
+            for dim, dim_ds in zip(shape, downsampled_shape)
+        )
+    )
+    # All axes but the last are stored in full by `rfftn` -- gather both the
+    # positive- and negative-frequency indices for those directly.
+    leading_idx = [jnp.concatenate([idx_pos[i], idx_neg[i]]) for i in range(ndim - 1)]
+    last_pos, last_neg = idx_pos[-1], idx_neg[-1]
+
+    block_pos = rfft_array[jnp.ix_(*leading_idx, last_pos)]
+    if last_neg.size > 0:
+        # The last axis's negative-frequency modes aren't stored by `rfftn`, so
+        # reconstruct them from Hermitian symmetry:
+        # `X[..., y_i, ..., N - m] = conj(X[..., (N_i - y_i) % N_i, ..., m])`,
+        # gathered from the already-computed `rfft_array` rather than via
+        # another transform.
+        m_neg = shape[-1] - last_neg
+        mirror_idx = [(shape[i] - leading_idx[i]) % shape[i] for i in range(ndim - 1)]
+        block_neg = jnp.conj(rfft_array[jnp.ix_(*mirror_idx, m_neg)])
+        hartley_array = jnp.concatenate([block_pos, block_neg], axis=-1)
+    else:
+        hartley_array = block_pos
     hartley_array = hartley_array.real - hartley_array.imag
 
-    # Crop to the desired shape
-    ds_array = crop_to_shape(hartley_array, downsampled_shape)
-
-    # Inverse Hartley Transform
-    ds_array = jnp.fft.fftshift(fftn(jnp.fft.ifftshift(ds_array)))
-    ds_array /= ds_array.size
+    # Inverse Hartley Transform. No `fftshift`/`ifftshift` is needed here (or
+    # before gathering `hartley_array` above): they are exact inverses of each
+    # other and the Hartley combine in between is pointwise, so the shifts that
+    # would otherwise bracket the crop cancel algebraically.
+    ds_array = jnp.fft.fftshift(fftn(hartley_array))
+    ds_array /= hartley_array.size
     ds_array = ds_array.real - ds_array.imag
 
     if outputs_real_space:
@@ -258,8 +430,14 @@ def _fft_ds_complex_signal_to_shape(
     image_or_volume: Complex[NDArrayLike, "_ _"] | Complex[NDArrayLike, "_ _ _"],
     downsampled_shape: tuple[int, int] | tuple[int, int, int],
     outputs_real_space: bool = True,
+    shift: tuple[float, ...] | None = None,
 ) -> Complex[Array, "_ _"] | Complex[Array, "_ _ _"]:
     fourier_array = jnp.fft.fftshift(fftn(image_or_volume))
+    if shift is not None:
+        fourier_array = (
+            _phase_shift_factor(image_or_volume.shape, shift, last_axis_is_rfft=False)
+            * fourier_array
+        )
 
     # Crop to the desired shape
     cropped_fourier_array = crop_to_shape(fourier_array, downsampled_shape)

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -22,6 +22,103 @@ def test_downsample_preserves_sum(shape, downsample_factor):
     np.testing.assert_allclose(image.sum(), upsampled_image.sum())
 
 
+def _flip_about_center(array):
+    """Flip an array about the RELION-convention real-space center (index
+    `shape // 2` on every axis), rather than about index `0` like `jnp.flip`.
+    Equal to `jnp.flip` on odd-length axes; requires an extra one-pixel roll
+    on even-length axes.
+    """
+    out = array
+    for axis, size in enumerate(array.shape):
+        out = jnp.flip(out, axis=axis)
+        if size % 2 == 0:
+            out = jnp.roll(out, shift=1, axis=axis)
+    return out
+
+
+@pytest.mark.parametrize(
+    "shape, downsample_factor",
+    (
+        ((20, 20), 2),
+        ((21, 21), 2),
+        ((20, 20), 3),
+        ((30, 30), 2.5),
+        ((16, 20), 2),
+        ((16, 16, 16), 2),
+    ),
+)
+def test_fourier_crop_downsample_center_unchanged(shape, downsample_factor):
+    # A real-space bump centered exactly at the RELION-convention center
+    # index (`shape // 2`) should still peak at the (downsampled) center
+    # index after downsampling.
+    coordinate_grid = im.make_coordinate_grid(shape)
+    image_or_volume = jnp.exp(-jnp.sum(coordinate_grid**2, axis=-1) / 8.0)
+    downsampled = im.fourier_crop_downsample(image_or_volume, downsample_factor)
+    peak_index = jnp.unravel_index(jnp.argmax(downsampled), downsampled.shape)
+    center_index = tuple(s // 2 for s in downsampled.shape)
+    assert peak_index == center_index
+
+
+@pytest.mark.parametrize(
+    "shape, downsample_factor",
+    (
+        ((20, 20), 2),
+        ((21, 21), 2),
+        ((20, 20), 3),
+        ((16, 20), 2),
+        ((15, 21), 3),
+        ((16, 16, 16), 2),
+    ),
+)
+def test_fourier_crop_downsample_preserves_center_symmetry(shape, downsample_factor):
+    # A real-space signal that is symmetric about the RELION-convention
+    # center should remain symmetric about that same (downsampled) center
+    # index after downsampling.
+    coordinate_grid = im.make_coordinate_grid(shape)
+    image_or_volume = jnp.exp(-jnp.sum(coordinate_grid**2, axis=-1) / 8.0)
+    downsampled = im.fourier_crop_downsample(image_or_volume, downsample_factor)
+    np.testing.assert_allclose(downsampled, _flip_about_center(downsampled), atol=1e-4)
+
+
+def test_fourier_crop_downsample_factor_one_is_identity():
+    rng_key = jr.key(seed=0)
+    image = jr.normal(rng_key, (10, 10))
+    downsampled = im.fourier_crop_downsample(image, 1)
+    np.testing.assert_allclose(downsampled, image, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "shape, pixel_size, downsample_factor, sigma",
+    (
+        ((60, 60), 0.5, 3, 8.0),
+        ((80, 80), 1.0, 2, 10.0),
+        ((63, 63), 0.75, 3, 9.0),
+        ((40, 40, 40), 0.5, 2, 6.0),
+    ),
+)
+def test_fourier_crop_downsample_matches_directly_rendered_gaussian(
+    shape, pixel_size, downsample_factor, sigma
+):
+    # Downsampling a well-resolved (i.e. not aliased -- `sigma` much greater
+    # than either pixel size) Gaussian rendered at a fine pixel size should
+    # quantitatively agree with directly rendering the same Gaussian at the
+    # coarse pixel size. `preserve_mean=True` is needed so that amplitude
+    # (rather than sum) is preserved, matching the amplitude-normalized,
+    # directly-rendered Gaussian.
+    fine_grid = im.make_coordinate_grid(shape) * pixel_size
+    fine_gaussian = jnp.exp(-jnp.sum(fine_grid**2, axis=-1) / (2 * sigma**2))
+
+    downsampled = im.fourier_crop_downsample(
+        fine_gaussian, downsample_factor, preserve_mean=True
+    )
+
+    coarse_shape = tuple(s // downsample_factor for s in shape)
+    coarse_grid = im.make_coordinate_grid(coarse_shape) * (pixel_size * downsample_factor)
+    coarse_gaussian = jnp.exp(-jnp.sum(coarse_grid**2, axis=-1) / (2 * sigma**2))
+
+    np.testing.assert_allclose(downsampled, coarse_gaussian, atol=2e-2)
+
+
 #
 # FFT
 #


### PR DESCRIPTION
Previous version did not downsample by the exact factor requested, and was 2x slower than it needed to be 