### PR TITLE
Only store half the Fourier grid in `FourierVoxelGridVolume`

### DIFF
--- a/cryojax/ndimage/_fourier_utils.py
+++ b/cryojax/ndimage/_fourier_utils.py
@@ -223,6 +223,6 @@ def make_fftshift_phase(
             indices = jnp.arange(n)
         p = jnp.where(indices % 2 == 0, 1.0, -1.0)
         reshape = [1] * ndim
-        reshape[ax] = n
+        reshape[ax] = indices.shape[0]
         phase = phase * p.reshape(reshape)
     return phase

--- a/cryojax/simulator/_api_utils.py
+++ b/cryojax/simulator/_api_utils.py
@@ -609,7 +609,7 @@ def render_voxel_volume(
         )
     if output_type == FourierVoxelGridVolume or output_type == FourierVoxelSplineVolume:
         fourier_voxel_grid = render_fn(
-            atom_volume, outputs_real_space=False, outputs_rfft=False
+            atom_volume, outputs_real_space=False, outputs_rfft=True
         )
         if output_type == FourierVoxelGridVolume:
             return FourierVoxelGridVolume.from_fourier_voxel_grid(fourier_voxel_grid)

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -3,7 +3,7 @@ Fourier voxel-based representations of a volume.
 """
 
 import abc
-from typing import Any, ClassVar, Self, cast
+from typing import Any, ClassVar, Self
 from typing_extensions import override
 
 import equinox as eqx
@@ -41,20 +41,7 @@ class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
     """Abstract interface for a voxel-based volume."""
 
     frequency_slice_in_pixels: eqx.AbstractVar[Float[Array, "1 dim dim 3"]]
-
-    def __check_init__(self):
-        if any(s % 2 == 1 for s in self.shape):
-            raise ValueError(
-                f"`{type(self).__name__}` does not support odd voxel map dimensions, "
-                f"but got a voxel map with shape `{self.shape}`. Please pass "
-                "a voxel map with even dimensions."
-            )
-        dim = self.shape[0]
-        if self.shape != (dim, dim, dim):
-            raise AttributeError(
-                f"Only cubic boxes are supported for `{type(self).__name__}.shape`, "
-                f"but got `shape = {self.shape}`."
-            )
+    is_rfft: eqx.AbstractVar[bool]
 
     @classmethod
     @abc.abstractmethod
@@ -73,6 +60,47 @@ class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
             pose.rotate_coordinates(
                 self.frequency_slice_in_pixels, inverse=self.is_frame_rotation
             ),
+        )
+
+
+def _check_voxel_array_shape(
+    shape: tuple[int, ...],
+    is_rfft: bool,
+    padding: int,
+    cls_name: str,
+    array_name: str,
+) -> None:
+    """Validate that `shape` (the raw stored array shape, e.g.
+    `fourier_voxel_grid.shape` or `spline_coefficients.shape`) is consistent
+    with a cubic, even-dimension volume, given `is_rfft` (whether the last
+    axis is RFFT-truncated) and `padding` (extra samples added per axis,
+    e.g. `2` for cubic-spline coefficients).
+    """
+    d0, d1, d2 = (s - padding for s in shape)
+    if d0 % 2 == 1:
+        raise ValueError(
+            f"`{cls_name}` does not support odd voxel map dimensions, but got "
+            f"a voxel map with `{array_name}.shape = {shape}`. Please pass a "
+            "voxel map with even dimensions."
+        )
+    expected_d2 = d0 // 2 + 1 if is_rfft else d0
+    if d1 != d0 or d2 != expected_d2:
+        expected_shape = tuple(s + padding for s in (d0, d0, expected_d2))
+        # Common misuse: the array is a valid voxel grid, just for the
+        # opposite `is_rfft` convention (e.g. passed the output of `rfftn`
+        # but left `is_rfft` at its default of `False`, or vice versa).
+        other_d2 = d0 if is_rfft else d0 // 2 + 1
+        if d1 == d0 and d2 == other_d2:
+            raise AttributeError(
+                f"`{array_name}` passed to `{cls_name}` has shape `{shape}`, "
+                f"which does not match `is_rfft={is_rfft}` (expected shape "
+                f"`{expected_shape}`). This shape matches `is_rfft={not is_rfft}` "
+                f"instead -- did you mean to set `is_rfft={not is_rfft}`?"
+            )
+        raise AttributeError(
+            f"`{array_name}` passed to `{cls_name}` has an invalid shape "
+            f"`{shape}`. Expected shape `{expected_shape}` for "
+            f"`is_rfft={is_rfft}`."
         )
 
 
@@ -108,36 +136,58 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         ```
     """  # noqa: E501
 
-    fourier_voxel_grid: Complex[Array, "dim dim dim"]
+    fourier_voxel_grid: Complex[Array, "dim dim dim"] | Complex[Array, "dim dim dim//2+1"]
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
+    is_rfft: bool = eqx.field(static=True)
 
     is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
-        fourier_voxel_grid: Complex[NDArrayLike, "dim dim dim"],
+        fourier_voxel_grid: (
+            Complex[NDArrayLike, "dim dim dim"] | Complex[NDArrayLike, "dim dim dim//2+1"]
+        ),
         frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim 3"],
+        is_rfft: bool = False,
     ):
         """**Arguments:**
 
         - `fourier_voxel_grid`:
-            The cubic voxel grid in fourier space.
+            The cubic voxel grid in fourier space. If `is_rfft = True`,
+            this is truncated to the half-space `(dim, dim, dim // 2 + 1)`,
+            as returned by `cryojax.ndimage.rfftn`.
         - `frequency_slice_in_pixels`:
             The frequency slice coordinate system.
+        - `is_rfft`:
+            Whether `fourier_voxel_grid` is a half-space RFFT grid (see
+            above) rather than the full FFT grid.
         """
         # Multiply by phase correction for interpolation logic
         self.fourier_voxel_grid = jnp.asarray(fourier_voxel_grid, dtype=complex)
+        _check_voxel_array_shape(
+            self.fourier_voxel_grid.shape,
+            is_rfft,
+            padding=0,
+            cls_name=type(self).__name__,
+            array_name="fourier_voxel_grid",
+        )
         self.frequency_slice_in_pixels = jnp.asarray(
             frequency_slice_in_pixels, dtype=float
         )
+        self.is_rfft = is_rfft
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        """The shape of the `fourier_voxel_grid`."""
-        return cast(tuple[int, int, int], self.fourier_voxel_grid.shape)
+        """The logical cubic shape of the volume, regardless of whether
+        `fourier_voxel_grid` is stored as a full or half-space (RFFT) grid.
+        """
+        dim = self.fourier_voxel_grid.shape[0]
+        return (dim, dim, dim)
 
     @classmethod
-    def from_fourier_voxel_grid(cls, fourier_voxel_grid: NDArrayLike) -> Self:
+    def from_fourier_voxel_grid(
+        cls, fourier_voxel_grid: NDArrayLike, *, is_rfft: bool = True
+    ) -> Self:
         """Load from a fourier-domain 3D voxel grid.
 
         This should be the output of
@@ -146,20 +196,28 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         import cryojax.simulator as cxs
         import cryojax.ndimage import im
 
-        fourier_voxel_grid = im.fftn(real_voxel_grid)
+        fourier_voxel_grid = im.rfftn(real_voxel_grid) if is_rfft else im.fftn(real_voxel_grid)
         volume = cxs.FourierVoxelSplineVolume(fourier_voxel_grid)
         ```
 
         **Arguments:**
 
         - `fourier_voxel_grid`:
-            A voxel grid in fourier space.
-        """
+            A voxel grid in fourier space. If `is_rfft = True`, this
+            should be the output of `cryojax.ndimage.rfftn`; otherwise,
+            the output of `cryojax.ndimage.fftn`.
+        - `is_rfft`:
+            Whether `fourier_voxel_grid` is the output of `cryojax.ndimage.rfftn`
+            (`True`, default) rather than `cryojax.ndimage.fftn` (`False`). If
+            `True`, the volume is stored as a half-space RFFT grid, halving
+            memory usage. This relies on the fact that `fourier_voxel_grid`
+            is the transform of a real-valued signal.
+        """  # noqa: E501
         fourier_voxel_grid, frequency_slice = _prepare_fourier_voxel_arguments(
-            jnp.asarray(fourier_voxel_grid)
+            jnp.asarray(fourier_voxel_grid), use_rfft=is_rfft
         )
 
-        return cls(jnp.asarray(fourier_voxel_grid), frequency_slice)
+        return cls(jnp.asarray(fourier_voxel_grid), frequency_slice, is_rfft=is_rfft)
 
     @classmethod
     def from_real_voxel_grid(
@@ -168,6 +226,7 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         *,
         apply_deconvolve: bool = False,
         pad_scale: float = 1.0,
+        use_rfft: bool = True,
     ) -> Self:
         """Load from a real-valued 3D voxel grid.
 
@@ -181,16 +240,20 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         - `pad_scale`:
             Scale factor at which to pad `real_voxel_grid` before fourier
             transform. Must be a value greater than `1.0`.
+        - `use_rfft`:
+            If `True` (default), store the volume as a half-space RFFT
+            grid, halving memory usage and speeding up construction (via
+            `cryojax.ndimage.rfftn` instead of `cryojax.ndimage.fftn`).
         """
         # Cast to JAX array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Preprocess to fourier grid, deconvolving after any padding so that
         # the sinc² correction uses the actual Fourier grid size.
         fourier_voxel_grid, frequency_slice = _real_to_fourier_voxels(
-            cls, real_voxel_grid, pad_scale, apply_deconvolve
+            cls, real_voxel_grid, pad_scale, apply_deconvolve, use_rfft=use_rfft
         )
 
-        return cls(fourier_voxel_grid, frequency_slice)
+        return cls(fourier_voxel_grid, frequency_slice, is_rfft=use_rfft)
 
 
 class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
@@ -198,41 +261,65 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
     by spline coefficients.
     """
 
-    spline_coefficients: Complex[Array, "coeff_dim coeff_dim coeff_dim"]
+    spline_coefficients: (
+        Complex[Array, "coeff_dim coeff_dim coeff_dim"]
+        | Complex[Array, "coeff_dim coeff_dim coeff_dim//2+1"]
+    )
     frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
+    is_rfft: bool = eqx.field(static=True)
 
     is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
-        spline_coefficients: Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim"],
+        spline_coefficients: (
+            Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim"]
+            | Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim//2+1"]
+        ),
         frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim 3"],
+        is_rfft: bool = False,
     ):
         """**Arguments:**
 
         - `spline_coefficients`:
             The spline coefficents computed from the cubic voxel grid
             in fourier space. See `cryojax.ndimage.compute_spline_coefficients`.
+            If `is_rfft = True`, these are computed from the half-space
+            RFFT grid (i.e. last axis of size `dim // 2 + 1`, before the
+            `+ 2` spline padding), as returned by `cryojax.ndimage.rfftn`.
         - `frequency_slice_in_pixels`:
             Frequency slice coordinate system.
             See `cryojax.coordinates.make_frequency_slice`.
+        - `is_rfft`:
+            Whether `spline_coefficients` were computed from a half-space
+            RFFT grid (see above) rather than the full FFT grid.
         """
         self.spline_coefficients = jnp.asarray(spline_coefficients, dtype=complex)
+        _check_voxel_array_shape(
+            self.spline_coefficients.shape,
+            is_rfft,
+            padding=2,
+            cls_name=type(self).__name__,
+            array_name="spline_coefficients",
+        )
         self.frequency_slice_in_pixels = jnp.asarray(
             frequency_slice_in_pixels, dtype=float
         )
+        self.is_rfft = is_rfft
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        """The shape of the original `fourier_voxel_grid` from which
-        `coefficients` were computed.
+        """The logical cubic shape of the original `fourier_voxel_grid`
+        from which `coefficients` were computed, regardless of whether it
+        was a full or half-space (RFFT) grid.
         """
-        return cast(
-            tuple[int, int, int], tuple([s - 2 for s in self.spline_coefficients.shape])
-        )
+        dim = self.spline_coefficients.shape[0] - 2
+        return (dim, dim, dim)
 
     @classmethod
-    def from_fourier_voxel_grid(cls, fourier_voxel_grid: NDArrayLike) -> Self:
+    def from_fourier_voxel_grid(
+        cls, fourier_voxel_grid: NDArrayLike, *, is_rfft: bool = True
+    ) -> Self:
         """Load from a fourier-domain 3D voxel grid.
 
         This should be the output of
@@ -241,26 +328,37 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         import cryojax.simulator as cxs
         import cryojax.ndimage import im
 
-        fourier_voxel_grid = im.fftn(real_voxel_grid)
+        fourier_voxel_grid = im.rfftn(real_voxel_grid) if is_rfft else im.fftn(real_voxel_grid)
         volume = cxs.FourierVoxelSplineVolume(fourier_voxel_grid)
         ```
 
         **Arguments:**
 
         - `fourier_voxel_grid`:
-            A voxel grid in fourier space.
-        """
+            A voxel grid in fourier space. If `is_rfft = True`, this
+            should be the output of `cryojax.ndimage.rfftn`; otherwise,
+            the output of `cryojax.ndimage.fftn`.
+        - `is_rfft`:
+            Whether `fourier_voxel_grid` is the output of `cryojax.ndimage.rfftn`
+            (`True`, default) rather than `cryojax.ndimage.fftn` (`False`). If
+            `True`, spline coefficients are computed from a half-space RFFT
+            grid, halving memory usage.
+        """  # noqa: E501
         fourier_voxel_grid, frequency_slice = _prepare_fourier_voxel_arguments(
-            jnp.asarray(fourier_voxel_grid)
+            jnp.asarray(fourier_voxel_grid), use_rfft=is_rfft
         )
         # Compute spline coefficients
         spline_coefficients = compute_spline_coefficients(fourier_voxel_grid)
 
-        return cls(spline_coefficients, frequency_slice)
+        return cls(spline_coefficients, frequency_slice, is_rfft=is_rfft)
 
     @classmethod
     def from_real_voxel_grid(
-        cls, real_voxel_grid: Float[NDArrayLike, "dim dim dim"], *, pad_scale: float = 1.0
+        cls,
+        real_voxel_grid: Float[NDArrayLike, "dim dim dim"],
+        *,
+        pad_scale: float = 1.0,
+        use_rfft: bool = True,
     ) -> Self:
         """Load from a real-valued 3D voxel grid.
 
@@ -271,17 +369,21 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         - `pad_scale`:
             Scale factor at which to pad `real_voxel_grid` before fourier
             transform. Must be a value greater than `1.0`.
+        - `use_rfft`:
+            If `True` (default), store the volume as a half-space RFFT
+            grid, halving memory usage and speeding up construction (via
+            `cryojax.ndimage.rfftn` instead of `cryojax.ndimage.fftn`).
         """
         # Cast to JAX array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Preprocess to fourier grid
         fourier_voxel_grid, frequency_slice = _real_to_fourier_voxels(
-            cls, real_voxel_grid, pad_scale
+            cls, real_voxel_grid, pad_scale, use_rfft=use_rfft
         )
         # Compute spline coefficients
         spline_coefficients = compute_spline_coefficients(fourier_voxel_grid)
 
-        return cls(spline_coefficients, frequency_slice)
+        return cls(spline_coefficients, frequency_slice, is_rfft=use_rfft)
 
 
 class FourierSliceExtraction(
@@ -364,6 +466,7 @@ class FourierSliceExtraction(
             fourier_projection = _extract_slice_spline(
                 volume_representation.spline_coefficients,
                 frequency_slice,
+                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -371,6 +474,7 @@ class FourierSliceExtraction(
             fourier_projection = _extract_slice(
                 volume_representation.fourier_voxel_grid,
                 frequency_slice,
+                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -484,6 +588,7 @@ class EwaldSphereExtraction(
                 frequency_slice,
                 image_config.pixel_size,
                 image_config.wavelength_in_angstroms,
+                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -493,6 +598,7 @@ class EwaldSphereExtraction(
                 frequency_slice,
                 image_config.pixel_size,
                 image_config.wavelength_in_angstroms,
+                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -614,13 +720,38 @@ def _extract_surface_from_voxel_grid(
     voxel_grid: Array,
     frequency_coordinates: Array,
     is_spline_coefficients: bool = False,
+    is_rfft: bool = False,
     **kwargs: Any,
 ):
     # Convert to logical coordinates
     N = frequency_coordinates.shape[1]
-    logical_coordinates = (frequency_coordinates * N) + N // 2
-    # Convert arguments to map_coordinates convention and compute
-    k_x, k_y, k_z = jnp.transpose(logical_coordinates, axes=[3, 0, 1, 2])
+    if is_rfft:
+        # `voxel_grid`'s last axis only stores non-negative frequencies
+        # along x (i.e. `F(-q) = conj(F(q))` is not stored, only `F(q)`
+        # for `q_x >= 0`). Reflect the whole 3-vector through the origin
+        # whenever `q_x < 0`, so we always look up a point with `q_x >= 0`,
+        # then conjugate the interpolated result to correct for it. This is
+        # exact, not an approximation: it's evaluated once per query point,
+        # on the continuous coordinate, before any interpolation taps are
+        # generated, so taps never straddle the truncation boundary.
+        sign = jnp.where(frequency_coordinates[..., 0] < 0, -1.0, 1.0)
+        reflected = sign[..., None] * frequency_coordinates
+        k_x = reflected[..., 0] * N  # rfft/corner convention: no N // 2 offset
+        k_y = reflected[..., 1] * N + N // 2
+        k_z = reflected[..., 2] * N + N // 2
+        # The centered axes' Nyquist bin (frequency -0.5) is stored only at
+        # index 0, not also at index N -- +0.5 and -0.5 are the same
+        # (aliased) physical frequency. Reflecting a coordinate that was
+        # exactly at -0.5 lands exactly on index N, one past the valid
+        # range; wrap that exact case back to index 0, without touching any
+        # other (genuinely out-of-bounds) coordinate.
+        k_y = jnp.where(k_y == N, 0.0, k_y)
+        k_z = jnp.where(k_z == N, 0.0, k_z)
+    else:
+        logical_coordinates = (frequency_coordinates * N) + N // 2
+        # Convert arguments to map_coordinates convention and compute
+        k_x, k_y, k_z = jnp.transpose(logical_coordinates, axes=[3, 0, 1, 2])
+        sign = None
     if is_spline_coefficients:
         spline_coefficients = voxel_grid
         surface = map_coordinates_spline(spline_coefficients, (k_z, k_y, k_x), **kwargs)[
@@ -629,6 +760,9 @@ def _extract_surface_from_voxel_grid(
     else:
         fourier_voxel_grid = voxel_grid
         surface = map_coordinates(fourier_voxel_grid, (k_z, k_y, k_x), **kwargs)[0, :, :]
+    if is_rfft:
+        assert sign is not None
+        surface = jnp.where(sign[0, :, :] < 0, jnp.conj(surface), surface)
     # FFT shift and multiply by (-1)^k phase factors
     surface = jnp.fft.ifftshift(make_fftshift_phase(surface.shape) * surface)
 
@@ -648,7 +782,11 @@ def _deconvolve_linear(real_voxel_grid: Array) -> Array:
 
 
 def _real_to_fourier_voxels(
-    cls, real_voxel_grid: Array, pad_scale: float, apply_deconvolve: bool = False
+    cls,
+    real_voxel_grid: Array,
+    pad_scale: float,
+    apply_deconvolve: bool = False,
+    use_rfft: bool = True,
 ) -> tuple[Array, Array]:
     if pad_scale == 1.0:
         shape_p = real_voxel_grid.shape
@@ -669,11 +807,20 @@ def _real_to_fourier_voxels(
     if apply_deconvolve:
         real_voxel_grid_p = _deconvolve_linear(real_voxel_grid_p)
 
-    return _prepare_fourier_voxel_arguments(fftn(real_voxel_grid_p))
+    transform = rfftn(real_voxel_grid_p) if use_rfft else fftn(real_voxel_grid_p)
+    return _prepare_fourier_voxel_arguments(transform, use_rfft=use_rfft)
 
 
-def _prepare_fourier_voxel_arguments(fourier_voxel_grid: Array) -> tuple[Array, Array]:
+def _prepare_fourier_voxel_arguments(
+    fourier_voxel_grid: Array, use_rfft: bool = True
+) -> tuple[Array, Array]:
     dim = fourier_voxel_grid.shape[0]
+    if use_rfft:
+        # Truncated (last) axis stays in rfft/corner convention -- only the
+        # two full axes get fftshift'd to center convention.
+        phase = make_fftshift_phase((dim, dim, dim), outputs_rfft=True)
+        shifted = jnp.fft.fftshift(phase * fourier_voxel_grid, axes=(0, 1))
+        return shifted, make_frequency_slice((dim, dim), fftshifted=True)
     return (
         jnp.fft.fftshift(make_fftshift_phase((dim, dim, dim)) * fourier_voxel_grid),
         make_frequency_slice((dim, dim), fftshifted=True),

--- a/cryojax/simulator/_volume/fourier_voxels.py
+++ b/cryojax/simulator/_volume/fourier_voxels.py
@@ -13,11 +13,12 @@ from jaxtyping import Array, Complex, Float
 from ...jax_util import NDArrayLike
 from ...ndimage import (
     compute_spline_coefficients,
-    convert_fftn_to_rfftn,
+    enforce_rfftn_self_conjugates,
     fftn,
     ifftn,
     irfftn,
     make_1d_coordinate_grid,
+    make_1d_frequency_grid,
     make_fftshift_phase,
     make_frequency_slice,
     map_coordinates,
@@ -40,8 +41,7 @@ from .base_volume import (
 class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
     """Abstract interface for a voxel-based volume."""
 
-    frequency_slice_in_pixels: eqx.AbstractVar[Float[Array, "1 dim dim 3"]]
-    is_rfft: eqx.AbstractVar[bool]
+    frequency_slice_in_pixels: eqx.AbstractVar[Float[Array, "1 dim dim//2+1 3"]]
 
     @classmethod
     @abc.abstractmethod
@@ -65,16 +65,15 @@ class AbstractFourierVoxelVolume(AbstractVoxelVolume, strict=True):
 
 def _check_voxel_array_shape(
     shape: tuple[int, ...],
-    is_rfft: bool,
     padding: int,
     cls_name: str,
     array_name: str,
 ) -> None:
     """Validate that `shape` (the raw stored array shape, e.g.
     `fourier_voxel_grid.shape` or `spline_coefficients.shape`) is consistent
-    with a cubic, even-dimension volume, given `is_rfft` (whether the last
-    axis is RFFT-truncated) and `padding` (extra samples added per axis,
-    e.g. `2` for cubic-spline coefficients).
+    with a cubic, even-dimension volume stored as a half-space RFFT grid
+    (last axis truncated to `dim // 2 + 1`), given `padding` (extra samples
+    added per axis, e.g. `2` for cubic-spline coefficients).
     """
     d0, d1, d2 = (s - padding for s in shape)
     if d0 % 2 == 1:
@@ -83,24 +82,22 @@ def _check_voxel_array_shape(
             f"a voxel map with `{array_name}.shape = {shape}`. Please pass a "
             "voxel map with even dimensions."
         )
-    expected_d2 = d0 // 2 + 1 if is_rfft else d0
+    expected_d2 = d0 // 2 + 1
     if d1 != d0 or d2 != expected_d2:
         expected_shape = tuple(s + padding for s in (d0, d0, expected_d2))
-        # Common misuse: the array is a valid voxel grid, just for the
-        # opposite `is_rfft` convention (e.g. passed the output of `rfftn`
-        # but left `is_rfft` at its default of `False`, or vice versa).
-        other_d2 = d0 if is_rfft else d0 // 2 + 1
-        if d1 == d0 and d2 == other_d2:
+        # Common misuse: the array is a valid *full* (non-rfft) voxel grid,
+        # e.g. the output of `fftn` rather than `rfftn`.
+        if d1 == d0 and d2 == d0:
             raise AttributeError(
                 f"`{array_name}` passed to `{cls_name}` has shape `{shape}`, "
-                f"which does not match `is_rfft={is_rfft}` (expected shape "
-                f"`{expected_shape}`). This shape matches `is_rfft={not is_rfft}` "
-                f"instead -- did you mean to set `is_rfft={not is_rfft}`?"
+                f"which is likely the full (non-rfft) FFT grid shape. Expected the "
+                f"half-space RFFT grid shape `{expected_shape}` -- did you "
+                "mean to pass `cryojax.ndimage.rfftn(real_voxel_grid)` "
+                "instead of `cryojax.ndimage.fftn(real_voxel_grid)`?"
             )
         raise AttributeError(
             f"`{array_name}` passed to `{cls_name}` has an invalid shape "
-            f"`{shape}`. Expected shape `{expected_shape}` for "
-            f"`is_rfft={is_rfft}`."
+            f"`{shape}`. Expected shape `{expected_shape}`."
         )
 
 
@@ -114,7 +111,7 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         - `from_real_voxel_grid`:
             Instantiate from a real-space map.
         - `from_fourier_voxel_grid`:
-            Instantiate from the output of `cryojax.ndimage.fftn`.
+            Instantiate from the output of `cryojax.ndimage.rfftn`.
 
         Using `__init__` directly requires `fourier_voxel_grid` and
         `frequency_grid_in_pixels` to have the correct conventions for
@@ -131,42 +128,37 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         dim = real_voxel_grid.shape[0]
         assert all(d == dim for d in real_voxel_grid.shape)
         # ... compute grid and coordinates in correct convention
-        fourier_voxel_grid = jnp.fft.fftshift(im.fftn(jnp.fft.ifftshift(real_voxel_grid))))
-        frequency_slice = jnp.fft.fftshift(im.make_frequency_slice((dim, dim)))
+        phase = im.make_fftshift_phase((dim, dim, dim), outputs_rfft=True)
+        fourier_voxel_grid = jnp.fft.fftshift(phase * im.rfftn(real_voxel_grid), axes=(0, 1))
+        frequency_slice = im.make_frequency_slice(
+            (dim, dim), outputs_rfftfreqs=True, fftshifted=True
+        )
         ```
     """  # noqa: E501
 
-    fourier_voxel_grid: Complex[Array, "dim dim dim"] | Complex[Array, "dim dim dim//2+1"]
-    frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
-    is_rfft: bool = eqx.field(static=True)
+    fourier_voxel_grid: Complex[Array, "dim dim dim//2+1"]
+    frequency_slice_in_pixels: Float[Array, "1 dim dim//2+1 3"]
 
     is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
-        fourier_voxel_grid: (
-            Complex[NDArrayLike, "dim dim dim"] | Complex[NDArrayLike, "dim dim dim//2+1"]
-        ),
-        frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim 3"],
-        is_rfft: bool = False,
+        fourier_voxel_grid: Complex[NDArrayLike, "dim dim dim//2+1"],
+        frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim//2+1 3"],
     ):
         """**Arguments:**
 
         - `fourier_voxel_grid`:
-            The cubic voxel grid in fourier space. If `is_rfft = True`,
-            this is truncated to the half-space `(dim, dim, dim // 2 + 1)`,
-            as returned by `cryojax.ndimage.rfftn`.
+            The cubic voxel grid in fourier space, truncated to the
+            half-space `(dim, dim, dim // 2 + 1)`, as returned by
+            `cryojax.ndimage.rfftn`.
         - `frequency_slice_in_pixels`:
             The frequency slice coordinate system.
-        - `is_rfft`:
-            Whether `fourier_voxel_grid` is a half-space RFFT grid (see
-            above) rather than the full FFT grid.
         """
         # Multiply by phase correction for interpolation logic
         self.fourier_voxel_grid = jnp.asarray(fourier_voxel_grid, dtype=complex)
         _check_voxel_array_shape(
             self.fourier_voxel_grid.shape,
-            is_rfft,
             padding=0,
             cls_name=type(self).__name__,
             array_name="fourier_voxel_grid",
@@ -174,20 +166,15 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         self.frequency_slice_in_pixels = jnp.asarray(
             frequency_slice_in_pixels, dtype=float
         )
-        self.is_rfft = is_rfft
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        """The logical cubic shape of the volume, regardless of whether
-        `fourier_voxel_grid` is stored as a full or half-space (RFFT) grid.
-        """
+        """The cubic shape of the volume in real-space."""
         dim = self.fourier_voxel_grid.shape[0]
         return (dim, dim, dim)
 
     @classmethod
-    def from_fourier_voxel_grid(
-        cls, fourier_voxel_grid: NDArrayLike, *, is_rfft: bool = True
-    ) -> Self:
+    def from_fourier_voxel_grid(cls, fourier_voxel_grid: NDArrayLike) -> Self:
         """Load from a fourier-domain 3D voxel grid.
 
         This should be the output of
@@ -196,28 +183,20 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         import cryojax.simulator as cxs
         import cryojax.ndimage import im
 
-        fourier_voxel_grid = im.rfftn(real_voxel_grid) if is_rfft else im.fftn(real_voxel_grid)
-        volume = cxs.FourierVoxelSplineVolume(fourier_voxel_grid)
+        fourier_voxel_grid = im.rfftn(real_voxel_grid)
+        volume = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(fourier_voxel_grid)
         ```
 
         **Arguments:**
 
         - `fourier_voxel_grid`:
-            A voxel grid in fourier space. If `is_rfft = True`, this
-            should be the output of `cryojax.ndimage.rfftn`; otherwise,
-            the output of `cryojax.ndimage.fftn`.
-        - `is_rfft`:
-            Whether `fourier_voxel_grid` is the output of `cryojax.ndimage.rfftn`
-            (`True`, default) rather than `cryojax.ndimage.fftn` (`False`). If
-            `True`, the volume is stored as a half-space RFFT grid, halving
-            memory usage. This relies on the fact that `fourier_voxel_grid`
-            is the transform of a real-valued signal.
+            A voxel grid in fourier space, the output of `cryojax.ndimage.rfftn`.
         """  # noqa: E501
         fourier_voxel_grid, frequency_slice = _prepare_fourier_voxel_arguments(
-            jnp.asarray(fourier_voxel_grid), use_rfft=is_rfft
+            jnp.asarray(fourier_voxel_grid)
         )
 
-        return cls(jnp.asarray(fourier_voxel_grid), frequency_slice, is_rfft=is_rfft)
+        return cls(jnp.asarray(fourier_voxel_grid), frequency_slice)
 
     @classmethod
     def from_real_voxel_grid(
@@ -226,7 +205,6 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         *,
         apply_deconvolve: bool = False,
         pad_scale: float = 1.0,
-        use_rfft: bool = True,
     ) -> Self:
         """Load from a real-valued 3D voxel grid.
 
@@ -240,20 +218,16 @@ class FourierVoxelGridVolume(AbstractFourierVoxelVolume, strict=True):
         - `pad_scale`:
             Scale factor at which to pad `real_voxel_grid` before fourier
             transform. Must be a value greater than `1.0`.
-        - `use_rfft`:
-            If `True` (default), store the volume as a half-space RFFT
-            grid, halving memory usage and speeding up construction (via
-            `cryojax.ndimage.rfftn` instead of `cryojax.ndimage.fftn`).
         """
         # Cast to JAX array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Preprocess to fourier grid, deconvolving after any padding so that
         # the sinc² correction uses the actual Fourier grid size.
         fourier_voxel_grid, frequency_slice = _real_to_fourier_voxels(
-            cls, real_voxel_grid, pad_scale, apply_deconvolve, use_rfft=use_rfft
+            cls, real_voxel_grid, pad_scale, apply_deconvolve
         )
 
-        return cls(fourier_voxel_grid, frequency_slice, is_rfft=use_rfft)
+        return cls(fourier_voxel_grid, frequency_slice)
 
 
 class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
@@ -261,43 +235,30 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
     by spline coefficients.
     """
 
-    spline_coefficients: (
-        Complex[Array, "coeff_dim coeff_dim coeff_dim"]
-        | Complex[Array, "coeff_dim coeff_dim coeff_dim//2+1"]
-    )
-    frequency_slice_in_pixels: Float[Array, "1 dim dim 3"]
-    is_rfft: bool = eqx.field(static=True)
+    spline_coefficients: Complex[Array, "coeff_dim coeff_dim coeff_dim//2+1"]
+    frequency_slice_in_pixels: Float[Array, "1 dim dim//2+1 3"]
 
     is_frame_rotation: ClassVar[bool] = True
 
     def __init__(
         self,
-        spline_coefficients: (
-            Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim"]
-            | Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim//2+1"]
-        ),
-        frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim 3"],
-        is_rfft: bool = False,
+        spline_coefficients: Complex[NDArrayLike, "coeff_dim coeff_dim coeff_dim//2+1"],
+        frequency_slice_in_pixels: Float[NDArrayLike, "1 dim dim//2+1 3"],
     ):
         """**Arguments:**
 
         - `spline_coefficients`:
-            The spline coefficents computed from the cubic voxel grid
-            in fourier space. See `cryojax.ndimage.compute_spline_coefficients`.
-            If `is_rfft = True`, these are computed from the half-space
-            RFFT grid (i.e. last axis of size `dim // 2 + 1`, before the
-            `+ 2` spline padding), as returned by `cryojax.ndimage.rfftn`.
+            The spline coefficents computed from the cubic voxel grid in
+            fourier space, i.e. the half-space RFFT grid (last axis of size
+            `dim // 2 + 1`, before the `+ 2` spline padding). See
+            `cryojax.ndimage.compute_spline_coefficients`.
         - `frequency_slice_in_pixels`:
             Frequency slice coordinate system.
             See `cryojax.coordinates.make_frequency_slice`.
-        - `is_rfft`:
-            Whether `spline_coefficients` were computed from a half-space
-            RFFT grid (see above) rather than the full FFT grid.
         """
         self.spline_coefficients = jnp.asarray(spline_coefficients, dtype=complex)
         _check_voxel_array_shape(
             self.spline_coefficients.shape,
-            is_rfft,
             padding=2,
             cls_name=type(self).__name__,
             array_name="spline_coefficients",
@@ -305,21 +266,17 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         self.frequency_slice_in_pixels = jnp.asarray(
             frequency_slice_in_pixels, dtype=float
         )
-        self.is_rfft = is_rfft
 
     @property
     def shape(self) -> tuple[int, int, int]:
-        """The logical cubic shape of the original `fourier_voxel_grid`
-        from which `coefficients` were computed, regardless of whether it
-        was a full or half-space (RFFT) grid.
+        """The cubic shape of the original real-space `fourier_voxel_grid`
+        from which `coefficients` were computed.
         """
         dim = self.spline_coefficients.shape[0] - 2
         return (dim, dim, dim)
 
     @classmethod
-    def from_fourier_voxel_grid(
-        cls, fourier_voxel_grid: NDArrayLike, *, is_rfft: bool = True
-    ) -> Self:
+    def from_fourier_voxel_grid(cls, fourier_voxel_grid: NDArrayLike) -> Self:
         """Load from a fourier-domain 3D voxel grid.
 
         This should be the output of
@@ -328,29 +285,22 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         import cryojax.simulator as cxs
         import cryojax.ndimage import im
 
-        fourier_voxel_grid = im.rfftn(real_voxel_grid) if is_rfft else im.fftn(real_voxel_grid)
-        volume = cxs.FourierVoxelSplineVolume(fourier_voxel_grid)
+        fourier_voxel_grid = im.rfftn(real_voxel_grid)
+        volume = cxs.FourierVoxelSplineVolume.from_fourier_voxel_grid(fourier_voxel_grid)
         ```
 
         **Arguments:**
 
         - `fourier_voxel_grid`:
-            A voxel grid in fourier space. If `is_rfft = True`, this
-            should be the output of `cryojax.ndimage.rfftn`; otherwise,
-            the output of `cryojax.ndimage.fftn`.
-        - `is_rfft`:
-            Whether `fourier_voxel_grid` is the output of `cryojax.ndimage.rfftn`
-            (`True`, default) rather than `cryojax.ndimage.fftn` (`False`). If
-            `True`, spline coefficients are computed from a half-space RFFT
-            grid, halving memory usage.
+            A voxel grid in fourier space, the output of `cryojax.ndimage.rfftn`.
         """  # noqa: E501
         fourier_voxel_grid, frequency_slice = _prepare_fourier_voxel_arguments(
-            jnp.asarray(fourier_voxel_grid), use_rfft=is_rfft
+            jnp.asarray(fourier_voxel_grid)
         )
         # Compute spline coefficients
         spline_coefficients = compute_spline_coefficients(fourier_voxel_grid)
 
-        return cls(spline_coefficients, frequency_slice, is_rfft=is_rfft)
+        return cls(spline_coefficients, frequency_slice)
 
     @classmethod
     def from_real_voxel_grid(
@@ -358,7 +308,6 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         real_voxel_grid: Float[NDArrayLike, "dim dim dim"],
         *,
         pad_scale: float = 1.0,
-        use_rfft: bool = True,
     ) -> Self:
         """Load from a real-valued 3D voxel grid.
 
@@ -369,21 +318,17 @@ class FourierVoxelSplineVolume(AbstractFourierVoxelVolume, strict=True):
         - `pad_scale`:
             Scale factor at which to pad `real_voxel_grid` before fourier
             transform. Must be a value greater than `1.0`.
-        - `use_rfft`:
-            If `True` (default), store the volume as a half-space RFFT
-            grid, halving memory usage and speeding up construction (via
-            `cryojax.ndimage.rfftn` instead of `cryojax.ndimage.fftn`).
         """
         # Cast to JAX array
         real_voxel_grid = jnp.asarray(real_voxel_grid, dtype=float)
         # Preprocess to fourier grid
         fourier_voxel_grid, frequency_slice = _real_to_fourier_voxels(
-            cls, real_voxel_grid, pad_scale, use_rfft=use_rfft
+            cls, real_voxel_grid, pad_scale
         )
         # Compute spline coefficients
         spline_coefficients = compute_spline_coefficients(fourier_voxel_grid)
 
-        return cls(spline_coefficients, frequency_slice, is_rfft=use_rfft)
+        return cls(spline_coefficients, frequency_slice)
 
 
 class FourierSliceExtraction(
@@ -466,7 +411,6 @@ class FourierSliceExtraction(
             fourier_projection = _extract_slice_spline(
                 volume_representation.spline_coefficients,
                 frequency_slice,
-                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -474,7 +418,6 @@ class FourierSliceExtraction(
             fourier_projection = _extract_slice(
                 volume_representation.fourier_voxel_grid,
                 frequency_slice,
-                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -581,24 +524,28 @@ class EwaldSphereExtraction(
             raise AttributeError(
                 "Only cubic boxes are supported for fourier slice extraction."
             )
+        # The Ewald sphere surface curves the in-plane slice out of its own
+        # plane, so unlike `FourierSliceExtraction`, its output isn't
+        # Hermitian-symmetric as a whole and every output pixel is queried
+        # independently -- reconstruct the full in-plane grid from the
+        # stored half one before curving.
+        full_frequency_slice = _reconstruct_full_slice_from_half_slice(frequency_slice)
         # Compute the fourier projection
         if isinstance(volume_representation, FourierVoxelSplineVolume):
             ewald_sphere_surface = _extract_ewald_sphere_spline(
                 volume_representation.spline_coefficients,
-                frequency_slice,
+                full_frequency_slice,
                 image_config.pixel_size,
                 image_config.wavelength_in_angstroms,
-                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
         elif isinstance(volume_representation, FourierVoxelGridVolume):
             ewald_sphere_surface = _extract_ewald_sphere(
                 volume_representation.fourier_voxel_grid,
-                frequency_slice,
+                full_frequency_slice,
                 image_config.pixel_size,
                 image_config.wavelength_in_angstroms,
-                is_rfft=volume_representation.is_rfft,
                 out_of_bounds_mode=self.out_of_bounds_mode,
                 unroll_gather=self.unroll_gather,
             )
@@ -632,26 +579,26 @@ def _extract_slice(
     frequency_slice: Array,
     **kwargs: Any,
 ) -> Complex[Array, "dim dim//2+1"]:
-    return convert_fftn_to_rfftn(
-        _extract_surface_from_voxel_grid(
-            fourier_voxel_grid,
-            frequency_slice,
-            is_spline_coefficients=False,
-            **kwargs,
-        ),
-        mode="zero",
+    N = frequency_slice.shape[1]
+    surface = _extract_surface_from_voxel_grid(
+        fourier_voxel_grid,
+        frequency_slice,
+        is_spline_coefficients=False,
+        **kwargs,
     )
+    # `surface` is already rfft-shaped (the query grid itself was), so only
+    # self-conjugate (DC/Nyquist) realness needs enforcing here -- no crop.
+    return enforce_rfftn_self_conjugates(surface, (N, N), includes_dc=False, mode="zero")
 
 
 def _extract_slice_spline(
     spline_coefficients: Array, frequency_slice: Array, **kwargs: Any
 ) -> Complex[Array, "dim dim//2+1"]:
-    return convert_fftn_to_rfftn(
-        _extract_surface_from_voxel_grid(
-            spline_coefficients, frequency_slice, is_spline_coefficients=True, **kwargs
-        ),
-        mode="zero",
+    N = frequency_slice.shape[1]
+    surface = _extract_surface_from_voxel_grid(
+        spline_coefficients, frequency_slice, is_spline_coefficients=True, **kwargs
     )
+    return enforce_rfftn_self_conjugates(surface, (N, N), includes_dc=False, mode="zero")
 
 
 def _extract_ewald_sphere(
@@ -690,6 +637,31 @@ def _extract_ewald_sphere_spline(
     )
 
 
+def _reconstruct_full_slice_from_half_slice(
+    half_slice: Float[Array, "1 dim dim//2+1 3"],
+) -> Float[Array, "1 dim dim 3"]:
+    """Reconstruct the full in-plane frequency grid from the half (rfft) one
+    stored on the volume, for `EwaldSphereExtraction`, which needs the full
+    grid to compute its local `xhat`/`yhat`/`zhat` basis and to produce its
+    curved, non-Hermitian-symmetric-as-a-whole output surface.
+
+    A rotated in-plane grid is an exactly linear function of the (unrotated)
+    local x-coordinate, for any fixed y: `slice(x, y) = x * xhat_rot +
+    slice(0, y)`, where `xhat_rot` is a single constant vector (the rotated
+    local x unit vector). `xhat_rot` is recovered from any two adjacent
+    columns of the half grid, then used to extrapolate every column of the
+    full grid. This is exact (no interpolation, and no reflection of array
+    indices, so no boundary case at the row-Nyquist frequency -- unlike a
+    literal point-reflection, this only ever reads columns that are already
+    stored in `half_slice`).
+    """
+    N = half_slice.shape[1]
+    xhat_rot = N * (half_slice[:, :, 1, :] - half_slice[:, :, 0, :])
+    x_full = make_1d_frequency_grid(N, outputs_rfftfreqs=False, fftshifted=True)
+    x_term = x_full[None, None, :, None] * xhat_rot[:, :, None, :]
+    return half_slice[:, :, 0:1, :] + x_term
+
+
 def _get_ewald_sphere_surface_from_slice(
     frequency_slice_in_pixels: Array, voxel_size: Array, wavelength: Array
 ) -> Float[Array, "1 dim dim 3"]:
@@ -720,38 +692,31 @@ def _extract_surface_from_voxel_grid(
     voxel_grid: Array,
     frequency_coordinates: Array,
     is_spline_coefficients: bool = False,
-    is_rfft: bool = False,
     **kwargs: Any,
 ):
     # Convert to logical coordinates
     N = frequency_coordinates.shape[1]
-    if is_rfft:
-        # `voxel_grid`'s last axis only stores non-negative frequencies
-        # along x (i.e. `F(-q) = conj(F(q))` is not stored, only `F(q)`
-        # for `q_x >= 0`). Reflect the whole 3-vector through the origin
-        # whenever `q_x < 0`, so we always look up a point with `q_x >= 0`,
-        # then conjugate the interpolated result to correct for it. This is
-        # exact, not an approximation: it's evaluated once per query point,
-        # on the continuous coordinate, before any interpolation taps are
-        # generated, so taps never straddle the truncation boundary.
-        sign = jnp.where(frequency_coordinates[..., 0] < 0, -1.0, 1.0)
-        reflected = sign[..., None] * frequency_coordinates
-        k_x = reflected[..., 0] * N  # rfft/corner convention: no N // 2 offset
-        k_y = reflected[..., 1] * N + N // 2
-        k_z = reflected[..., 2] * N + N // 2
-        # The centered axes' Nyquist bin (frequency -0.5) is stored only at
-        # index 0, not also at index N -- +0.5 and -0.5 are the same
-        # (aliased) physical frequency. Reflecting a coordinate that was
-        # exactly at -0.5 lands exactly on index N, one past the valid
-        # range; wrap that exact case back to index 0, without touching any
-        # other (genuinely out-of-bounds) coordinate.
-        k_y = jnp.where(k_y == N, 0.0, k_y)
-        k_z = jnp.where(k_z == N, 0.0, k_z)
-    else:
-        logical_coordinates = (frequency_coordinates * N) + N // 2
-        # Convert arguments to map_coordinates convention and compute
-        k_x, k_y, k_z = jnp.transpose(logical_coordinates, axes=[3, 0, 1, 2])
-        sign = None
+    # `voxel_grid`'s last axis only stores non-negative frequencies along x
+    # (i.e. `F(-q) = conj(F(q))` is not stored, only `F(q)` for `q_x >= 0`).
+    # Reflect the whole 3-vector through the origin whenever `q_x < 0`, so we
+    # always look up a point with `q_x >= 0`, then conjugate the interpolated
+    # result to correct for it. This is exact, not an approximation: it's
+    # evaluated once per query point, on the continuous coordinate, before
+    # any interpolation taps are generated, so taps never straddle the
+    # truncation boundary.
+    sign = jnp.where(frequency_coordinates[..., 0] < 0, -1.0, 1.0)
+    reflected = sign[..., None] * frequency_coordinates
+    k_x = reflected[..., 0] * N  # rfft/corner convention: no N // 2 offset
+    k_y = reflected[..., 1] * N + N // 2
+    k_z = reflected[..., 2] * N + N // 2
+    # The centered axes' Nyquist bin (frequency -0.5) is stored only at
+    # index 0, not also at index N -- +0.5 and -0.5 are the same (aliased)
+    # physical frequency. Reflecting a coordinate that was exactly at -0.5
+    # lands exactly on index N, one past the valid range; wrap that exact
+    # case back to index 0, without touching any other (genuinely
+    # out-of-bounds) coordinate.
+    k_y = jnp.where(k_y == N, 0.0, k_y)
+    k_z = jnp.where(k_z == N, 0.0, k_z)
     if is_spline_coefficients:
         spline_coefficients = voxel_grid
         surface = map_coordinates_spline(spline_coefficients, (k_z, k_y, k_x), **kwargs)[
@@ -760,11 +725,19 @@ def _extract_surface_from_voxel_grid(
     else:
         fourier_voxel_grid = voxel_grid
         surface = map_coordinates(fourier_voxel_grid, (k_z, k_y, k_x), **kwargs)[0, :, :]
-    if is_rfft:
-        assert sign is not None
-        surface = jnp.where(sign[0, :, :] < 0, jnp.conj(surface), surface)
-    # FFT shift and multiply by (-1)^k phase factors
-    surface = jnp.fft.ifftshift(make_fftshift_phase(surface.shape) * surface)
+    surface = jnp.where(sign[0, :, :] < 0, jnp.conj(surface), surface)
+    # FFT shift and multiply by (-1)^k phase factors. `surface` is itself
+    # rfft-shaped only when `frequency_coordinates` was (i.e. only for
+    # `FourierSliceExtraction`'s half in-plane slice -- `EwaldSphereExtraction`
+    # always reconstructs a full grid before calling this function), in which
+    # case only the first axis is shifted, mirroring the same convention used
+    # for the 3D volume storage.
+    if surface.shape[0] == surface.shape[1]:
+        surface = jnp.fft.ifftshift(make_fftshift_phase(surface.shape) * surface)
+    else:
+        surface = jnp.fft.ifftshift(
+            make_fftshift_phase((N, N), outputs_rfft=True) * surface, axes=(0,)
+        )
 
     return surface
 
@@ -786,7 +759,6 @@ def _real_to_fourier_voxels(
     real_voxel_grid: Array,
     pad_scale: float,
     apply_deconvolve: bool = False,
-    use_rfft: bool = True,
 ) -> tuple[Array, Array]:
     if pad_scale == 1.0:
         shape_p = real_voxel_grid.shape
@@ -807,21 +779,21 @@ def _real_to_fourier_voxels(
     if apply_deconvolve:
         real_voxel_grid_p = _deconvolve_linear(real_voxel_grid_p)
 
-    transform = rfftn(real_voxel_grid_p) if use_rfft else fftn(real_voxel_grid_p)
-    return _prepare_fourier_voxel_arguments(transform, use_rfft=use_rfft)
+    return _prepare_fourier_voxel_arguments(rfftn(real_voxel_grid_p))
 
 
-def _prepare_fourier_voxel_arguments(
-    fourier_voxel_grid: Array, use_rfft: bool = True
-) -> tuple[Array, Array]:
+def _prepare_fourier_voxel_arguments(fourier_voxel_grid: Array) -> tuple[Array, Array]:
     dim = fourier_voxel_grid.shape[0]
-    if use_rfft:
-        # Truncated (last) axis stays in rfft/corner convention -- only the
-        # two full axes get fftshift'd to center convention.
-        phase = make_fftshift_phase((dim, dim, dim), outputs_rfft=True)
-        shifted = jnp.fft.fftshift(phase * fourier_voxel_grid, axes=(0, 1))
-        return shifted, make_frequency_slice((dim, dim), fftshifted=True)
-    return (
-        jnp.fft.fftshift(make_fftshift_phase((dim, dim, dim)) * fourier_voxel_grid),
-        make_frequency_slice((dim, dim), fftshifted=True),
+    # Only the kept (non-negative local-x) half of the in-plane slice is
+    # ever needed: `FourierSliceExtraction`'s output is itself rfft-shaped,
+    # and `EwaldSphereExtraction` reconstructs the full grid on demand from
+    # this half (see `_reconstruct_full_slice_from_half_slice`). This halves
+    # the cost of rotating the slice to a pose.
+    frequency_slice = make_frequency_slice(
+        (dim, dim), outputs_rfftfreqs=True, fftshifted=True
     )
+    # Truncated (last) axis stays in rfft/corner convention -- only the
+    # two full axes get fftshift'd to center convention.
+    phase = make_fftshift_phase((dim, dim, dim), outputs_rfft=True)
+    shifted = jnp.fft.fftshift(phase * fourier_voxel_grid, axes=(0, 1))
+    return shifted, frequency_slice

--- a/tests/test_volume_voxel.py
+++ b/tests/test_volume_voxel.py
@@ -34,6 +34,9 @@ import numpy as np
 import pytest
 from cryojax.constants import PengScatteringFactorParameters
 from cryojax.io import read_atoms_from_pdb
+from cryojax.simulator._volume.fourier_voxels import (
+    _reconstruct_full_slice_from_half_slice,
+)
 from jaxtyping import Array, Float
 
 
@@ -84,27 +87,6 @@ def fourier_spline_volume(gmm_volume):
     """FourierVoxelSplineVolume rendered from the GMM volume."""
     render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
     return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(render_fn(gmm_volume))
-
-
-@pytest.fixture(scope="module")
-def fourier_grid_volume_full_cube(gmm_volume):
-    """FourierVoxelGridVolume with `use_rfft=False` (full complex FFT cube),
-    for direct comparison against `fourier_grid_volume`'s RFFT storage."""
-    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
-    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        render_fn(gmm_volume), use_rfft=False
-    )
-
-
-@pytest.fixture(scope="module")
-def fourier_spline_volume_full_cube(gmm_volume):
-    """FourierVoxelSplineVolume with `use_rfft=False` (full complex FFT
-    cube), for direct comparison against `fourier_spline_volume`'s RFFT
-    storage."""
-    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
-    return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        render_fn(gmm_volume), use_rfft=False
-    )
 
 
 @pytest.fixture(scope="module")
@@ -567,15 +549,21 @@ def _gaussian_mixture_fourier_transform(
 
 
 def _ewald_sphere_analytic_ground_truth(volume, voltage_in_kilovolts: float) -> Array:
+    N = volume.frequency_slice_in_pixels.shape[1]
     config = cxs.BasicImageConfig(
-        volume.frequency_slice_in_pixels.shape[1:3],
+        (N, N),
         pixel_size=1.0,
         voltage_in_kilovolts=voltage_in_kilovolts,
     )
     wavelength = config.wavelength_in_angstroms
     # Curved Ewald sphere frequency coordinates (paraxial approximation, at
-    # identity pose the beam/projection axis is exactly z).
-    q_at_slice = volume.frequency_slice_in_pixels[0]
+    # identity pose the beam/projection axis is exactly z). `volume` only
+    # stores the half (rfft) in-plane slice; reconstruct the full grid this
+    # ground truth needs (an exact, non-interpolating coordinate operation,
+    # independent of the interpolation logic under test).
+    q_at_slice = _reconstruct_full_slice_from_half_slice(
+        volume.frequency_slice_in_pixels
+    )[0]
     q_parallel_squared = jnp.sum(q_at_slice[..., :2] ** 2, axis=-1)
     q_z_curvature = 0.5 * wavelength * q_parallel_squared
     q_at_surface = q_at_slice.at[..., 2].add(q_z_curvature)
@@ -612,34 +600,6 @@ def two_atom_spline_volume():
     return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(render_fn(volume))
 
 
-@pytest.fixture(scope="module")
-def two_atom_grid_volume_full_cube():
-    """Same as `two_atom_grid_volume`, but with `use_rfft=False`."""
-    volume = cxs.GaussianMixtureVolume(
-        _TWO_ATOM_POSITIONS,
-        amplitudes=_TWO_ATOM_AMPLITUDES,
-        variances=_TWO_ATOM_VARIANCES,
-    )
-    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
-    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        render_fn(volume), use_rfft=False
-    )
-
-
-@pytest.fixture(scope="module")
-def two_atom_spline_volume_full_cube():
-    """Same as `two_atom_spline_volume`, but with `use_rfft=False`."""
-    volume = cxs.GaussianMixtureVolume(
-        _TWO_ATOM_POSITIONS,
-        amplitudes=_TWO_ATOM_AMPLITUDES,
-        variances=_TWO_ATOM_VARIANCES,
-    )
-    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
-    return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        render_fn(volume), use_rfft=False
-    )
-
-
 def test_ewald_sphere_matches_analytic_ground_truth_grid(two_atom_grid_volume):
     """`EwaldSphereExtraction` must agree with the closed-form gaussian mixture
     fourier transform evaluated directly on the curved Ewald sphere surface.
@@ -672,246 +632,56 @@ def test_ewald_sphere_matches_analytic_ground_truth_spline(two_atom_spline_volum
     assert err < 0.02 * peak
 
 
-# ── use_rfft=True (half-cube) vs use_rfft=False (full cube) equivalence ──────
+# ── RFFT storage shape assertions ─────────────────────────────────────────────
 #
-# `use_rfft=True` stores the 3D voxel grid as a half-space RFFT grid instead
-# of the full complex FFT cube, halving memory. Interpolation reflects each
-# out-of-range query point through the origin and conjugates the result --
-# see `_extract_surface_from_voxel_grid` in `fourier_voxels.py`. This is
-# exact for linear interpolation (`FourierVoxelGridVolume`). For cubic-spline
-# interpolation (`FourierVoxelSplineVolume`), queries very close to the
-# truncation boundary (near the volume's own DC plane) pull a small
-# extrapolated -- rather than exact -- contribution from the spline solver's
-# open boundary condition, so a slightly looser tolerance is used there,
-# with a dedicated test isolating that regime.
-#
-# At an off-axis pose, a handful of query points fall outside the Nyquist
-# box entirely (the rotated slice extends past the edge of the frequency
-# grid). For those, exact equivalence with the full-cube path is *not*
-# expected: JAX's `.at[].get(mode="fill")` only fills indices that are
-# out-of-range on the *positive* side; a negative float index within
-# `[-N, -1]` is treated as ordinary (wrapping) negative indexing, not as
-# out-of-bounds. The full-cube path can therefore pick up a wrapped, non-zero
-# value for some off-grid points with a negative logical index, while the
-# reflected rfft path turns the same query into a *positive* overflow (which
-# does get zero-filled) -- so the two paths can legitimately disagree at
-# those specific pixels. This is a pre-existing quirk of the underlying
-# `out_of_bounds_mode="fill"` indexing, not a bug introduced by RFFT storage;
-# it's already implicitly present in the existing accuracy tolerances used
-# elsewhere in this module for off-axis, boundary-touching poses (see the
-# module docstring), so the same peak-relative scale is used here.
-
-_OFFAXIS_POSE = cxs.EulerAnglePose(phi_angle=30.0, theta_angle=45.0, psi_angle=10.0)
+# Both `FourierVoxelGridVolume`/`FourierVoxelSplineVolume` store the 3D voxel
+# grid as a half-space RFFT grid (halving memory relative to the full complex
+# FFT cube), and `frequency_slice_in_pixels` as the half in-plane grid too.
+# Interpolation reflects each out-of-range query point through the origin and
+# conjugates the result -- see `_extract_surface_from_voxel_grid` in
+# `fourier_voxels.py`. `EwaldSphereExtraction` reconstructs the full in-plane
+# grid on demand (`_reconstruct_full_slice_from_half_slice`), since its
+# curved output isn't Hermitian-symmetric as a whole.
 
 
-def test_rfft_matches_full_cube_slice_extraction_grid_identity(
-    fourier_grid_volume, fourier_grid_volume_full_cube, image_config
-):
-    """At identity (no query points fall outside the Nyquist box), `use_rfft=True`
-    must match `use_rfft=False` for `FourierSliceExtraction` to near machine
-    precision (exact for linear interpolation)."""
-    err = float(
-        _max_abs_error(
-            fourier_grid_volume, fourier_grid_volume_full_cube, _FSE, _FSE, image_config
-        )
-    )
-    assert err < 1e-10
-
-
-def test_rfft_matches_full_cube_slice_extraction_grid_offaxis(
-    fourier_grid_volume, fourier_grid_volume_full_cube, image_config
-):
-    """At an off-axis pose, `use_rfft=True` must match `use_rfft=False` for
-    `FourierSliceExtraction` up to the boundary-pixel effect described above."""
-    proj_rfft = np.array(
-        _project_real(
-            fourier_grid_volume.rotate_to_pose(_OFFAXIS_POSE), _FSE, image_config
-        )
-    )
-    proj_full = np.array(
-        _project_real(
-            fourier_grid_volume_full_cube.rotate_to_pose(_OFFAXIS_POSE),
-            _FSE,
-            image_config,
-        )
-    )
-    err = float(np.max(np.abs(proj_rfft - proj_full)))
-    peak = float(np.max(np.abs(proj_full)))
-    assert err < 0.01 * peak
-
-
-def test_rfft_matches_full_cube_slice_extraction_spline_identity(
-    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
-):
-    """At identity, `use_rfft=True` must match `use_rfft=False` for
-    `FourierSliceExtraction` with spline interpolation, to a tolerance that
-    accounts for the DC-region approximation described above."""
-    err = float(
-        _max_abs_error(
-            fourier_spline_volume,
-            fourier_spline_volume_full_cube,
-            _FSE,
-            _FSE,
-            image_config,
-        )
-    )
-    assert err < 1e-3
-
-
-def test_rfft_matches_full_cube_slice_extraction_spline_offaxis(
-    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
-):
-    """At an off-axis pose, `use_rfft=True` must match `use_rfft=False` for
-    `FourierSliceExtraction` with spline interpolation, up to both the
-    DC-region approximation and the boundary-pixel effect described above."""
-    proj_rfft = np.array(
-        _project_real(
-            fourier_spline_volume.rotate_to_pose(_OFFAXIS_POSE), _FSE, image_config
-        )
-    )
-    proj_full = np.array(
-        _project_real(
-            fourier_spline_volume_full_cube.rotate_to_pose(_OFFAXIS_POSE),
-            _FSE,
-            image_config,
-        )
-    )
-    err = float(np.max(np.abs(proj_rfft - proj_full)))
-    peak = float(np.max(np.abs(proj_full)))
-    assert err < 0.01 * peak
-
-
-def test_rfft_matches_full_cube_near_dc_spline(
-    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
-):
-    """Isolate and quantify the spline DC-region residual: at identity pose,
-    the projection's DC coefficient directly samples the volume's own
-    `q_x = 0` plane, right at the RFFT truncation boundary.
-    """
-    proj_rfft = np.array(_project_real(fourier_spline_volume, _FSE, image_config))
-    proj_full = np.array(
-        _project_real(fourier_spline_volume_full_cube, _FSE, image_config)
-    )
-    err = float(np.max(np.abs(proj_rfft - proj_full)))
-    peak = float(np.max(np.abs(proj_full)))
-    # Reported here (rather than just asserted tightly) so this test also
-    # documents the measured size of the DC-region approximation for the
-    # spline path -- see the "Open question" note in the RFFT storage plan
-    # about whether to keep both `use_rfft` code paths.
-    assert err < 5e-3 * peak
-
-
-@pytest.mark.parametrize("volume_kind", ["grid", "spline"])
-def test_rfft_matches_full_cube_ewald_sphere(
-    volume_kind,
-    two_atom_grid_volume,
-    two_atom_grid_volume_full_cube,
-    two_atom_spline_volume,
-    two_atom_spline_volume_full_cube,
-):
-    """`use_rfft=True` must match `use_rfft=False` for `EwaldSphereExtraction`
-    at low voltage (large curvature), the strongest test that the
-    reflect+conjugate interpolation rule is correct for a curved, globally
-    non-Hermitian-symmetric output surface (not just a flat plane)."""
-    if volume_kind == "grid":
-        rfft_volume, full_cube_volume = (
-            two_atom_grid_volume,
-            two_atom_grid_volume_full_cube,
-        )
-    else:
-        rfft_volume, full_cube_volume = (
-            two_atom_spline_volume,
-            two_atom_spline_volume_full_cube,
-        )
-    config = cxs.BasicImageConfig((32, 32), pixel_size=1.0, voltage_in_kilovolts=60.0)
-    ese_rfft = _ESE.integrate(rfft_volume, config, outputs_real_space=False)
-    ese_full = _ESE.integrate(full_cube_volume, config, outputs_real_space=False)
-    err = float(jnp.max(jnp.abs(ese_rfft - ese_full)))
-    peak = float(jnp.max(jnp.abs(ese_full)))
-    tol = 1e-4 if volume_kind == "grid" else 1e-2
-    assert err < tol * peak
-
-
-# ── use_rfft: storage shape/memory assertions ────────────────────────────────
-
-
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_use_rfft_storage_shape_grid(use_rfft):
+def test_storage_shape_grid():
     dim = 16
     real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
-    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        real_voxel_grid, use_rfft=use_rfft
-    )
-    assert vol.is_rfft == use_rfft
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid)
     assert vol.shape == (dim, dim, dim)
-    expected_last_axis = dim // 2 + 1 if use_rfft else dim
-    assert vol.fourier_voxel_grid.shape == (dim, dim, expected_last_axis)
+    assert vol.fourier_voxel_grid.shape == (dim, dim, dim // 2 + 1)
+    assert vol.frequency_slice_in_pixels.shape == (1, dim, dim // 2 + 1, 3)
 
 
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_use_rfft_storage_shape_spline(use_rfft):
+def test_storage_shape_spline():
     dim = 16
     real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
-    vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_voxel_grid, use_rfft=use_rfft
-    )
-    assert vol.is_rfft == use_rfft
+    vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(real_voxel_grid)
     assert vol.shape == (dim, dim, dim)
-    expected_last_axis = (dim // 2 + 1 if use_rfft else dim) + 2
-    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, expected_last_axis)
-
-
-def test_use_rfft_default_is_true():
-    """`use_rfft` defaults to `True` on both `from_real_voxel_grid` and
-    `from_fourier_voxel_grid`."""
-    dim = 16
-    real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
-    grid_vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid)
-    spline_vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(real_voxel_grid)
-    assert grid_vol.is_rfft
-    assert spline_vol.is_rfft
-    grid_vol2 = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(
-        im.rfftn(real_voxel_grid)
-    )
-    assert grid_vol2.is_rfft
+    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, dim // 2 + 3)
+    assert vol.frequency_slice_in_pixels.shape == (1, dim, dim // 2 + 1, 3)
 
 
 # ── from_fourier_voxel_grid constructor equivalence ───────────────────────────
 
 
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_grid_from_fourier_voxel_grid_matches_from_real(
-    gmm_volume, image_config, use_rfft
-):
-    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid),
-    for both `use_rfft=True` (rfftn) and `use_rfft=False` (fftn)."""
+def test_grid_from_fourier_voxel_grid_matches_from_real(gmm_volume, image_config):
+    """from_fourier_voxel_grid(rfftn(grid)) must equal from_real_voxel_grid(grid)."""
     render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
     real_grid = render_fn(gmm_volume)
-    transform = im.rfftn(real_grid) if use_rfft else im.fftn(real_grid)
-    vol_real = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        real_grid, use_rfft=use_rfft
-    )
-    vol_fourier = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(
-        transform, is_rfft=use_rfft
-    )
+    vol_real = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_grid)
+    vol_fourier = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(im.rfftn(real_grid))
     err = float(_max_abs_error(vol_real, vol_fourier, _FSE, _FSE, image_config))
     assert np.isclose(err, 0.0)
 
 
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_spline_from_fourier_voxel_grid_matches_from_real(
-    gmm_volume, image_config, use_rfft
-):
-    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid),
-    for both `use_rfft=True` (rfftn) and `use_rfft=False` (fftn)."""
+def test_spline_from_fourier_voxel_grid_matches_from_real(gmm_volume, image_config):
+    """from_fourier_voxel_grid(rfftn(grid)) must equal from_real_voxel_grid(grid)."""
     render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
     real_grid = render_fn(gmm_volume)
-    transform = im.rfftn(real_grid) if use_rfft else im.fftn(real_grid)
-    vol_real = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_grid, use_rfft=use_rfft
-    )
+    vol_real = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(real_grid)
     vol_fourier = cxs.FourierVoxelSplineVolume.from_fourier_voxel_grid(
-        transform, is_rfft=use_rfft
+        im.rfftn(real_grid)
     )
     err = float(_max_abs_error(vol_real, vol_fourier, _FSE, _FSE, image_config))
     assert np.isclose(err, 0.0)
@@ -1020,45 +790,35 @@ def test_spline_odd_dimension_raises():
 
 def test_grid_shape_mismatch_raises():
     """A `fourier_voxel_grid` whose shape doesn't correspond to any cubic
-    volume (for either `is_rfft` value) must raise."""
+    volume's half-space RFFT grid must raise."""
     with pytest.raises(AttributeError, match="invalid shape"):
         cxs.FourierVoxelGridVolume(
             jnp.zeros((16, 16, 5), dtype=complex),
-            im.make_frequency_slice((16, 16), fftshifted=True),
-            is_rfft=False,
+            im.make_frequency_slice((16, 16), outputs_rfftfreqs=True, fftshifted=True),
         )
 
 
-def test_grid_is_rfft_mismatch_suggests_correct_flag():
-    """Passing an rfftn-shaped array with `is_rfft=False` (or the reverse)
-    must raise an error naming the `is_rfft` value that would fit."""
+def test_grid_full_cube_shape_suggests_rfftn():
+    """Passing the full (non-rfft) FFT grid shape must raise an error
+    suggesting `cryojax.ndimage.rfftn` instead of `fftn`."""
     dim = 16
-    half_shaped = jnp.zeros((dim, dim, dim // 2 + 1), dtype=complex)
-    with pytest.raises(AttributeError, match="is_rfft=True"):
-        cxs.FourierVoxelGridVolume(
-            half_shaped,
-            im.make_frequency_slice((dim, dim), fftshifted=True),
-            is_rfft=False,
-        )
     full_shaped = jnp.zeros((dim, dim, dim), dtype=complex)
-    with pytest.raises(AttributeError, match="is_rfft=False"):
+    with pytest.raises(AttributeError, match="rfftn"):
         cxs.FourierVoxelGridVolume(
             full_shaped,
-            im.make_frequency_slice((dim, dim), fftshifted=True),
-            is_rfft=True,
+            im.make_frequency_slice((dim, dim), outputs_rfftfreqs=True, fftshifted=True),
         )
 
 
-def test_spline_is_rfft_mismatch_suggests_correct_flag():
-    """Same `is_rfft`-mismatch check for `FourierVoxelSplineVolume`, whose
+def test_spline_full_cube_shape_suggests_rfftn():
+    """Same full-cube-shape check for `FourierVoxelSplineVolume`, whose
     stored array is padded by 2 samples per axis relative to the grid."""
     dim = 16
-    half_shaped = jnp.zeros((dim + 2, dim + 2, dim // 2 + 1 + 2), dtype=complex)
-    with pytest.raises(AttributeError, match="is_rfft=True"):
+    full_shaped = jnp.zeros((dim + 2, dim + 2, dim + 2), dtype=complex)
+    with pytest.raises(AttributeError, match="rfftn"):
         cxs.FourierVoxelSplineVolume(
-            half_shaped,
-            im.make_frequency_slice((dim, dim), fftshifted=True),
-            is_rfft=False,
+            full_shaped,
+            im.make_frequency_slice((dim, dim), outputs_rfftfreqs=True, fftshifted=True),
         )
 
 
@@ -1123,33 +883,27 @@ def _is_smooth(n: int) -> bool:
 
 
 @pytest.mark.parametrize("pad_scale", (1.5, 2.0))
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale, use_rfft):
+def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
     vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=pad_scale, use_rfft=use_rfft
+        real_voxel_grid, pad_scale=pad_scale
     )
-    # `.shape` reports the logical (always-full) cubic shape, regardless of
-    # whether storage is truncated -- see it against `_is_smooth` here, and
-    # check the storage shape's own last-axis convention separately below.
+    # `.shape` reports the logical cubic (real-space) shape; check it
+    # against `_is_smooth`, and check the storage shape's own rfft-truncated
+    # last axis separately below.
     for s, p in zip(shape, vol.shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-    expected_last_axis = vol.shape[-1] // 2 + 1 if use_rfft else vol.shape[-1]
-    assert vol.fourier_voxel_grid.shape == vol.shape[:-1] + (expected_last_axis,)
+    assert vol.fourier_voxel_grid.shape == vol.shape[:-1] + (vol.shape[-1] // 2 + 1,)
 
 
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_fourier_voxel_grid_pad_scale_one_unchanged(use_rfft):
+def test_fourier_voxel_grid_pad_scale_one_unchanged():
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
-    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=1.0, use_rfft=use_rfft
-    )
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=1.0)
     assert vol.shape == shape
-    expected_last_axis = shape[-1] // 2 + 1 if use_rfft else shape[-1]
-    assert vol.fourier_voxel_grid.shape == shape[:-1] + (expected_last_axis,)
+    assert vol.fourier_voxel_grid.shape == shape[:-1] + (shape[-1] // 2 + 1,)
 
 
 def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
@@ -1159,32 +913,29 @@ def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
 
 
 @pytest.mark.parametrize("pad_scale", (1.5, 2.0))
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_fourier_voxel_spline_pad_scale_produces_smooth_shape(pad_scale, use_rfft):
+def test_fourier_voxel_spline_pad_scale_produces_smooth_shape(pad_scale):
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
     vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=pad_scale, use_rfft=use_rfft
+        real_voxel_grid, pad_scale=pad_scale
     )
     for s, p in zip(shape, vol.shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
-    expected_last_axis = (vol.shape[-1] // 2 + 1 if use_rfft else vol.shape[-1]) + 2
+    expected_last_axis = vol.shape[-1] // 2 + 1 + 2
     assert vol.spline_coefficients.shape == tuple(d + 2 for d in vol.shape[:-1]) + (
         expected_last_axis,
     )
 
 
-@pytest.mark.parametrize("use_rfft", [True, False])
-def test_fourier_voxel_spline_pad_scale_one_unchanged(use_rfft):
+def test_fourier_voxel_spline_pad_scale_one_unchanged():
     dim = 10
     real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
     vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=1.0, use_rfft=use_rfft
+        real_voxel_grid, pad_scale=1.0
     )
     assert vol.shape == (dim, dim, dim)
-    expected_last_axis = (dim // 2 + 1 if use_rfft else dim) + 2
-    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, expected_last_axis)
+    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, dim // 2 + 3)
 
 
 def test_fourier_voxel_spline_pad_scale_less_than_one_raises():
@@ -1214,20 +965,15 @@ def test_fourier_vs_real_agreement(sample_pdb_path):
     real_volume = cxs.render_voxel_volume(
         atom_volume, render_fn, output_type=cxs.RealVoxelGridVolume
     )
-    if fourier_volume.is_rfft:
-        # Only the two full axes were fftshift'd at construction time (the
-        # truncated axis stays in rfft/corner convention) -- see
-        # `_prepare_fourier_voxel_arguments` in `fourier_voxels.py`.
-        real_voxel_grid = jnp.fft.fftshift(
-            im.irfftn(
-                jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid, axes=(0, 1)),
-                s=shape,
-            )
+    # Only the two full axes were fftshift'd at construction time (the
+    # rfft-truncated axis stays in rfft/corner convention) -- see
+    # `_prepare_fourier_voxel_arguments` in `fourier_voxels.py`.
+    real_voxel_grid = jnp.fft.fftshift(
+        im.irfftn(
+            jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid, axes=(0, 1)),
+            s=shape,
         )
-    else:
-        real_voxel_grid = jnp.fft.fftshift(
-            im.ifftn(jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid)).real
-        )
+    )
 
     np.testing.assert_allclose(real_voxel_grid, real_volume.real_voxel_grid, atol=1e-12)
 

--- a/tests/test_volume_voxel.py
+++ b/tests/test_volume_voxel.py
@@ -87,6 +87,27 @@ def fourier_spline_volume(gmm_volume):
 
 
 @pytest.fixture(scope="module")
+def fourier_grid_volume_full_cube(gmm_volume):
+    """FourierVoxelGridVolume with `use_rfft=False` (full complex FFT cube),
+    for direct comparison against `fourier_grid_volume`'s RFFT storage."""
+    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
+    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        render_fn(gmm_volume), use_rfft=False
+    )
+
+
+@pytest.fixture(scope="module")
+def fourier_spline_volume_full_cube(gmm_volume):
+    """FourierVoxelSplineVolume with `use_rfft=False` (full complex FFT
+    cube), for direct comparison against `fourier_spline_volume`'s RFFT
+    storage."""
+    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
+    return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
+        render_fn(gmm_volume), use_rfft=False
+    )
+
+
+@pytest.fixture(scope="module")
 def image_config():
     return cxs.BasicImageConfig((32, 32), pixel_size=1.0, voltage_in_kilovolts=300.0)
 
@@ -591,6 +612,34 @@ def two_atom_spline_volume():
     return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(render_fn(volume))
 
 
+@pytest.fixture(scope="module")
+def two_atom_grid_volume_full_cube():
+    """Same as `two_atom_grid_volume`, but with `use_rfft=False`."""
+    volume = cxs.GaussianMixtureVolume(
+        _TWO_ATOM_POSITIONS,
+        amplitudes=_TWO_ATOM_AMPLITUDES,
+        variances=_TWO_ATOM_VARIANCES,
+    )
+    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
+    return cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        render_fn(volume), use_rfft=False
+    )
+
+
+@pytest.fixture(scope="module")
+def two_atom_spline_volume_full_cube():
+    """Same as `two_atom_spline_volume`, but with `use_rfft=False`."""
+    volume = cxs.GaussianMixtureVolume(
+        _TWO_ATOM_POSITIONS,
+        amplitudes=_TWO_ATOM_AMPLITUDES,
+        variances=_TWO_ATOM_VARIANCES,
+    )
+    render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
+    return cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
+        render_fn(volume), use_rfft=False
+    )
+
+
 def test_ewald_sphere_matches_analytic_ground_truth_grid(two_atom_grid_volume):
     """`EwaldSphereExtraction` must agree with the closed-form gaussian mixture
     fourier transform evaluated directly on the curved Ewald sphere surface.
@@ -623,25 +672,247 @@ def test_ewald_sphere_matches_analytic_ground_truth_spline(two_atom_spline_volum
     assert err < 0.02 * peak
 
 
+# ── use_rfft=True (half-cube) vs use_rfft=False (full cube) equivalence ──────
+#
+# `use_rfft=True` stores the 3D voxel grid as a half-space RFFT grid instead
+# of the full complex FFT cube, halving memory. Interpolation reflects each
+# out-of-range query point through the origin and conjugates the result --
+# see `_extract_surface_from_voxel_grid` in `fourier_voxels.py`. This is
+# exact for linear interpolation (`FourierVoxelGridVolume`). For cubic-spline
+# interpolation (`FourierVoxelSplineVolume`), queries very close to the
+# truncation boundary (near the volume's own DC plane) pull a small
+# extrapolated -- rather than exact -- contribution from the spline solver's
+# open boundary condition, so a slightly looser tolerance is used there,
+# with a dedicated test isolating that regime.
+#
+# At an off-axis pose, a handful of query points fall outside the Nyquist
+# box entirely (the rotated slice extends past the edge of the frequency
+# grid). For those, exact equivalence with the full-cube path is *not*
+# expected: JAX's `.at[].get(mode="fill")` only fills indices that are
+# out-of-range on the *positive* side; a negative float index within
+# `[-N, -1]` is treated as ordinary (wrapping) negative indexing, not as
+# out-of-bounds. The full-cube path can therefore pick up a wrapped, non-zero
+# value for some off-grid points with a negative logical index, while the
+# reflected rfft path turns the same query into a *positive* overflow (which
+# does get zero-filled) -- so the two paths can legitimately disagree at
+# those specific pixels. This is a pre-existing quirk of the underlying
+# `out_of_bounds_mode="fill"` indexing, not a bug introduced by RFFT storage;
+# it's already implicitly present in the existing accuracy tolerances used
+# elsewhere in this module for off-axis, boundary-touching poses (see the
+# module docstring), so the same peak-relative scale is used here.
+
+_OFFAXIS_POSE = cxs.EulerAnglePose(phi_angle=30.0, theta_angle=45.0, psi_angle=10.0)
+
+
+def test_rfft_matches_full_cube_slice_extraction_grid_identity(
+    fourier_grid_volume, fourier_grid_volume_full_cube, image_config
+):
+    """At identity (no query points fall outside the Nyquist box), `use_rfft=True`
+    must match `use_rfft=False` for `FourierSliceExtraction` to near machine
+    precision (exact for linear interpolation)."""
+    err = float(
+        _max_abs_error(
+            fourier_grid_volume, fourier_grid_volume_full_cube, _FSE, _FSE, image_config
+        )
+    )
+    assert err < 1e-10
+
+
+def test_rfft_matches_full_cube_slice_extraction_grid_offaxis(
+    fourier_grid_volume, fourier_grid_volume_full_cube, image_config
+):
+    """At an off-axis pose, `use_rfft=True` must match `use_rfft=False` for
+    `FourierSliceExtraction` up to the boundary-pixel effect described above."""
+    proj_rfft = np.array(
+        _project_real(
+            fourier_grid_volume.rotate_to_pose(_OFFAXIS_POSE), _FSE, image_config
+        )
+    )
+    proj_full = np.array(
+        _project_real(
+            fourier_grid_volume_full_cube.rotate_to_pose(_OFFAXIS_POSE),
+            _FSE,
+            image_config,
+        )
+    )
+    err = float(np.max(np.abs(proj_rfft - proj_full)))
+    peak = float(np.max(np.abs(proj_full)))
+    assert err < 0.01 * peak
+
+
+def test_rfft_matches_full_cube_slice_extraction_spline_identity(
+    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
+):
+    """At identity, `use_rfft=True` must match `use_rfft=False` for
+    `FourierSliceExtraction` with spline interpolation, to a tolerance that
+    accounts for the DC-region approximation described above."""
+    err = float(
+        _max_abs_error(
+            fourier_spline_volume,
+            fourier_spline_volume_full_cube,
+            _FSE,
+            _FSE,
+            image_config,
+        )
+    )
+    assert err < 1e-3
+
+
+def test_rfft_matches_full_cube_slice_extraction_spline_offaxis(
+    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
+):
+    """At an off-axis pose, `use_rfft=True` must match `use_rfft=False` for
+    `FourierSliceExtraction` with spline interpolation, up to both the
+    DC-region approximation and the boundary-pixel effect described above."""
+    proj_rfft = np.array(
+        _project_real(
+            fourier_spline_volume.rotate_to_pose(_OFFAXIS_POSE), _FSE, image_config
+        )
+    )
+    proj_full = np.array(
+        _project_real(
+            fourier_spline_volume_full_cube.rotate_to_pose(_OFFAXIS_POSE),
+            _FSE,
+            image_config,
+        )
+    )
+    err = float(np.max(np.abs(proj_rfft - proj_full)))
+    peak = float(np.max(np.abs(proj_full)))
+    assert err < 0.01 * peak
+
+
+def test_rfft_matches_full_cube_near_dc_spline(
+    fourier_spline_volume, fourier_spline_volume_full_cube, image_config
+):
+    """Isolate and quantify the spline DC-region residual: at identity pose,
+    the projection's DC coefficient directly samples the volume's own
+    `q_x = 0` plane, right at the RFFT truncation boundary.
+    """
+    proj_rfft = np.array(_project_real(fourier_spline_volume, _FSE, image_config))
+    proj_full = np.array(
+        _project_real(fourier_spline_volume_full_cube, _FSE, image_config)
+    )
+    err = float(np.max(np.abs(proj_rfft - proj_full)))
+    peak = float(np.max(np.abs(proj_full)))
+    # Reported here (rather than just asserted tightly) so this test also
+    # documents the measured size of the DC-region approximation for the
+    # spline path -- see the "Open question" note in the RFFT storage plan
+    # about whether to keep both `use_rfft` code paths.
+    assert err < 5e-3 * peak
+
+
+@pytest.mark.parametrize("volume_kind", ["grid", "spline"])
+def test_rfft_matches_full_cube_ewald_sphere(
+    volume_kind,
+    two_atom_grid_volume,
+    two_atom_grid_volume_full_cube,
+    two_atom_spline_volume,
+    two_atom_spline_volume_full_cube,
+):
+    """`use_rfft=True` must match `use_rfft=False` for `EwaldSphereExtraction`
+    at low voltage (large curvature), the strongest test that the
+    reflect+conjugate interpolation rule is correct for a curved, globally
+    non-Hermitian-symmetric output surface (not just a flat plane)."""
+    if volume_kind == "grid":
+        rfft_volume, full_cube_volume = (
+            two_atom_grid_volume,
+            two_atom_grid_volume_full_cube,
+        )
+    else:
+        rfft_volume, full_cube_volume = (
+            two_atom_spline_volume,
+            two_atom_spline_volume_full_cube,
+        )
+    config = cxs.BasicImageConfig((32, 32), pixel_size=1.0, voltage_in_kilovolts=60.0)
+    ese_rfft = _ESE.integrate(rfft_volume, config, outputs_real_space=False)
+    ese_full = _ESE.integrate(full_cube_volume, config, outputs_real_space=False)
+    err = float(jnp.max(jnp.abs(ese_rfft - ese_full)))
+    peak = float(jnp.max(jnp.abs(ese_full)))
+    tol = 1e-4 if volume_kind == "grid" else 1e-2
+    assert err < tol * peak
+
+
+# ── use_rfft: storage shape/memory assertions ────────────────────────────────
+
+
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_use_rfft_storage_shape_grid(use_rfft):
+    dim = 16
+    real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        real_voxel_grid, use_rfft=use_rfft
+    )
+    assert vol.is_rfft == use_rfft
+    assert vol.shape == (dim, dim, dim)
+    expected_last_axis = dim // 2 + 1 if use_rfft else dim
+    assert vol.fourier_voxel_grid.shape == (dim, dim, expected_last_axis)
+
+
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_use_rfft_storage_shape_spline(use_rfft):
+    dim = 16
+    real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
+    vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
+        real_voxel_grid, use_rfft=use_rfft
+    )
+    assert vol.is_rfft == use_rfft
+    assert vol.shape == (dim, dim, dim)
+    expected_last_axis = (dim // 2 + 1 if use_rfft else dim) + 2
+    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, expected_last_axis)
+
+
+def test_use_rfft_default_is_true():
+    """`use_rfft` defaults to `True` on both `from_real_voxel_grid` and
+    `from_fourier_voxel_grid`."""
+    dim = 16
+    real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
+    grid_vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid)
+    spline_vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(real_voxel_grid)
+    assert grid_vol.is_rfft
+    assert spline_vol.is_rfft
+    grid_vol2 = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(
+        im.rfftn(real_voxel_grid)
+    )
+    assert grid_vol2.is_rfft
+
+
 # ── from_fourier_voxel_grid constructor equivalence ───────────────────────────
 
 
-def test_grid_from_fourier_voxel_grid_matches_from_real(gmm_volume, image_config):
-    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid)."""
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_grid_from_fourier_voxel_grid_matches_from_real(
+    gmm_volume, image_config, use_rfft
+):
+    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid),
+    for both `use_rfft=True` (rfftn) and `use_rfft=False` (fftn)."""
     render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
     real_grid = render_fn(gmm_volume)
-    vol_real = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_grid)
-    vol_fourier = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(im.fftn(real_grid))
+    transform = im.rfftn(real_grid) if use_rfft else im.fftn(real_grid)
+    vol_real = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        real_grid, use_rfft=use_rfft
+    )
+    vol_fourier = cxs.FourierVoxelGridVolume.from_fourier_voxel_grid(
+        transform, is_rfft=use_rfft
+    )
     err = float(_max_abs_error(vol_real, vol_fourier, _FSE, _FSE, image_config))
     assert np.isclose(err, 0.0)
 
 
-def test_spline_from_fourier_voxel_grid_matches_from_real(gmm_volume, image_config):
-    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid)."""
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_spline_from_fourier_voxel_grid_matches_from_real(
+    gmm_volume, image_config, use_rfft
+):
+    """from_fourier_voxel_grid(fftn(grid)) must equal from_real_voxel_grid(grid),
+    for both `use_rfft=True` (rfftn) and `use_rfft=False` (fftn)."""
     render_fn = cxs.GaussianMixtureRenderFn((32, 32, 32), voxel_size=1.0)
     real_grid = render_fn(gmm_volume)
-    vol_real = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(real_grid)
-    vol_fourier = cxs.FourierVoxelSplineVolume.from_fourier_voxel_grid(im.fftn(real_grid))
+    transform = im.rfftn(real_grid) if use_rfft else im.fftn(real_grid)
+    vol_real = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
+        real_grid, use_rfft=use_rfft
+    )
+    vol_fourier = cxs.FourierVoxelSplineVolume.from_fourier_voxel_grid(
+        transform, is_rfft=use_rfft
+    )
     err = float(_max_abs_error(vol_real, vol_fourier, _FSE, _FSE, image_config))
     assert np.isclose(err, 0.0)
 
@@ -747,6 +1018,50 @@ def test_spline_odd_dimension_raises():
         cxs.FourierVoxelSplineVolume.from_real_voxel_grid(np.ones((31, 31, 31)))
 
 
+def test_grid_shape_mismatch_raises():
+    """A `fourier_voxel_grid` whose shape doesn't correspond to any cubic
+    volume (for either `is_rfft` value) must raise."""
+    with pytest.raises(AttributeError, match="invalid shape"):
+        cxs.FourierVoxelGridVolume(
+            jnp.zeros((16, 16, 5), dtype=complex),
+            im.make_frequency_slice((16, 16), fftshifted=True),
+            is_rfft=False,
+        )
+
+
+def test_grid_is_rfft_mismatch_suggests_correct_flag():
+    """Passing an rfftn-shaped array with `is_rfft=False` (or the reverse)
+    must raise an error naming the `is_rfft` value that would fit."""
+    dim = 16
+    half_shaped = jnp.zeros((dim, dim, dim // 2 + 1), dtype=complex)
+    with pytest.raises(AttributeError, match="is_rfft=True"):
+        cxs.FourierVoxelGridVolume(
+            half_shaped,
+            im.make_frequency_slice((dim, dim), fftshifted=True),
+            is_rfft=False,
+        )
+    full_shaped = jnp.zeros((dim, dim, dim), dtype=complex)
+    with pytest.raises(AttributeError, match="is_rfft=False"):
+        cxs.FourierVoxelGridVolume(
+            full_shaped,
+            im.make_frequency_slice((dim, dim), fftshifted=True),
+            is_rfft=True,
+        )
+
+
+def test_spline_is_rfft_mismatch_suggests_correct_flag():
+    """Same `is_rfft`-mismatch check for `FourierVoxelSplineVolume`, whose
+    stored array is padded by 2 samples per axis relative to the grid."""
+    dim = 16
+    half_shaped = jnp.zeros((dim + 2, dim + 2, dim // 2 + 1 + 2), dtype=complex)
+    with pytest.raises(AttributeError, match="is_rfft=True"):
+        cxs.FourierVoxelSplineVolume(
+            half_shaped,
+            im.make_frequency_slice((dim, dim), fftshifted=True),
+            is_rfft=False,
+        )
+
+
 def test_wrong_volume_type_raises(image_config):
     """FourierSliceExtraction must raise for unsupported volume types."""
     wrong_volume = cxs.GaussianMixtureVolume(
@@ -808,23 +1123,33 @@ def _is_smooth(n: int) -> bool:
 
 
 @pytest.mark.parametrize("pad_scale", (1.5, 2.0))
-def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale):
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_fourier_voxel_grid_pad_scale_produces_smooth_shape(pad_scale, use_rfft):
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
     vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=pad_scale
+        real_voxel_grid, pad_scale=pad_scale, use_rfft=use_rfft
     )
-    padded_shape = vol.fourier_voxel_grid.shape
-    for s, p in zip(shape, padded_shape):
+    # `.shape` reports the logical (always-full) cubic shape, regardless of
+    # whether storage is truncated -- see it against `_is_smooth` here, and
+    # check the storage shape's own last-axis convention separately below.
+    for s, p in zip(shape, vol.shape):
         assert p >= math.ceil(pad_scale * s)
         assert _is_smooth(p)
+    expected_last_axis = vol.shape[-1] // 2 + 1 if use_rfft else vol.shape[-1]
+    assert vol.fourier_voxel_grid.shape == vol.shape[:-1] + (expected_last_axis,)
 
 
-def test_fourier_voxel_grid_pad_scale_one_unchanged():
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_fourier_voxel_grid_pad_scale_one_unchanged(use_rfft):
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
-    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(real_voxel_grid, pad_scale=1.0)
-    assert vol.fourier_voxel_grid.shape == shape
+    vol = cxs.FourierVoxelGridVolume.from_real_voxel_grid(
+        real_voxel_grid, pad_scale=1.0, use_rfft=use_rfft
+    )
+    assert vol.shape == shape
+    expected_last_axis = shape[-1] // 2 + 1 if use_rfft else shape[-1]
+    assert vol.fourier_voxel_grid.shape == shape[:-1] + (expected_last_axis,)
 
 
 def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
@@ -834,25 +1159,32 @@ def test_fourier_voxel_grid_pad_scale_less_than_one_raises():
 
 
 @pytest.mark.parametrize("pad_scale", (1.5, 2.0))
-def test_fourier_voxel_spline_pad_scale_produces_smooth_shape(pad_scale):
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_fourier_voxel_spline_pad_scale_produces_smooth_shape(pad_scale, use_rfft):
     shape = (10, 10, 10)
     real_voxel_grid = jnp.zeros(shape, dtype=float)
     vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=pad_scale
+        real_voxel_grid, pad_scale=pad_scale, use_rfft=use_rfft
     )
-    padded_shape = vol.spline_coefficients.shape
-    for s, p in zip(shape, padded_shape):
+    for s, p in zip(shape, vol.shape):
         assert p >= math.ceil(pad_scale * s)
-        assert _is_smooth(p - 2)
+        assert _is_smooth(p)
+    expected_last_axis = (vol.shape[-1] // 2 + 1 if use_rfft else vol.shape[-1]) + 2
+    assert vol.spline_coefficients.shape == tuple(d + 2 for d in vol.shape[:-1]) + (
+        expected_last_axis,
+    )
 
 
-def test_fourier_voxel_spline_pad_scale_one_unchanged():
+@pytest.mark.parametrize("use_rfft", [True, False])
+def test_fourier_voxel_spline_pad_scale_one_unchanged(use_rfft):
     dim = 10
     real_voxel_grid = jnp.zeros((dim, dim, dim), dtype=float)
     vol = cxs.FourierVoxelSplineVolume.from_real_voxel_grid(
-        real_voxel_grid, pad_scale=1.0
+        real_voxel_grid, pad_scale=1.0, use_rfft=use_rfft
     )
-    assert all(d - 2 == dim for d in vol.spline_coefficients.shape)
+    assert vol.shape == (dim, dim, dim)
+    expected_last_axis = (dim // 2 + 1 if use_rfft else dim) + 2
+    assert vol.spline_coefficients.shape == (dim + 2, dim + 2, expected_last_axis)
 
 
 def test_fourier_voxel_spline_pad_scale_less_than_one_raises():
@@ -882,9 +1214,20 @@ def test_fourier_vs_real_agreement(sample_pdb_path):
     real_volume = cxs.render_voxel_volume(
         atom_volume, render_fn, output_type=cxs.RealVoxelGridVolume
     )
-    real_voxel_grid = jnp.fft.fftshift(
-        im.ifftn(jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid)).real
-    )
+    if fourier_volume.is_rfft:
+        # Only the two full axes were fftshift'd at construction time (the
+        # truncated axis stays in rfft/corner convention) -- see
+        # `_prepare_fourier_voxel_arguments` in `fourier_voxels.py`.
+        real_voxel_grid = jnp.fft.fftshift(
+            im.irfftn(
+                jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid, axes=(0, 1)),
+                s=shape,
+            )
+        )
+    else:
+        real_voxel_grid = jnp.fft.fftshift(
+            im.ifftn(jnp.fft.ifftshift(fourier_volume.fourier_voxel_grid)).real
+        )
 
     np.testing.assert_allclose(real_voxel_grid, real_volume.real_voxel_grid, atol=1e-12)
 


### PR DESCRIPTION
Have been meaning to make this upgrade for a while; until now, we are much more memory-limited than we need to be by storing the full Fourier grid